### PR TITLE
Ajoute un script "pre-commit" à utiliser dans le pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,15 @@ Il est également possible de demander au linter d'accepter les dépendances dé
 
 // début du code source
 ```
+
+## Crochet de pre-commit
+
+Pour créer le crochet de pre-commit à partir du fichier d'exemple de git
+```
+$ cp .git/hook/pre-commit{.sample,}
+```
+
+Pour ajouter le lancement du script de pre-commit à la fin du crochet de pre-commit :
+```
+$ echo "exec /usr/local/bin/npm run pre-commit" >> .git/hook/pre-commit
+```

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "webpack-dev-server --history-api-fallback --inline --progress --mode development",
     "start": "node server.js",
     "test": "npm run --silent lint && (webpack --watch --mode development --progress --colors --config webpack.config-test.js&  mocha --watch --colors tests_build/testBundle.js)",
-    "push": "npm run --silent lint && webpack --mode production --progress --colors --config webpack.config-test.js && mocha --colors tests_build/testBundle.js && git push",
+    "pre-commit": "npm run --silent lint && webpack --mode production --progress --colors --config webpack.config-test.js && mocha --colors tests_build/testBundle.js",
     "lint": "semistandard"
   },
   "engines": {


### PR DESCRIPTION
Si vous n'avez pas encore de pre-commit hook :
    $ cp .git/hook/pre-commit{.sample,}

Pour ajouter le lancement du script à la fin du pre-commit hook :
    $ echo "exec /usr/local/bin/npm run pre-commit" >> .git/hook/pre-commit