### PR TITLE
Enregistrement de plus d’événements dans l'inventaire

### DIFF
--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -31,7 +31,7 @@ function afficheMagasin (pointInsertion, $) {
 
     Array.from(resultatValidation).forEach((correction) => { afficheCorrection(correction, $); });
     window.alert(message);
-  });
+  }, journal);
   new VueStop(pointInsertion, $).afficher();
   const vueConsigne = new VueConsigne(pointInsertion, sonConsigneDemarrage);
   new VueGo(pointInsertion, vueConsigne, journal).afficher();

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -34,7 +34,7 @@ function afficheMagasin (pointInsertion, $) {
     Array.from(resultatValidation).forEach((correction) => { afficheCorrection(correction, $); });
     window.alert(message);
   }, journal);
-  new VueStop(pointInsertion, $).afficher();
+  new VueStop(pointInsertion, $, journal).afficher();
   const vueConsigne = new VueConsigne(pointInsertion, sonConsigneDemarrage);
   new VueGo(pointInsertion, vueConsigne, journal).afficher();
 }

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -17,10 +17,11 @@ import sonConsigneDemarrage from 'inventaire/assets/consigne_demarrage.mp3';
 function afficheMagasin (pointInsertion, $) {
   let magasin = creeMagasin({ contenants, contenus });
   const lignePrincipale = document.createElement('div');
+  const journal = new Journal(Date.now, new DepotJournal());
   lignePrincipale.classList.add('ligne-principale');
   lignePrincipale.id = 'ligne-principale';
   document.querySelector(pointInsertion).appendChild(lignePrincipale);
-  new VueEtageres('#ligne-principale', new Journal(Date.now, new DepotJournal()))
+  new VueEtageres('#ligne-principale', journal)
     .affiche(magasin.contenants());
   new VueFicheReferences('#ligne-principale').affiche();
 
@@ -33,7 +34,7 @@ function afficheMagasin (pointInsertion, $) {
   });
   new VueStop(pointInsertion, $).afficher();
   const vueConsigne = new VueConsigne(pointInsertion, sonConsigneDemarrage);
