### PR TITLE
Fait écouter le serveur webpack sur toutes les interfaces.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "scripts": {
     "build": "webpack --mode production",
-    "dev": "webpack-dev-server --history-api-fallback --inline --progress --mode development",
+    "dev": "webpack-dev-server --history-api-fallback --inline --progress --mode development --host 0.0.0.0",
     "start": "node server.js",
     "test": "./bin/test.sh",
     "lint": "semistandard"


### PR DESCRIPTION
Actuellement `webpack-dev-server` écoute, par défaut, sur 127.0.0.1. Pour pouvoir faire tourner le projet dans docker, j'ai besoin de lui faire écouter sur toutes les interfaces possible (pour pouvoir me connecter de l'extérieur.