### PR TITLE
Ajoute scripts de déploiement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /public
+dist/
 node_modules/
 test_build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /public
+bin/config.sh
 dist/
 node_modules/
 test_build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:10.13-jessie
+ARG dossier_source
+
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm install
+
+COPY ${dossier_source} ./
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node server.js

--- a/README.md
+++ b/README.md
@@ -4,17 +4,42 @@
 
 https://beta.gouv.fr/startup/competences-pro.html
 
-## Mise en place pour le développement
+## Démarrer un serveur Webpack en local (mode développement)
+
+Installer `npm` si nécessaire, et exécuter la commande suivante.
 
 ```
-$ npm install
-$ npm run dev
+$ npm install && npm run dev
 ```
 
-## Déploiement en production
+## Démarrer l'application en local (mode production)
+
+Installer `npm` si nécessaire, et exécuter la commande suivante.
 
 ```
-$ npm install
-$ npm run build
-$ npm start
+$ npm install && npm run build && npm start
+```
+
+## Déployer l'application sur une machine distante
+
+_Note : la machine distante doit être équipée de…_
+- _un démon SSH_
+- _Docker_
+
+
+Copier le fichier `bin/config.sh.sample` vers `bin/config.sh` (fichier non suivi par Git)
+```
+$ cp bin/config.sh.sample bin/config.sh
+```
+
+Éditer le fichier `bin/config.sh` pour renseigner
+- l'adresse de la machine distante, éventuellement précédée du login (si le
+  login n'est pas renseigné, les scripts de déploiement utiliseront le login de
+  l'utilisateur qui lance le script de déploiement), et
+- le répertoire cible dans lequel les fichiers nécessaires à l'installation de l'application seront copiés.
+- le port d'écoute du serveur (le serveur écoute par défaut sur le port `80`)
+
+Ensuite, lancer le déploiement.
+```
+$ bin/prod_deploy.sh
 ```

--- a/bin/clean_dist.sh
+++ b/bin/clean_dist.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+rm -rf dist/*

--- a/bin/config.sh.sample
+++ b/bin/config.sh.sample
@@ -1,0 +1,5 @@
+# Ce fichier sert de modèle pour bin/config.sh
+
+adresse_machine_production=login_utilisateur@127.0.0.1  # le login est facultatif, par ex. 127.0.0.1
+repertoire_application=chemin/application/              # le chemin doit finir par un `/`
+port_ecoute=80                                          # le port sur lequel le serveur écoute

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+nom_conteneur=competences-pro
+nom_image_conteneur=betagouv/${nom_conteneur}
+horodatage=$(date +%Y%m%d%H%M%S)
+dossier_distribution=dist/${horodatage}
+
+mkdir -p ${dossier_distribution}
+cp -R package-lock.json package.json server.js src webpack.config.js ${dossier_distribution}
+
+docker build -t ${nom_image_conteneur} --build-arg dossier_source=${dossier_distribution} .
+
+if [[ -n $(docker ps -a | grep ${nom_conteneur}) ]]
+then
+  docker rm -f ${nom_conteneur}
+fi
+
+docker run --name ${nom_conteneur} --rm -p 80:3000 ${nom_image_conteneur}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -15,4 +15,4 @@ then
   docker rm -f ${nom_conteneur}
 fi
 
-docker run --name ${nom_conteneur} --rm -p 80:3000 ${nom_image_conteneur}
+docker run --name ${nom_conteneur} --detach -p 80:3000 ${nom_image_conteneur}

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -5,6 +5,10 @@ nom_image_conteneur=betagouv/${nom_conteneur}
 horodatage=$(date +%Y%m%d%H%M%S)
 dossier_distribution=dist/${horodatage}
 
+if [[ -z ${port_ecoute} ]]
+then port_ecoute=80
+fi
+
 mkdir -p ${dossier_distribution}
 cp -R package-lock.json package.json server.js src webpack.config.js ${dossier_distribution}
 
@@ -15,4 +19,4 @@ then
   docker rm -f ${nom_conteneur}
 fi
 
-docker run --name ${nom_conteneur} --detach -p 80:3000 ${nom_image_conteneur}
+docker run --name ${nom_conteneur} --detach -p ${port_ecoute}:3000 ${nom_image_conteneur}

--- a/bin/prod_deploy.sh
+++ b/bin/prod_deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+if [[ -f bin/config.sh ]]
+then source bin/config.sh
+else
+  echo "fichier bin/config.sh manquant, veuillez le créer à partir de bin/config.sh.sample"
+  exit 1
+fi
+
+scp -r Dockerfile package-lock.json package.json server.js src webpack.config.js ${adresse_machine_production}:${repertoire_application}
+
+echo "cd ${repertoire_application} && port_ecoute=${port_ecoute} && $(cat bin/deploy.sh)" | ssh ${adresse_machine_production}
+


### PR DESCRIPTION
Une fois qu'on a ajouté un fichier `bin/config.sh` (non suivi par Git) et qu'on l'a rempli en s'inspirant de `bin/config.sample`, il est possible de déployer le logiciel sur une machine et un répertoire cible.

L'instance de production tourne dans un conteneur docker, qui écoute sur le port `3000`. La machine hôte de production écoute les requêtes sur le port spécifié (par défaut : `80`) et transmets les requêtes au conteneur.