-  new VueGo(pointInsertion, vueConsigne).afficher();
+  new VueGo(pointInsertion, vueConsigne, journal).afficher();
 }
 
 jQuery(function () {

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -25,9 +25,11 @@ function afficheMagasin (pointInsertion, $) {
     .affiche(magasin.contenants());
   new VueFicheReferences('#ligne-principale').affiche();
 
-  initialiseFormulaireSaisieInventaire(magasin, pointInsertion, $, function (resultatValidation) {
-    let toutCorrect = Array.from(resultatValidation.values()).every(v => v);
-    let message = toutCorrect ? 'Bravo, vous avez réussi !' : 'Ce n\'est pas tout à fait ça… réessayez.';
+  initialiseFormulaireSaisieInventaire(magasin, pointInsertion, $, function (resultatValidation, reponses) {
+    const toutCorrect = Array.from(resultatValidation.values()).every(v => v);
+    const message = toutCorrect ? 'Bravo, vous avez réussi !' : 'Ce n\'est pas tout à fait ça… réessayez.';
+
+    journal.enregistreSaisieInventaire(toutCorrect, reponses);
 
     Array.from(resultatValidation).forEach((correction) => { afficheCorrection(correction, $); });
     window.alert(message);

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -1,7 +1,7 @@
 import 'commun/styles/go.scss';
 
 export class VueGo {
-  constructor (pointInsertion, vueConsigne) {
+  constructor (pointInsertion, vueConsigne, journal) {
     const elementPointInsertion = document.querySelector(pointInsertion);
     this.overlay = document.createElement('div');
     this.overlay.id = 'overlay-go';
@@ -17,6 +17,7 @@ export class VueGo {
     this.boutonGo.classList.add('invisible', 'bouton-centre', 'bouton-go');
     this.boutonGo.addEventListener('click', () => {
       this.overlay.classList.add('invisible');
+      journal.enregistreDemarrage();
     });
     this.overlay.appendChild(this.boutonGo);
 

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -2,7 +2,7 @@ import 'commun/styles/stop.scss';
 import { afficheFenetreModale } from 'commun/vues/modale.js';
 
 export class VueStop {
-  constructor (pointInsertion, $, retourAccueil = () => {
+  constructor (pointInsertion, $, journal, retourAccueil = () => {
     window.location.assign('/');
   }) {
     this.$pointInsertion = $(pointInsertion);
@@ -11,7 +11,7 @@ export class VueStop {
     this.$boutonStop.on('click', () => {
       afficheFenetreModale(this.$pointInsertion, $,
         'Voulez vous vraiment quitter la mission ?',
-        retourAccueil);
+        () => { journal.enregistreStop(); retourAccueil(); });
     });
   }
 

--- a/src/situations/inventaire/modeles/journal.js
+++ b/src/situations/inventaire/modeles/journal.js
@@ -1,3 +1,11 @@
+function mapToObj (map) {
+  const obj = {};
+  for (let [clef, valeur] of map) {
+    obj[clef] = valeur;
+  }
+  return obj;
+}
+
 export class Journal {
   constructor (maintenant, depot) {
     this.maintenant = maintenant;
@@ -28,6 +36,17 @@ export class Journal {
       {
         date: this.maintenant(),
         type: 'ouvertureSaisieInventaire'
+      }
+    );
+  }
+
+  enregistreSaisieInventaire (resultat, reponses) {
+    this.depot.enregistre(
+      {
+        date: this.maintenant(),
+        type: 'saisieInventaire',
+        resultat,
+        reponses: mapToObj(reponses)
       }
     );
   }

--- a/src/situations/inventaire/modeles/journal.js
+++ b/src/situations/inventaire/modeles/journal.js
@@ -23,6 +23,15 @@ export class Journal {
     );
   }
 
+  enregistreOuvertureSaisieInventaire () {
+    this.depot.enregistre(
+      {
+        date: this.maintenant(),
+        type: 'ouvertureSaisieInventaire'
+      }
+    );
+  }
+
   evenements () {
     return this.depot.evenements();
   }

--- a/src/situations/inventaire/modeles/journal.js
+++ b/src/situations/inventaire/modeles/journal.js
@@ -4,6 +4,15 @@ export class Journal {
     this.depot = depot;
   }
 
+  enregistreDemarrage () {
+    this.depot.enregistre(
+      {
+        date: this.maintenant(),
+        type: 'demarrage'
+      }
+    );
+  }
+
   enregistreOuvertureContenant (contenant) {
     this.depot.enregistre(
       {

--- a/src/situations/inventaire/modeles/journal.js
+++ b/src/situations/inventaire/modeles/journal.js
@@ -21,6 +21,15 @@ export class Journal {
     );
   }
 
+  enregistreStop () {
+    this.depot.enregistre(
+      {
+        date: this.maintenant(),
+        type: 'stop'
+      }
+    );
+  }
+
   enregistreOuvertureContenant (contenant) {
     this.depot.enregistre(
       {

--- a/src/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/src/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -52,11 +52,11 @@ export function initialiseFormulaireSaisieInventaire (magasin, pointInsertion, $
   }
 
   function creeBoutonValidation () {
-    let $bouton = $('<button type="button" class="valide-saisie">Valider la saisie d\'inventaire</button>');
+    const $bouton = $('<button type="button" class="valide-saisie">Valider la saisie d\'inventaire</button>');
     $bouton.click(function () {
-      let reponses = extraisReponses();
-      let saisieValide = inventaireReference.valide(reponses);
-      callbackValidation(saisieValide);
+      const reponses = extraisReponses();
+      const saisieValide = inventaireReference.valide(reponses);
+      callbackValidation(saisieValide, reponses);
     });
 
     return $bouton;

--- a/src/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/src/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -19,7 +19,7 @@ export function afficheCorrection ([idProduit, reponseCorrecte], $) {
   $marque.insertAfter($(selecteurEmplacementMarque));
 }
 
-export function initialiseFormulaireSaisieInventaire (magasin, pointInsertion, $, callbackValidation) {
+export function initialiseFormulaireSaisieInventaire (magasin, pointInsertion, $, callbackValidation, journal) {
   let produits = magasin.produitsEnStock();
   let inventaireReference = magasin.inventaireReference();
 
@@ -85,6 +85,9 @@ export function initialiseFormulaireSaisieInventaire (magasin, pointInsertion, $
     let $elementsCombines = $boutonSaisie.add($overlay);
 
     function basculeVisibiliteFormulaire () {
+      if ($overlay.hasClass('invisible')) {
+        journal.enregistreOuvertureSaisieInventaire();
+      }
       basculeVisibilite($overlay);
       basculeVisibilite($formulaireSaisie);
     }

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -8,12 +8,16 @@ describe('vue Go', function () {
   let boutonGo;
   let boutonDemarrerConsigne;
   let mockVueConsigne = {
-    jouerConsigneDemarrage: () => {}
+    jouerConsigneDemarrage () {}
   };
+  let mockJournal;
 
   beforeEach(function () {
     jsdom('<div id="magasin"></div>');
-    vue = new VueGo('#magasin', mockVueConsigne);
+    mockJournal = {
+      enregistreDemarrage () {}
+    };
+    vue = new VueGo('#magasin', mockVueConsigne, mockJournal);
     overlay = document.querySelector('#magasin #overlay-go');
     boutonGo = overlay.querySelector('#go');
     boutonDemarrerConsigne = overlay.querySelector('#demarrer-consigne');
@@ -68,5 +72,12 @@ describe('vue Go', function () {
     boutonGo.dispatchEvent(new Event('click'));
 
     expect(overlay.classList).to.contain('invisible');
+  });
+
+  it("journalise l'événement lorsque le jeu est démarré", function (done) {
+    mockJournal.enregistreDemarrage = done;
+    vue.afficher();
+
+    boutonGo.dispatchEvent(new Event('click'));
   });
 });

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -5,11 +5,15 @@ describe('vue Stop', function () {
   let vue;
   let $;
   let retourAccueil = false;
+  let mockJournal;
 
   beforeEach(function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
-    vue = new VueStop('#magasin', $, () => {
+    mockJournal = {
+      enregistreStop () {}
+    };
+    vue = new VueStop('#magasin', $, mockJournal, () => {
       retourAccueil = true;
     });
   });
@@ -33,5 +37,12 @@ describe('vue Stop', function () {
     $('#OK-modale').click();
 
     expect(retourAccueil).to.equal(true);
+  });
+
+  it("Enregistre l'événément quand on confirme la modale", function (done) {
+    mockJournal.enregistreStop = done;
+    vue.afficher();
+    $('#magasin #stop').click();
+    $('#OK-modale').click();
   });
 });

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -58,4 +58,36 @@ describe('le journal', function () {
       }
     ]);
   });
+
+  it("enregistre la saisie d'inventaire", function () {
+    const detail = new Map();
+    detail.set('1', '42');
+    detail.set('2', '1');
+
+    journal.enregistreSaisieInventaire(true, detail);
+    journal.enregistreSaisieInventaire(false, detail);
+
+    const enregistrement = mockDepot.evenements();
+    expect(enregistrement.length).to.equal(2);
+    expect(enregistrement).to.eql([
+      {
+        date: 123,
+        type: 'saisieInventaire',
+        resultat: true,
+        reponses: {
+          1: 42,
+          2: 1
+        }
+      },
+      {
+        date: 123,
+        type: 'saisieInventaire',
+        resultat: false,
+        reponses: {
+          1: 42,
+          2: 1
+        }
+      }
+    ]);
+  });
 });

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -45,4 +45,17 @@ describe('le journal', function () {
       }
     ]);
   });
+
+  it("enregistre l'ouverture de la saisie d'inventaire", function () {
+    journal.enregistreOuvertureSaisieInventaire();
+
+    const enregistrement = mockDepot.evenements();
+    expect(enregistrement.length).to.equal(1);
+    expect(enregistrement).to.eql([
+      {
+        date: 123,
+        type: 'ouvertureSaisieInventaire'
+      }
+    ]);
+  });
 });

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -26,6 +26,19 @@ describe('le journal', function () {
     ]);
   });
 
+  it("enregistre l'appui sur le bouton de stop", function () {
+    journal.enregistreStop();
+
+    const enregistrement = mockDepot.evenements();
+    expect(enregistrement.length).to.equal(1);
+    expect(enregistrement).to.eql([
+      {
+        date: 123,
+        type: 'stop'
+      }
+    ]);
+  });
+
   it("enregistre l'ouverture d'un contenant", function () {
     journal.enregistreOuvertureContenant(new Contenant({ idProduit: '9', quantite: 12 }, { nom: 'Nova Sky' }));
     journal.enregistreOuvertureContenant(new Contenant({ idProduit: '4', quantite: 7 }, { nom: 'Gink Cola' }));

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -13,6 +13,19 @@ describe('le journal', function () {
     journal = new Journal(mockMaintenant, mockDepot);
   });
 
+  it("enregistre l'appui sur le bouton de démarrage", function () {
+    journal.enregistreDemarrage();
+
+    const enregistrement = mockDepot.evenements();
+    expect(enregistrement.length).to.equal(1);
+    expect(enregistrement).to.eql([
+      {
+        date: 123,
+        type: 'demarrage'
+      }
+    ]);
+  });
+
   it("enregistre l'ouverture d'un contenant", function () {
     journal.enregistreOuvertureContenant(new Contenant({ idProduit: '9', quantite: 12 }, { nom: 'Nova Sky' }));
     journal.enregistreOuvertureContenant(new Contenant({ idProduit: '4', quantite: 7 }, { nom: 'Gink Cola' }));

--- a/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -42,7 +42,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
     });
 
     it("journalise l'événement", function (done) {
-      journal.enregistreOuvertureSaisieInventaire = () => done();
+      journal.enregistreOuvertureSaisieInventaire = done;
       $('.affiche-saisie').click();
     });
   });
@@ -65,9 +65,9 @@ describe("Le formulaire de saisie d'inventaire", function () {
     });
 
     it("n'enregistre pas une ouverture de saisie d'inventaire", function () {
-      const evenementOuvertureSaisieInventaire = 0;
+      let evenementOuvertureSaisieInventaire = 0;
       journal.enregistreOuvertureSaisieInventaire = () => {
-        enregistreOuvertureSaisieInventaire++;
+        evenementOuvertureSaisieInventaire++;
       };
       $('.overlay').click();
       expect(evenementOuvertureSaisieInventaire).to.eql(0);
@@ -126,9 +126,12 @@ describe("Le formulaire de saisie d'inventaire", function () {
       new Contenant({ idContenu: '0', quantite: 12 })
     ).construit();
 
-    let verifieValidite = function (saisieValide) {
+    let verifieValidite = function (saisieValide, reponses) {
       expect(Array.from(saisieValide)).to.eql([
         ['0', true]
+      ]);
+      expect(Array.from(reponses)).to.eql([
+        ['0', { quantite: '12' }]
       ]);
       done();
     };

--- a/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -6,10 +6,14 @@ let jsdom = require('jsdom-global');
 
 describe("Le formulaire de saisie d'inventaire", function () {
   let $;
+  let journal;
 
   beforeEach(function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
+    journal = {
+      enregistreOuvertureSaisieInventaire () {}
+    };
   });
 
   it("sait afficher un bouton pour saisir l'inventaire", function () {
@@ -20,7 +24,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
 
   describe('quand on clique sur le bouton', function () {
     beforeEach(function () {
-      initialiseFormulaireSaisieInventaire(unMagasinVide(), '#magasin', $);
+      initialiseFormulaireSaisieInventaire(unMagasinVide(), '#magasin', $, () => {}, journal);
     });
 
     it('affiche un overlay extérieur pour commander sa fermeture', function () {
@@ -36,11 +40,16 @@ describe("Le formulaire de saisie d'inventaire", function () {
       $('.affiche-saisie').click();
       expect($('.formulaire-saisie-inventaire.invisible').length).to.equal(0);
     });
+
+    it("journalise l'événement", function (done) {
+      journal.enregistreOuvertureSaisieInventaire = () => done();
+      $('.affiche-saisie').click();
+    });
   });
 
   describe("quand on clique sur l'overlay", function () {
     beforeEach(function () {
-      initialiseFormulaireSaisieInventaire(unMagasinVide(), '#magasin', $);
+      initialiseFormulaireSaisieInventaire(unMagasinVide(), '#magasin', $, () => {}, journal);
       $('.affiche-saisie').click();
       expect($('.overlay.invisible').length).to.equal(0);
     });
@@ -53,6 +62,15 @@ describe("Le formulaire de saisie d'inventaire", function () {
     it("s'efface (l'overlay)", function () {
       $('.overlay').click();
       expect($('.overlay.invisible').length).to.equal(1);
+    });
+
+    it("n'enregistre pas une ouverture de saisie d'inventaire", function () {
+      const evenementOuvertureSaisieInventaire = 0;
+      journal.enregistreOuvertureSaisieInventaire = () => {
+        enregistreOuvertureSaisieInventaire++;
+      };
+      $('.overlay').click();
+      expect(evenementOuvertureSaisieInventaire).to.eql(0);
     });
   });
 


### PR DESCRIPTION
J'ai rajouté l'enregistrement de l'appui sur les boutons go, stop et saisie d'inventaire. Lors de la validation de celui ci, le résultat ainsi que les valeurs rentrées sont aussi sauvegardé. 

Pour tester manuellement ce que j'ai fait, j'ai utilisé la page de restitution disponible localement: http://localhost:7700/restitution.html

Il manque un point de #43. Je compte m'en occuper après.