### PR TITLE
Mise en place de CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.11
+    steps:
+      - checkout
+      - run: npm install
+


### PR DESCRIPTION
Cette PR est nécessaire pour la mise en place d'une intégration continue avec CircleCI

Elle contient le fichier de configuration de circleCI ne lançant pas les tests pour pouvoir simplement mettre en place l'outil.