### PR TITLE
Envoie les données en JSON.

### DIFF
--- a/src/situations/commun/infra/depot_journal.js
+++ b/src/situations/commun/infra/depot_journal.js
@@ -24,7 +24,7 @@ export class DepotJournal {
     this.$.ajax({
       type: 'POST',
       url: config.hote_serveur + '/api/evenements',
-      data: JSON.stringify(this.recupereDonnees(ligne)),
+      data: JSON.stringify(this.recuperePayload(ligne)),
       contentType: 'application/json; charset=utf-8',
       retryTimeout: 60000,
       appel: this.$,
@@ -39,8 +39,8 @@ export class DepotJournal {
     });
   }
 
-  recupereDonnees (ligne) {
+  recuperePayload (ligne) {
     const { date, nom, donnees, sessionId } = ligne;
-    return { date, donnees: JSON.stringify(donnees), nom, session_id: sessionId, situation: 'inventaire' };
+    return { date, donnees, nom, session_id: sessionId, situation: 'inventaire' };
   }
 }

--- a/tests/situations/inventaire/infra/depot_journal.js
+++ b/tests/situations/inventaire/infra/depot_journal.js
@@ -39,11 +39,12 @@ describe('le depot du journal', function () {
   });
 
   it('vérifie la conformité des données récupèrées', function () {
-    const donnees = journal.recupereDonnees({ autreCle: 'valeur2', sessionId: 'ma session id', donnees: { cle: 'valeur2' } });
+    const donnees = { cle: 'valeur2' };
+    const payload = journal.recuperePayload({ autreCle: 'valeur2', sessionId: 'ma session id', donnees });
 
-    expect(donnees['donnees']).to.equal('{"cle":"valeur2"}');
-    expect(donnees['session_id']).to.equal('ma session id');
-    expect(donnees['situation']).to.equal('inventaire');
+    expect(payload['donnees']).to.equal(donnees);
+    expect(payload['session_id']).to.equal('ma session id');
+    expect(payload['situation']).to.equal('inventaire');
   });
 
   it("vérifie s'il n'existe pas un journal au démarrage et le charge", function () {


### PR DESCRIPTION
Grâce à betagouv/competences-pro-serveur#14, le serveur accepte désormais qu'on lui envoie le paramètre `donnees` en JSON. Nous avons pu enlever le `JSON.stringify` pour ne rien faire de spécial.