### PR TITLE
[CORRECTION] Corrige le glitch au moment de l'ouverture du contenant

### DIFF
--- a/src/situations/inventaire/vues/contenu.js
+++ b/src/situations/inventaire/vues/contenu.js
@@ -30,17 +30,19 @@ class VueContenu {
   }
 
   affiche (contenant) {
-    this.calque.classList.remove('invisible');
-    this.element.classList.remove('invisible');
+    this.element.src = contenant.imageOuvert;
     this.element.style.top = this.position(contenant.posY - contenant.hauteur, contenant.hauteur, contenant.dimensionsOuvert.hauteur) + '%';
     this.element.style.left = this.position(contenant.posX, contenant.largeur, contenant.dimensionsOuvert.largeur) + '%';
     this.element.style.height = contenant.dimensionsOuvert.hauteur + '%';
     this.element.style.width = contenant.dimensionsOuvert.largeur + '%';
-    this.element.src = contenant.imageOuvert;
 
-    setTimeout(() => {
-      this.element.classList.replace('fermer', 'ouvrir');
-    }, 50);
+    this.element.addEventListener('load', () => {
+      this.calque.classList.remove('invisible');
+      this.element.classList.remove('invisible');
+      setTimeout(() => {
+        this.element.classList.replace('fermer', 'ouvrir');
+      }, 50);
+    });
   }
 }
 

--- a/tests/situations/inventaire/vues/contenu.js
+++ b/tests/situations/inventaire/vues/contenu.js
@@ -21,9 +21,11 @@ describe('vue contenu', function () {
     expect(calque.classList).to.contain('invisible');
   });
 
-  it('sait se cacher', function (done) {
+  it("sait s'afficher puis se cacher", function (done) {
     const contenant = new Contenant({ idProduit: '0', quantite: 1, dimensionsOuvert: { largeur: 33, hauteur: 33 } });
     vue.affiche(contenant);
+    vue.element.dispatchEvent(new Event('load'));
+
     expect(calque.classList).to.not.contain('invisible');
 
     calque.dispatchEvent(new Event('click'));
@@ -41,11 +43,11 @@ describe('vue contenu', function () {
   });
 
   describe('affiche()', function () {
-    it("sait afficher l'image du contenant", function () {
+    it("sait afficher l'image du contenant ouvert", function () {
       const contenant = new Contenant({ imageOuvert: 'image_contenant', dimensionsOuvert: { largeur: 33, hauteur: 33 } }, { nom: 'Nova Sky' });
       vue.affiche(contenant);
+      vue.element.dispatchEvent(new Event('load'));
 
-      expect(calque.classList).to.not.contain('invisible');
       expect(element.src).to.eql('image_contenant');
     });
 


### PR DESCRIPTION
J'ai ajouté l'attente de l'événement "load" sur l'image du contenant ouvert avant d'afficher la vue contenu.