### PR TITLE
Met à jour les noms de paramètres envoyés au serveur.

### DIFF
--- a/src/situations/inventaire/infra/depot_journal.js
+++ b/src/situations/inventaire/infra/depot_journal.js
@@ -40,7 +40,7 @@ export class DepotJournal {
   }
 
   recupereDonnees (ligne) {
-    const { date, type, description, sessionId } = ligne;
-    return { date, description: JSON.stringify(description), type_evenement: type, session_id: sessionId, situation: 'inventaire' };
+    const { date, nom, donnees, sessionId } = ligne;
+    return { date, donnees: JSON.stringify(donnees), nom, session_id: sessionId, situation: 'inventaire' };
   }
 }

--- a/src/situations/inventaire/modeles/journal.js
+++ b/src/situations/inventaire/modeles/journal.js
@@ -33,12 +33,12 @@ export class Journal {
     this.enregistre('saisieInventaire', { resultat, reponses: mapToObj(reponses) });
   }
 
-  enregistre (type, donnees = {}) {
+  enregistre (nom, donnees = {}) {
     this.depot.enregistre(
       {
         date: this.maintenant(),
         sessionId: this.sessionId,
-        type,
+        nom,
         donnees
       }
     );

--- a/tests/situations/inventaire/infra/depot_journal.js
+++ b/tests/situations/inventaire/infra/depot_journal.js
@@ -39,18 +39,18 @@ describe('le depot du journal', function () {
   });
 
   it('vérifie la conformité des données récupèrées', function () {
-    const donnees = journal.recupereDonnees({ autreCle: 'valeur2', sessionId: 'ma session id', description: { cle: 'valeur2' } });
+    const donnees = journal.recupereDonnees({ autreCle: 'valeur2', sessionId: 'ma session id', donnees: { cle: 'valeur2' } });
 
-    expect(donnees['description']).to.equal('{"cle":"valeur2"}');
+    expect(donnees['donnees']).to.equal('{"cle":"valeur2"}');
     expect(donnees['session_id']).to.equal('ma session id');
     expect(donnees['situation']).to.equal('inventaire');
   });
 
   it("vérifie s'il n'existe pas un journal au démarrage et le charge", function () {
-    journal.enregistre({ type: 'typeEvenement', description: { cle: 'valeur' } });
+    journal.enregistre({ nom: 'NomEvenement', description: { cle: 'valeur' } });
 
     journal = new DepotJournal({ ajax (params) { requetes.push(params); } });
-    journal.enregistre({ type: 'typeEvenement', description: { cle: 'valeur' } });
+    journal.enregistre({ nom: 'NomEvenement', description: { cle: 'valeur' } });
 
     const lignes = JSON.parse(window.localStorage.getItem('journal'));
     expect(lignes.length).to.equal(2);

--- a/tests/situations/inventaire/modeles/journal.js
+++ b/tests/situations/inventaire/modeles/journal.js
@@ -19,8 +19,8 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);
-    expect(enregistrement[0]).to.only.have.keys('date', 'sessionId', 'type', 'donnees');
-    expect(enregistrement[0]).to.have.property('type', 'demarrage');
+    expect(enregistrement[0]).to.only.have.keys('date', 'sessionId', 'nom', 'donnees');
+    expect(enregistrement[0]).to.have.property('nom', 'demarrage');
     expect(enregistrement[0]).to.have.property('date', 123);
     expect(enregistrement[0]).to.have.property('sessionId', sessionId);
   });
@@ -30,7 +30,7 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);
-    expect(enregistrement[0]).to.have.property('type', 'stop');
+    expect(enregistrement[0]).to.have.property('nom', 'stop');
   });
 
   it("enregistre l'ouverture d'un contenant", function () {
@@ -39,7 +39,7 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(2);
-    expect(enregistrement[0]).to.have.property('type', 'ouvertureContenant');
+    expect(enregistrement[0]).to.have.property('nom', 'ouvertureContenant');
     expect(enregistrement[0].donnees).to.eql({ idProduit: '9', quantite: 12, contenu: { nom: 'Nova Sky' } });
     expect(enregistrement[1].donnees).to.eql({ idProduit: '4', quantite: 7, contenu: { nom: 'Gink Cola' } });
   });
@@ -49,7 +49,7 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);
-    expect(enregistrement[0]).to.have.property('type', 'ouvertureSaisieInventaire');
+    expect(enregistrement[0]).to.have.property('nom', 'ouvertureSaisieInventaire');
   });
 
   it("enregistre la saisie d'inventaire", function () {
@@ -62,7 +62,7 @@ describe('le journal', function () {
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(2);
-    expect(enregistrement[0]).to.have.property('type', 'saisieInventaire');
+    expect(enregistrement[0]).to.have.property('nom', 'saisieInventaire');
     expect(enregistrement[0].donnees).to.eql({
       resultat: true,
       reponses: {


### PR DESCRIPTION
Le json envoyé au serveur a changé un peu. `type_evenement` a été renommé en `nom` et `description` en `donnees`.

Avec cela, le serveur accepte de sauvegarder l'événement.