### PR TITLE
Met à jour le titre de la situation controle.

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -17,7 +17,7 @@
     }
   },
   "controle": {
-    "titre": "Situation Contrôle"
+    "titre": "Chaîne de fabrication"
   },
   "restitution_inventaire": {
     "titre": "Restitution de la mise en situation"


### PR DESCRIPTION
Pour uniformiser avec le nom de la situation inventaire. J'ai fait le choix de ne pas mettre dans le nom de la situation l'action qui doit être fait. Mais cela pourrait être changé en "Inventaire de boissons" et *Contrôle de biscuits* par exemple.

![Screenshot_2019-03-22 Compétences pro](https://user-images.githubusercontent.com/86659/54826890-16fb4880-4cb1-11e9-8be8-294aa9787107.png)

Ferme / fix #93 