### PR TITLE
Affiche bacs

### DIFF
--- a/src/app/situationControle.js
+++ b/src/app/situationControle.js
@@ -10,11 +10,12 @@ function afficheSituation (pointInsertion, $) {
     positionApparitionPieces: { x: 100, y: 70 },
     dureeViePiece: 12000
   });
+  let vueSituation = new VueSituation(situation);
+  vueSituation.affiche(pointInsertion, $);
+
   new ActionsCommunesSituation(pointInsertion, $, {
     enregistreStop () {}
   }).afficheElementEnCommun();
-  let vueSituation = new VueSituation(situation);
-  vueSituation.affiche(pointInsertion, $);
 }
 
 jQuery(function () {

--- a/src/situations/controle/modeles/bac.js
+++ b/src/situations/controle/modeles/bac.js
@@ -1,0 +1,14 @@
+export class Bac {
+  constructor ({ x, y, largeur, hauteur }) {
+    this._dimensions = { largeur: largeur, hauteur: hauteur };
+    this._position = { x: x, y: y };
+  }
+
+  dimensions () {
+    return this._dimensions;
+  }
+
+  position () {
+    return this._position;
+  }
+}

--- a/src/situations/controle/modeles/bac.js
+++ b/src/situations/controle/modeles/bac.js
@@ -1,5 +1,6 @@
 export class Bac {
-  constructor ({ x, y, largeur, hauteur }) {
+  constructor ({ categorie, x, y, largeur, hauteur }) {
+    this._categorie = categorie;
     this._dimensions = { largeur: largeur, hauteur: hauteur };
     this._position = { x: x, y: y };
   }
@@ -10,5 +11,9 @@ export class Bac {
 
   position () {
     return this._position;
+  }
+
+  categorie () {
+    return this._categorie;
   }
 }

--- a/src/situations/controle/modeles/piece.js
+++ b/src/situations/controle/modeles/piece.js
@@ -1,3 +1,6 @@
+export const PIECE_CONFORME = true;
+export const PIECE_DEFECTUEUSE = false;
+
 export class Piece {
   constructor ({ x, y, conforme }) {
     this.x = x;

--- a/src/situations/controle/styles/bac.scss
+++ b/src/situations/controle/styles/bac.scss
@@ -1,0 +1,26 @@
+.bac {
+  position: absolute;
+  border: 5px dashed;
+
+  &.pieces-conformes {
+    background: palegreen;
+    border-color: limegreen;
+    background-image: repeating-linear-gradient(-45deg,
+      transparent,
+      transparent 20px,
+      rgba(0, 0, 0, 0.1) 20px,
+      rgba(0, 0, 0, 0.1) 40px
+    );
+  }
+
+  &.pieces-defectueuses {
+    background: lightcoral;
+    border-color: crimson;
+    background-image: repeating-linear-gradient(45deg,
+      transparent,
+      transparent 20px,
+      rgba(0, 0, 0, 0.1) 20px,
+      rgba(0, 0, 0, 0.1) 40px
+    );
+  }
+}

--- a/src/situations/controle/vues/bac.js
+++ b/src/situations/controle/vues/bac.js
@@ -1,0 +1,34 @@
+import 'controle/styles/bac.scss';
+
+import { PIECE_CONFORME } from 'controle/modeles/piece.js';
+
+export class VueBac {
+  constructor (bac) {
+    this.bac = bac;
+  }
+
+  affiche (pointInsertion, $) {
+    function creeElementBac (categorie, { x, y }, { largeur, hauteur }, { largeurParent, hauteurParent }) {
+      const classeCategorie = categorie === PIECE_CONFORME ? 'pieces-conformes' : 'pieces-defectueuses';
+      const $element = $(`<div class="bac ${classeCategorie}"></div>`);
+      $element.css('left', x * largeurParent / 100);
+      $element.css('top', y * hauteurParent / 100);
+      $element.width(largeur * largeurParent / 100).height(hauteur * hauteurParent / 100);
+      return $element;
+    }
+
+    const $elementParent = $(pointInsertion);
+    const dimensionsElementParent = {
+      largeurParent: $elementParent.width(),
+      hauteurParent: $elementParent.height()
+    };
+    const $bac = creeElementBac(
+      this.bac.categorie(),
+      this.bac.position(),
+      this.bac.dimensions(),
+      dimensionsElementParent
+    );
+
+    $elementParent.append($bac);
+  }
+}

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,3 +1,6 @@
+import { Bac } from 'controle/modeles/bac.js';
+import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece.js';
+import { VueBac } from 'controle/vues/bac.js';
 import { VuePiece } from 'controle/vues/piece.js';
 
 export class VueSituation {
@@ -7,6 +10,15 @@ export class VueSituation {
   }
 
   affiche (pointInsertion, $) {
+    function afficheBac (categorie, { x, y }) {
+      const bacPiecesDefectueuses = new Bac({ categorie: categorie, x: x, y: y, largeur: 30, hauteur: 40 });
+      const vueBacPiecesDefectueuses = new VueBac(bacPiecesDefectueuses);
+      vueBacPiecesDefectueuses.affiche(pointInsertion, $);
+    }
+
+    afficheBac(PIECE_CONFORME, { x: 10, y: 10 });
+    afficheBac(PIECE_DEFECTUEUSE, { x: 60, y: 10 });
+
     let identifiantIntervalle = setInterval(() => {
       if (this.situation.sequenceTerminee()) {
         clearInterval(identifiantIntervalle);
@@ -14,9 +26,7 @@ export class VueSituation {
       }
 
       let piece = this.situation.pieceSuivante();
-      let vuePiece = new VuePiece(piece,
-        this.situation.dureeViePiece(),
-        this.callbackApresCreationPiece);
+      let vuePiece = new VuePiece(piece, this.situation.dureeViePiece(), this.callbackApresCreationPiece);
       vuePiece.affiche(pointInsertion, $);
     }, this.situation.cadenceArriveePieces());
   }

--- a/tests/situations/controle/modeles/bac.js
+++ b/tests/situations/controle/modeles/bac.js
@@ -1,0 +1,13 @@
+import { Bac } from 'controle/modeles/bac.js';
+
+describe('un bac', function () {
+  it('connaît ses dimensions', function () {
+    const bac = new Bac({ largeur: 20, hauteur: 30 });
+    expect(bac.dimensions()).to.eql({ largeur: 20, hauteur: 30 });
+  });
+
+  it('connaît sa position', function () {
+    const bac = new Bac({ x: 5, y: 10 });
+    expect(bac.position()).to.eql({ x: 5, y: 10 });
+  });
+});

--- a/tests/situations/controle/modeles/bac.js
+++ b/tests/situations/controle/modeles/bac.js
@@ -1,4 +1,5 @@
 import { Bac } from 'controle/modeles/bac.js';
+import { PIECE_CONFORME } from 'controle/modeles/piece.js';
 
 describe('un bac', function () {
   it('connaît ses dimensions', function () {
@@ -9,5 +10,10 @@ describe('un bac', function () {
   it('connaît sa position', function () {
     const bac = new Bac({ x: 5, y: 10 });
     expect(bac.position()).to.eql({ x: 5, y: 10 });
+  });
+
+  it('sait quel catégorie de pièces accueillir', function () {
+    const bac = new Bac({ categorie: PIECE_CONFORME });
+    expect(bac.categorie()).to.equal(PIECE_CONFORME);
   });
 });

--- a/tests/situations/controle/vues/bac.js
+++ b/tests/situations/controle/vues/bac.js
@@ -1,0 +1,59 @@
+import jsdom from 'jsdom-global';
+
+import { Bac } from 'controle/modeles/bac.js';
+import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece.js';
+import { VueBac } from 'controle/vues/bac.js';
+
+describe("La vue d'un bac", function () {
+  let $;
+
+  beforeEach(function () {
+    jsdom('<div id="controle" style="width: 100px; height: 100px"></div>');
+    $ = jQuery(window);
+  });
+
+  it("s'affiche à partir d'un point d'insertion", function () {
+    const bac = new Bac({ x: 10, y: 15, largeur: 20, hauteur: 30 });
+    const vue = new VueBac(bac);
+    expect($('.bac').length).to.equal(0);
+
+    vue.affiche('#controle', $);
+
+    expect($('#controle .bac').length).to.equal(1);
+  });
+
+  it("se positionne correctement vis-à-vis de l'élément parent", function () {
+    const bac = new Bac({ x: 10, y: 12, largeur: 20, hauteur: 30 });
+    const vue = new VueBac(bac);
+
+    $('#controle').width(200).height(150);
+    vue.affiche('#controle', $);
+
+    expect($('.bac').css('left')).to.eql('20px');
+    expect($('.bac').css('top')).to.eql('18px');
+    expect($('.bac').css('width')).to.eql('40px');
+    expect($('.bac').css('height')).to.eql('45px');
+  });
+
+  it('affiche le bac des pièces conformes', function () {
+    const bac = new Bac({ categorie: PIECE_CONFORME });
+    const vue = new VueBac(bac);
+    expect($('.bac.pieces-conformes').length).to.equal(0);
+
+    vue.affiche('#controle', $);
+
+    expect($('.bac.pieces-conformes').length).to.equal(1);
+    expect($('.bac.pieces-defectueuses').length).to.equal(0);
+  });
+
+  it('affiche le bac des pièces défectueuses', function () {
+    const bac = new Bac({ categorie: PIECE_DEFECTUEUSE });
+    const vue = new VueBac(bac);
+    expect($('.bac.pieces-conformes').length).to.equal(0);
+
+    vue.affiche('#controle', $);
+
+    expect($('.bac.pieces-defectueuses').length).to.equal(1);
+    expect($('.bac.pieces-conformes').length).to.equal(0);
+  });
+});

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -11,7 +11,19 @@ describe('La situation « Contrôle »', function () {
     $ = jQuery(window);
   });
 
-  it('Affiche les pièces en séquence selon le scénario pré-établi', function (done) {
+  it('affiche le bac des pièces conformes et le bac des pièces défectueuses', function () {
+    const situation = new Situation({ scenario: [] });
+    const vueSituation = new VueSituation(situation, () => {});
+    expect($('#situation-controle .bac.pieces-conformes').length).to.equal(0);
+    expect($('#situation-controle .bac.pieces-defectueuses').length).to.equal(0);
+
+    vueSituation.affiche('#situation-controle', $);
+
+    expect($('#situation-controle .bac.pieces-conformes').length).to.equal(1);
+    expect($('#situation-controle .bac.pieces-defectueuses').length).to.equal(1);
+  });
+
+  it('affiche les pièces en séquence selon le scénario pré-établi', function (done) {
     const situation = new Situation({
       cadence: 0,
       scenario: [true, false],


### PR DESCRIPTION
Contribue à #54 

Ce code introduit le modèle `Bac` et la vue `VueBac`. J'ai l'intuition qu'on pourra réutiliser le code de ce modèle et de cette vue pour la situation « Tri ». C'est avec cette intention que j'ai fait certains choix de design (comme celui d'associer une « catégorie de pièce » à chaque bac).