### PR TITLE
[CORRECTION] Corrige le problème de dimension des contenants ouverts

### DIFF
--- a/src/situations/inventaire/styles/etageres.scss
+++ b/src/situations/inventaire/styles/etageres.scss
@@ -6,6 +6,17 @@
     position:absolute;
     top: 0;
     left: 0;
+
+    .contenants {
+      // Les trois premières propriétés sont indispensables pour que les
+      // deux dernières soit bien active sur Safari
+      // https://benfrain.com/attempting-to-fix-responsive-svgs-in-desktop-safari/
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+    }
   }
 
   .image-fond {

--- a/src/situations/inventaire/vues/contenants.js
+++ b/src/situations/inventaire/vues/contenants.js
@@ -6,9 +6,7 @@ export class VueContenants {
     this.svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     this.svg.setAttribute('preserveAspectRatio', 'none');
     this.svg.setAttribute('viewBox', '0 0 100 100');
-    this.svg.style.width = '100%';
-    this.svg.style.height = '100%';
-    this.svg.classList.add('avant-plan');
+    this.svg.classList.add('contenants');
     pointInsertion.appendChild(this.svg);
   }
 
@@ -20,10 +18,5 @@ export class VueContenants {
         this.journal.enregistreOuvertureContenant({ contenant: contenant.id });
       });
     });
-  }
-
-  redimensionne (largeur, hauteur) {
-    this.svg.style.width = largeur + 'px';
-    this.svg.style.height = hauteur + 'px';
   }
 }

--- a/src/situations/inventaire/vues/contenu.js
+++ b/src/situations/inventaire/vues/contenu.js
@@ -10,8 +10,7 @@ class VueContenu {
     this.calque = document.createElement('div');
     this.calque.id = 'calque';
     pointInsertion.appendChild(this.calque);
-    this.calque.classList.add('calque');
-    this.calque.classList.add('invisible');
+    this.calque.classList.add('calque', 'invisible');
     this.calque.addEventListener('click', (event) => {
       this.element.classList.replace('ouvrir', 'fermer');
       setTimeout(() => {

--- a/src/situations/inventaire/vues/etageres.js
+++ b/src/situations/inventaire/vues/etageres.js
@@ -18,12 +18,17 @@ export class VueEtageres {
     etageres.classList.add('image-fond');
     this.element.appendChild(etageres);
 
-    const vueContenants = new VueContenants(this.element, this.journal);
-    const vueContenu = new VueContenu(this.element);
+    const avantPlan = document.createElement('div');
+    avantPlan.classList.add('avant-plan');
+    this.element.appendChild(avantPlan);
+
+    const vueContenants = new VueContenants(avantPlan, this.journal);
+    const vueContenu = new VueContenu(avantPlan);
     vueContenants.afficheLesContenants(contenants, vueContenu);
 
     const redimensionne = () => {
-      vueContenants.redimensionne(etageres.width, etageres.height);
+      avantPlan.style.width = etageres.width + 'px';
+      avantPlan.style.height = etageres.height + 'px';
     };
 
     window.addEventListener('resize', redimensionne);

--- a/tests/situations/inventaire/vues/etageres.js
+++ b/tests/situations/inventaire/vues/etageres.js
@@ -44,4 +44,10 @@ describe('vue etagères', function () {
     expect(avantPlan.style.width).to.equal('50px');
     expect(avantPlan.style.height).to.equal('25px');
   });
+
+  it("ajoute la vue contenu à l'interieur de l'avant plan pour que ses dimensions soient bien calculées par rapport à la taille de l'image", function () {
+    vue.affiche([]);
+
+    expect(document.querySelector('.avant-plan .contenu')).to.not.equal(null);
+  });
 });


### PR DESCRIPTION
Cette PR corrige un problème de redimensionnement des contenant ouvert qui vient d'être introduit avec la dernière correction sur la ré-intégration des barres des étagères dans les images de fond.

Cette PR corrige aussi le problème du dimensionnement du SVG sur safari (https://benfrain.com/attempting-to-fix-responsive-svgs-in-desktop-safari/)