### PR TITLE
Ajout d'un identifiant de session dans les événements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9556,8 +9556,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "dev": true
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
     },
     "v8-compile-cache": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
   "dependencies": {
     "express": "^4.16.4",
     "jquery": "^3.3.1",
-    "pluralize": "^7.0.0"
+    "pluralize": "^7.0.0",
+    "uuid": "^3.3.2"
   },
   "semistandard": {
     "globals": [

--- a/src/app/restitutionSituationInventaire.js
+++ b/src/app/restitutionSituationInventaire.js
@@ -1,3 +1,5 @@
+import uuidv4 from 'uuid/v4';
+
 import { DepotJournal } from 'inventaire/infra/depot_journal.js';
 import { Journal } from 'inventaire/modeles/journal.js';
 import { VueJournal } from 'inventaire/vues/journal.js';
@@ -8,7 +10,8 @@ jQuery(function () {
       <h1>Restitution de la mise en situation</h1>
     </div>
     `);
-  let journal = new Journal(Date.now, new DepotJournal());
-  let vue = new VueJournal('#restitution', journal);
+
+  const journal = new Journal(Date.now, uuidv4(), new DepotJournal());
+  const vue = new VueJournal('#restitution', journal);
   vue.affiche();
 });

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -1,6 +1,8 @@
 import 'inventaire/styles/app.scss';
 import 'inventaire/styles/etageres.scss';
 
+import uuidv4 from 'uuid/v4';
+
 import { contenants, contenus } from 'inventaire/data/stock.js';
 import { DepotJournal } from 'inventaire/infra/depot_journal.js';
 import { Journal } from 'inventaire/modeles/journal.js';
@@ -15,9 +17,10 @@ import { ActionsCommunesSituation } from 'commun/vues/actions_communes_situation
 import sonConsigneDemarrage from 'inventaire/assets/consigne_demarrage.mp3';
 
 function afficheMagasin (pointInsertion, $) {
-  let magasin = creeMagasin({ contenants, contenus });
+  const session = uuidv4();
+  const magasin = creeMagasin({ contenants, contenus });
   const lignePrincipale = document.createElement('div');
-  const journal = new Journal(Date.now, new DepotJournal());
+  const journal = new Journal(Date.now, session, new DepotJournal());
   lignePrincipale.classList.add('ligne-principale');
   lignePrincipale.id = 'ligne-principale';
   document.querySelector(pointInsertion).appendChild(lignePrincipale);

--- a/src/situations/inventaire/infra/depot_journal.js
+++ b/src/situations/inventaire/infra/depot_journal.js
@@ -40,7 +40,7 @@ export class DepotJournal {
   }
 
   recupereDonnees (ligne) {
-    const { date, type, description } = ligne;
-    return { date, description: JSON.stringify(description), type_evenement: type, session_id: 'fake session_id', situation: 'inventaire' };
+    const { date, type, description, sessionId } = ligne;
+    return { date, description: JSON.stringify(description), type_evenement: type, session_id: sessionId, situation: 'inventaire' };
   }
 }

--- a/src/situations/inventaire/modeles/journal.js
+++ b/src/situations/inventaire/modeles/journal.js
@@ -14,54 +14,32 @@ export class Journal {
   }
 
   enregistreDemarrage () {
-    this.depot.enregistre(
-      {
-        date: this.maintenant(),
-        sessionId: this.sessionId,
-        type: 'demarrage'
-      }
-    );
+    this.enregistre('demarrage');
   }
 
   enregistreStop () {
-    this.depot.enregistre(
-      {
-        date: this.maintenant(),
-        sessionId: this.sessionId,
-        type: 'stop'
-      }
-    );
+    this.enregistre('stop');
   }
 
   enregistreOuvertureContenant (contenant) {
-    this.depot.enregistre(
-      {
-        date: this.maintenant(),
-        sessionId: this.sessionId,
-        type: 'ouvertureContenant',
-        description: contenant
-      }
-    );
+    this.enregistre('ouvertureContenant', contenant);
   }
 
   enregistreOuvertureSaisieInventaire () {
-    this.depot.enregistre(
-      {
-        date: this.maintenant(),
-        sessionId: this.sessionId,
-        type: 'ouvertureSaisieInventaire'
-      }
-    );
+    this.enregistre('ouvertureSaisieInventaire');
   }
 
   enregistreSaisieInventaire (resultat, reponses) {
+    this.enregistre('saisieInventaire', { resultat, reponses: mapToObj(reponses) });
+  }
+
+  enregistre (type, donnees = {}) {
     this.depot.enregistre(
       {
         date: this.maintenant(),
         sessionId: this.sessionId,
-        type: 'saisieInventaire',
-        resultat,
-        reponses: mapToObj(reponses)
+        type,
+        donnees
       }
     );
   }

--- a/src/situations/inventaire/modeles/journal.js
+++ b/src/situations/inventaire/modeles/journal.js
@@ -7,15 +7,17 @@ function mapToObj (map) {
 }
 
 export class Journal {
-  constructor (maintenant, depot) {
+  constructor (maintenant, session, depot) {
     this.maintenant = maintenant;
     this.depot = depot;
+    this.sessionId = session;
   }
 
   enregistreDemarrage () {
     this.depot.enregistre(
       {
         date: this.maintenant(),
+        sessionId: this.sessionId,
         type: 'demarrage'
       }
     );
@@ -25,6 +27,7 @@ export class Journal {
     this.depot.enregistre(
       {
         date: this.maintenant(),
+        sessionId: this.sessionId,
         type: 'stop'
       }
     );
@@ -34,6 +37,7 @@ export class Journal {
     this.depot.enregistre(
       {
         date: this.maintenant(),
+        sessionId: this.sessionId,
         type: 'ouvertureContenant',
         description: contenant
       }
@@ -44,6 +48,7 @@ export class Journal {
     this.depot.enregistre(
       {
         date: this.maintenant(),
+        sessionId: this.sessionId,
         type: 'ouvertureSaisieInventaire'
       }
     );
@@ -53,6 +58,7 @@ export class Journal {
     this.depot.enregistre(
       {
         date: this.maintenant(),
+        sessionId: this.sessionId,
         type: 'saisieInventaire',
         resultat,
         reponses: mapToObj(reponses)

--- a/tests/situations/inventaire/infra/depot_journal.js
+++ b/tests/situations/inventaire/infra/depot_journal.js
@@ -39,10 +39,10 @@ describe('le depot du journal', function () {
   });
 
   it('vérifie la conformité des données récupèrées', function () {
-    const donnees = journal.recupereDonnees({ autreCle: 'valeur2', description: { cle: 'valeur2' } });
+    const donnees = journal.recupereDonnees({ autreCle: 'valeur2', sessionId: 'ma session id', description: { cle: 'valeur2' } });
 
     expect(donnees['description']).to.equal('{"cle":"valeur2"}');
-    expect(donnees['session_id']).to.equal('fake session_id');
+    expect(donnees['session_id']).to.equal('ma session id');
     expect(donnees['situation']).to.equal('inventaire');
   });
 

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -19,14 +19,10 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);
-    expect(enregistrement).to.eql([
-      {
-        date: 123,
-        sessionId,
-        type: 'demarrage',
-        donnees: {}
-      }
-    ]);
+    expect(enregistrement[0]).to.only.have.keys('date', 'sessionId', 'type', 'donnees');
+    expect(enregistrement[0]).to.have.property('type', 'demarrage');
+    expect(enregistrement[0]).to.have.property('date', 123);
+    expect(enregistrement[0]).to.have.property('sessionId', sessionId);
   });
 
   it("enregistre l'appui sur le bouton de stop", function () {
@@ -34,14 +30,7 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);
-    expect(enregistrement).to.eql([
-      {
-        date: 123,
-        sessionId,
-        type: 'stop',
-        donnees: {}
-      }
-    ]);
+    expect(enregistrement[0]).to.have.property('type', 'stop');
   });
 
   it("enregistre l'ouverture d'un contenant", function () {
@@ -50,20 +39,9 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(2);
-    expect(enregistrement).to.eql([
-      {
-        date: 123,
-        sessionId,
-        type: 'ouvertureContenant',
-        donnees: { idProduit: '9', quantite: 12, contenu: { nom: 'Nova Sky' } }
-      },
-      {
-        date: 123,
-        sessionId,
-        type: 'ouvertureContenant',
-        donnees: { idProduit: '4', quantite: 7, contenu: { nom: 'Gink Cola' } }
-      }
-    ]);
+    expect(enregistrement[0]).to.have.property('type', 'ouvertureContenant');
+    expect(enregistrement[0].donnees).to.eql({ idProduit: '9', quantite: 12, contenu: { nom: 'Nova Sky' } });
+    expect(enregistrement[1].donnees).to.eql({ idProduit: '4', quantite: 7, contenu: { nom: 'Gink Cola' } });
   });
 
   it("enregistre l'ouverture de la saisie d'inventaire", function () {
@@ -71,14 +49,7 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);
-    expect(enregistrement).to.eql([
-      {
-        date: 123,
-        sessionId,
-        type: 'ouvertureSaisieInventaire',
-        donnees: {}
-      }
-    ]);
+    expect(enregistrement[0]).to.have.property('type', 'ouvertureSaisieInventaire');
   });
 
   it("enregistre la saisie d'inventaire", function () {
@@ -91,31 +62,20 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(2);
-    expect(enregistrement).to.eql([
-      {
-        date: 123,
-        sessionId,
-        type: 'saisieInventaire',
-        donnees: {
-          resultat: true,
-          reponses: {
-            1: 42,
-            2: 1
-          }
-        }
-      },
-      {
-        date: 123,
-        sessionId,
-        type: 'saisieInventaire',
-        donnees: {
-          resultat: false,
-          reponses: {
-            1: 42,
-            2: 1
-          }
-        }
+    expect(enregistrement[0]).to.have.property('type', 'saisieInventaire');
+    expect(enregistrement[0].donnees).to.eql({
+      resultat: true,
+      reponses: {
+        1: 42,
+        2: 1
       }
-    ]);
+    });
+    expect(enregistrement[1].donnees).to.eql({
+      resultat: false,
+      reponses: {
+        1: 42,
+        2: 1
+      }
+    });
   });
 });

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -23,7 +23,8 @@ describe('le journal', function () {
       {
         date: 123,
         sessionId,
-        type: 'demarrage'
+        type: 'demarrage',
+        donnees: {}
       }
     ]);
   });
@@ -37,7 +38,8 @@ describe('le journal', function () {
       {
         date: 123,
         sessionId,
-        type: 'stop'
+        type: 'stop',
+        donnees: {}
       }
     ]);
   });
@@ -53,13 +55,13 @@ describe('le journal', function () {
         date: 123,
         sessionId,
         type: 'ouvertureContenant',
-        description: { idProduit: '9', quantite: 12, contenu: { nom: 'Nova Sky' } }
+        donnees: { idProduit: '9', quantite: 12, contenu: { nom: 'Nova Sky' } }
       },
       {
         date: 123,
         sessionId,
         type: 'ouvertureContenant',
-        description: { idProduit: '4', quantite: 7, contenu: { nom: 'Gink Cola' } }
+        donnees: { idProduit: '4', quantite: 7, contenu: { nom: 'Gink Cola' } }
       }
     ]);
   });
@@ -73,7 +75,8 @@ describe('le journal', function () {
       {
         date: 123,
         sessionId,
-        type: 'ouvertureSaisieInventaire'
+        type: 'ouvertureSaisieInventaire',
+        donnees: {}
       }
     ]);
   });
@@ -93,20 +96,24 @@ describe('le journal', function () {
         date: 123,
         sessionId,
         type: 'saisieInventaire',
-        resultat: true,
-        reponses: {
-          1: 42,
-          2: 1
+        donnees: {
+          resultat: true,
+          reponses: {
+            1: 42,
+            2: 1
+          }
         }
       },
       {
         date: 123,
         sessionId,
         type: 'saisieInventaire',
-        resultat: false,
-        reponses: {
-          1: 42,
-          2: 1
+        donnees: {
+          resultat: false,
+          reponses: {
+            1: 42,
+            2: 1
+          }
         }
       }
     ]);

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -6,11 +6,12 @@ describe('le journal', function () {
   let journal;
   let mockMaintenant;
   let mockDepot;
+  const sessionId = 42;
 
   beforeEach(function () {
     mockMaintenant = () => { return 123; };
     mockDepot = new MockDepot();
-    journal = new Journal(mockMaintenant, mockDepot);
+    journal = new Journal(mockMaintenant, sessionId, mockDepot);
   });
 
   it("enregistre l'appui sur le bouton de démarrage", function () {
@@ -21,6 +22,7 @@ describe('le journal', function () {
     expect(enregistrement).to.eql([
       {
         date: 123,
+        sessionId,
         type: 'demarrage'
       }
     ]);
@@ -34,6 +36,7 @@ describe('le journal', function () {
     expect(enregistrement).to.eql([
       {
         date: 123,
+        sessionId,
         type: 'stop'
       }
     ]);
@@ -48,11 +51,13 @@ describe('le journal', function () {
     expect(enregistrement).to.eql([
       {
         date: 123,
+        sessionId,
         type: 'ouvertureContenant',
         description: { idProduit: '9', quantite: 12, contenu: { nom: 'Nova Sky' } }
       },
       {
         date: 123,
+        sessionId,
         type: 'ouvertureContenant',
         description: { idProduit: '4', quantite: 7, contenu: { nom: 'Gink Cola' } }
       }
@@ -67,6 +72,7 @@ describe('le journal', function () {
     expect(enregistrement).to.eql([
       {
         date: 123,
+        sessionId,
         type: 'ouvertureSaisieInventaire'
       }
     ]);
@@ -85,6 +91,7 @@ describe('le journal', function () {
     expect(enregistrement).to.eql([
       {
         date: 123,
+        sessionId,
         type: 'saisieInventaire',
         resultat: true,
         reponses: {
@@ -94,6 +101,7 @@ describe('le journal', function () {
       },
       {
         date: 123,
+        sessionId,
         type: 'saisieInventaire',
         resultat: false,
         reponses: {


### PR DESCRIPTION
Le `session_id` était simplement une fausse chaine lors de l'envoi des événements au serveur. J'ai changé cela en utilisant un uuid généré au chargement de la page. Le journal le passe simplement a chaque enregistrement d'un événement. 

Pour tester, j'ai joué la situation inventaire, et j'ai vérifié sur la page restitution.html que j'avais un uuid qui était le même qu'auparavant.