### PR TITLE
[NETTOYAGE] choisit la bonne image de caisse ouverte en javascript

### DIFF
--- a/src/styles/contenu.scss
+++ b/src/styles/contenu.scss
@@ -25,6 +25,7 @@
 
   .caisse {
     position: absolute;
+    background: no-repeat center/contain;
 
     .interieur {
       position: absolute;
@@ -37,30 +38,6 @@
         padding-left: 0.1rem;
       }
     }
-  }
-
-  .marron {
-    background: url('../images/carton.png') no-repeat center/contain;
-  }
-
-  .bleu {
-    background: url('../images/boite_bleue.png') no-repeat center/contain;
-  }
-
-  .jaune {
-    background: url('../images/boite_jaune.png') no-repeat center/contain;
-  }
-
-  .gris {
-    background: url('../images/boite_grise.png') no-repeat center/contain;
-  }
-
-  .rouge {
-    background: url('../images/boite_rouge.png') no-repeat center/contain;
-  }
-
-  .vert {
-    background: url('../images/boite_verte.png') no-repeat center/contain;
   }
 
   .etiquette {

--- a/src/vues/contenu_unitaire.js
+++ b/src/vues/contenu_unitaire.js
@@ -3,6 +3,7 @@ import { VueContenu } from './contenu.js';
 export class VueContenuUnitaire extends VueContenu {
   constructor (pointInsertion) {
     super(pointInsertion, 'contenu-unitaire', { hauteur: 21.5, largeur: 16.5 });
+    this.element.classList.add('caisse');
     this.bouteilles = new Map();
     this.bouteilles.set('Premium Terra', require('../images/premterra.png'));
     this.bouteilles.set('Nova Sky', require('../images/novasky.png'));
@@ -10,13 +11,19 @@ export class VueContenuUnitaire extends VueContenu {
     this.bouteilles.set("Lem'cola", require('../images/lemcola.png'));
     this.bouteilles.set('Terra Cola', require('../images/terracola.png'));
     this.bouteilles.set("O'cola", require('../images/ocola.png'));
-    this.element.classList.add('caisse');
+
+    this.caisses = new Map();
+    this.caisses.set('marron', '../images/carton.png');
+    this.caisses.set('bleu', '../images/boite_bleue.png');
+    this.caisses.set('jaune', '../images/boite_jaune.png');
+    this.caisses.set('gris', '../images/boite_grise.png');
+    this.caisses.set('rouge', '../images/boite_rouge.png');
+    this.caisses.set('vert', '../images/boite_verte.png');
   }
 
   affiche (contenant) {
     super.affiche(contenant);
-    this.element.classList.remove('marron', 'bleu', 'jaune', 'gris', 'rouge', 'vert');
-    this.element.classList.add(contenant.couleur);
+    this.element.style.backgroundImage = `url(${this.caisses.get(contenant.couleur)})`;
 
     this.elementInterieur.innerHTML = '';
     for (let i = 0; i < contenant.quantite; i++) {

--- a/tests/vues/contenu_unitaire.js
+++ b/tests/vues/contenu_unitaire.js
@@ -24,7 +24,7 @@ describe('vue contenu unitaire', function () {
   it('sait afficher la couleur du contenant', function () {
     vue.affiche(unContenantUnitaire('Nova Sky', 1).deCouleur('marron'));
 
-    expect(element.querySelector(':first-child').classList).to.contain('marron');
+    expect(element.querySelector(':first-child').style.backgroundImage).to.eql('url(../images/carton.png)');
   });
 
   it("sait afficher plusieurs bouteilles d'un certain type", function () {


### PR DESCRIPTION
Ceci est une PR de nettoyage pour supprimer la duplication sur les couleurs des contenants qui était mentionné à la fois dans le css et dans le javascript.

Maintenant elles ne sont plus mentionnées que dans le javascript

Les couleurs sont aussi mentionnées dans `data/stock.json` mais je n'ai pas voulu adresser cette question avec cette PR.