### PR TITLE
Extrait les methodes du journal pour les remplacer par une méthode générique

### DIFF
--- a/src/situations/commun/modeles/evenement.js
+++ b/src/situations/commun/modeles/evenement.js
@@ -1,0 +1,13 @@
+export default class Evenement {
+  constructor (donnees = {}) {
+    this._donnees = donnees;
+  }
+
+  nom () {
+    throw new Error('Pas implémenté');
+  }
+
+  donnees () {
+    return this._donnees;
+  }
+}

--- a/src/situations/commun/modeles/evenement_demarrage.js
+++ b/src/situations/commun/modeles/evenement_demarrage.js
@@ -1,0 +1,7 @@
+import Evenement from './evenement';
+
+export default class EvenementDemarrage extends Evenement {
+  nom () {
+    return 'demarrage';
+  }
+}

--- a/src/situations/commun/modeles/evenement_stop.js
+++ b/src/situations/commun/modeles/evenement_stop.js
@@ -1,0 +1,7 @@
+import Evenement from './evenement';
+
+export default class EvenementStop extends Evenement {
+  nom () {
+    return 'stop';
+  }
+}

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -18,10 +18,6 @@ export class Journal {
     this.enregistre(evenement.nom(), evenement.donnees());
   }
 
-  enregistreStop () {
-    this.enregistre('stop');
-  }
-
   enregistreOuvertureContenant (contenant) {
     this.enregistre('ouvertureContenant', contenant);
   }

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -18,10 +18,6 @@ export class Journal {
     this.enregistre(evenement.nom(), evenement.donnees());
   }
 
-  enregistreOuvertureSaisieInventaire () {
-    this.enregistre('ouvertureSaisieInventaire');
-  }
-
   enregistreSaisieInventaire (resultat, reponses) {
     this.enregistre('saisieInventaire', { resultat, reponses: mapToObj(reponses) });
   }

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -6,18 +6,14 @@ export class Journal {
     this.situation = situation;
   }
 
-  enregistreEvenement (evenement) {
-    this.enregistre(evenement.nom(), evenement.donnees());
-  }
-
-  enregistre (nom, donnees = {}) {
+  enregistre (evenement) {
     this.depot.enregistre(
       {
         date: this.maintenant(),
         sessionId: this.sessionId,
         situation: this.situation,
-        nom,
-        donnees
+        nom: evenement.nom(),
+        donnees: evenement.donnees()
       }
     );
   }

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -1,11 +1,3 @@
-function mapToObj (map) {
-  const obj = {};
-  for (let [clef, valeur] of map) {
-    obj[clef] = valeur;
-  }
-  return obj;
-}
-
 export class Journal {
   constructor (maintenant, session, situation, depot) {
     this.maintenant = maintenant;
@@ -16,10 +8,6 @@ export class Journal {
 
   enregistreEvenement (evenement) {
     this.enregistre(evenement.nom(), evenement.donnees());
-  }
-
-  enregistreSaisieInventaire (resultat, reponses) {
-    this.enregistre('saisieInventaire', { resultat, reponses: mapToObj(reponses) });
   }
 
   enregistre (nom, donnees = {}) {

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -18,10 +18,6 @@ export class Journal {
     this.enregistre(evenement.nom(), evenement.donnees());
   }
 
-  enregistreDemarrage () {
-    this.enregistre('demarrage');
-  }
-
   enregistreStop () {
     this.enregistre('stop');
   }

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -14,6 +14,10 @@ export class Journal {
     this.situation = situation;
   }
 
+  enregistreEvenement (evenement) {
+    this.enregistre(evenement.nom(), evenement.donnees());
+  }
+
   enregistreDemarrage () {
     this.enregistre('demarrage');
   }

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -18,10 +18,6 @@ export class Journal {
     this.enregistre(evenement.nom(), evenement.donnees());
   }
 
-  enregistreOuvertureContenant (contenant) {
-    this.enregistre('ouvertureContenant', contenant);
-  }
-
   enregistreOuvertureSaisieInventaire () {
     this.enregistre('ouvertureSaisieInventaire');
   }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -21,7 +21,7 @@ export class VueGo {
 
     this.$boutonGo.on('click', () => {
       this.$overlay.addClass('invisible');
-      this.journal.enregistreEvenement(new EvenementDemarrage());
+      this.journal.enregistre(new EvenementDemarrage());
     });
     this.$overlay.append(this.$boutonGo);
 

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -3,6 +3,7 @@ import go from 'commun/assets/go.svg';
 import play from 'commun/assets/play.svg';
 
 import { traduction } from 'commun/infra/internationalisation';
+import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 
 export class VueGo {
   constructor (vueConsigne, journal) {
@@ -20,7 +21,7 @@ export class VueGo {
 
     this.$boutonGo.on('click', () => {
       this.$overlay.addClass('invisible');
-      this.journal.enregistreDemarrage();
+      this.journal.enregistreEvenement(new EvenementDemarrage());
     });
     this.$overlay.append(this.$boutonGo);
 

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -1,4 +1,5 @@
 import { traduction } from 'commun/infra/internationalisation';
+import EvenementStop from 'commun/modeles/evenement_stop';
 import stop from 'commun/assets/stop.svg';
 
 import 'commun/styles/stop.scss';
@@ -15,7 +16,7 @@ export class VueStop {
     this.$boutonStop.on('click', () => {
       afficheFenetreModale(this.$pointInsertion, $,
         traduction('situation.stop'),
-        () => { journal.enregistreStop(); retourAccueil(); });
+        () => { journal.enregistreEvenement(new EvenementStop()); retourAccueil(); });
     });
   }
 

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -16,7 +16,7 @@ export class VueStop {
     this.$boutonStop.on('click', () => {
       afficheFenetreModale(this.$pointInsertion, $,
         traduction('situation.stop'),
-        () => { journal.enregistreEvenement(new EvenementStop()); retourAccueil(); });
+        () => { journal.enregistre(new EvenementStop()); retourAccueil(); });
     });
   }
 

--- a/src/situations/inventaire/modeles/evenement_ouverture_contenant.js
+++ b/src/situations/inventaire/modeles/evenement_ouverture_contenant.js
@@ -1,0 +1,7 @@
+import Evenement from 'commun/modeles/evenement';
+
+export default class EvenementOuvertureContenant extends Evenement {
+  nom () {
+    return 'ouvertureContenant';
+  }
+}

--- a/src/situations/inventaire/modeles/evenement_ouverture_saisie_inventaire.js
+++ b/src/situations/inventaire/modeles/evenement_ouverture_saisie_inventaire.js
@@ -1,0 +1,7 @@
+import Evenement from 'commun/modeles/evenement';
+
+export default class EvenementOuvertureSaisieInventaire extends Evenement {
+  nom () {
+    return 'ouvertureSaisieInventaire';
+  }
+}

--- a/src/situations/inventaire/modeles/evenement_saisie_inventaire.js
+++ b/src/situations/inventaire/modeles/evenement_saisie_inventaire.js
@@ -1,0 +1,22 @@
+import Evenement from 'commun/modeles/evenement';
+
+function mapToObj (map) {
+  const obj = {};
+  for (let [clef, valeur] of map) {
+    obj[clef] = valeur;
+  }
+  return obj;
+}
+
+export default class EvenementSaisieInventaire extends Evenement {
+  nom () {
+    return 'saisieInventaire';
+  }
+
+  donnees () {
+    return {
+      resultat: this._donnees.resultat,
+      reponses: mapToObj(this._donnees.reponses)
+    };
+  }
+}

--- a/src/situations/inventaire/vues/contenants.js
+++ b/src/situations/inventaire/vues/contenants.js
@@ -16,7 +16,7 @@ export class VueContenants {
       const vueContenant = new VueContenant(this.svg, contenant);
       vueContenant.affiche((event) => {
         vueContenu.affiche(contenant);
-        this.journal.enregistreEvenement(new EvenementOuvertureContenant({ contenant: contenant.id }));
+        this.journal.enregistre(new EvenementOuvertureContenant({ contenant: contenant.id }));
       });
     });
   }

--- a/src/situations/inventaire/vues/contenants.js
+++ b/src/situations/inventaire/vues/contenants.js
@@ -1,4 +1,5 @@
 import { VueContenant } from './contenant.js';
+import EvenementOuvertureContenant from 'inventaire/modeles/evenement_ouverture_contenant';
 
 export class VueContenants {
   constructor (pointInsertion, journal) {
@@ -15,7 +16,7 @@ export class VueContenants {
       const vueContenant = new VueContenant(this.svg, contenant);
       vueContenant.affiche((event) => {
         vueContenu.affiche(contenant);
-        this.journal.enregistreOuvertureContenant({ contenant: contenant.id });
+        this.journal.enregistreEvenement(new EvenementOuvertureContenant({ contenant: contenant.id }));
       });
     });
   }

--- a/src/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/src/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -90,7 +90,7 @@ export function initialiseFormulaireSaisieInventaire (magasin, pointInsertion, $
 
     function basculeVisibiliteFormulaire () {
       if ($overlay.hasClass('invisible')) {
-        journal.enregistreEvenement(new EvenementOuvertureSaisieInventaire());
+        journal.enregistre(new EvenementOuvertureSaisieInventaire());
       }
       basculeVisibilite($overlay);
       basculeVisibilite($formulaireSaisie);

--- a/src/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/src/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -1,5 +1,6 @@
 import { traduction } from 'commun/infra/internationalisation';
 import boutonSaisie from 'inventaire/assets/saisie-reponse.svg';
+import EvenementOuvertureSaisieInventaire from 'inventaire/modeles/evenement_ouverture_saisie_inventaire';
 
 import 'commun/styles/commun.scss';
 import 'commun/styles/overlay.scss';
@@ -89,7 +90,7 @@ export function initialiseFormulaireSaisieInventaire (magasin, pointInsertion, $
 
     function basculeVisibiliteFormulaire () {
       if ($overlay.hasClass('invisible')) {
-        journal.enregistreOuvertureSaisieInventaire();
+        journal.enregistreEvenement(new EvenementOuvertureSaisieInventaire());
       }
       basculeVisibilite($overlay);
       basculeVisibilite($formulaireSaisie);

--- a/src/situations/inventaire/vues/situation.js
+++ b/src/situations/inventaire/vues/situation.js
@@ -18,7 +18,7 @@ export class VueSituation {
       const toutCorrect = Array.from(resultatValidation.values()).every(v => v);
       const message = toutCorrect ? traduction('inventaire.resultat.ok') : traduction('inventaire.resultat.echec');
 
-      this.journal.enregistreEvenement(new EvenementSaisieInventaire({ resultat: toutCorrect, reponses }));
+      this.journal.enregistre(new EvenementSaisieInventaire({ resultat: toutCorrect, reponses }));
 
       Array.from(resultatValidation).forEach((correction) => { afficheCorrection(correction, $); });
       window.alert(message);

--- a/src/situations/inventaire/vues/situation.js
+++ b/src/situations/inventaire/vues/situation.js
@@ -1,6 +1,7 @@
 import { traduction } from 'commun/infra/internationalisation';
 import { contenants, contenus } from 'inventaire/data/stock.js';
 import { creeMagasin } from 'inventaire/modeles/magasin.js';
+import EvenementSaisieInventaire from 'inventaire/modeles/evenement_saisie_inventaire';
 import { VueEtageres } from 'inventaire/vues/etageres.js';
 import { afficheCorrection, initialiseFormulaireSaisieInventaire } from 'inventaire/vues/formulaireSaisieInventaire.js';
 
@@ -17,7 +18,7 @@ export class VueSituation {
       const toutCorrect = Array.from(resultatValidation.values()).every(v => v);
       const message = toutCorrect ? traduction('inventaire.resultat.ok') : traduction('inventaire.resultat.echec');
 
-      this.journal.enregistreSaisieInventaire(toutCorrect, reponses);
+      this.journal.enregistreEvenement(new EvenementSaisieInventaire({ resultat: toutCorrect, reponses }));
 
       Array.from(resultatValidation).forEach((correction) => { afficheCorrection(correction, $); });
       window.alert(message);

--- a/tests/situations/commun/modeles/evenement.js
+++ b/tests/situations/commun/modeles/evenement.js
@@ -1,0 +1,11 @@
+import Evenement from 'commun/modeles/evenement.js';
+
+describe("l'événement", function () {
+  it("renvoit une exception lorsqu'on lui demande son nom", function () {
+    expect(new Evenement().nom).to.throwError('Pas implémenté');
+  });
+
+  it('retourne ses donnéees', function () {
+    expect(new Evenement().donnees()).to.eql({});
+  });
+});

--- a/tests/situations/commun/modeles/evenement_demarrage.js
+++ b/tests/situations/commun/modeles/evenement_demarrage.js
@@ -1,0 +1,7 @@
+import EvenementDemarrage from 'commun/modeles/evenement_demarrage.js';
+
+describe("l'événement de demarrage", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementDemarrage().nom()).to.eql('demarrage');
+  });
+});

--- a/tests/situations/commun/modeles/evenement_stop.js
+++ b/tests/situations/commun/modeles/evenement_stop.js
@@ -1,0 +1,7 @@
+import EvenementStop from 'commun/modeles/evenement_stop.js';
+
+describe("l'événement de stop", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementStop().nom()).to.eql('stop');
+  });
+});

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -34,18 +34,6 @@ describe('le journal', function () {
     expect(enregistrement[0]).to.have.property('situation', situation);
   });
 
-  it("enregistre l'appui sur le bouton de démarrage", function () {
-    journal.enregistreDemarrage();
-
-    const enregistrement = mockDepot.evenements();
-    expect(enregistrement.length).to.equal(1);
-    expect(enregistrement[0]).to.only.have.keys('date', 'sessionId', 'nom', 'donnees', 'situation');
-    expect(enregistrement[0]).to.have.property('nom', 'demarrage');
-    expect(enregistrement[0]).to.have.property('date', 123);
-    expect(enregistrement[0]).to.have.property('sessionId', sessionId);
-    expect(enregistrement[0]).to.have.property('situation', situation);
-  });
-
   it("enregistre l'appui sur le bouton de stop", function () {
     journal.enregistreStop();
 

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -1,4 +1,5 @@
 import { Journal } from 'commun/modeles/journal.js';
+import Evenement from 'commun/modeles/evenement.js';
 import { Contenant } from 'inventaire/modeles/contenant.js';
 import { MockDepot } from '../aides/mockDepot.js';
 
@@ -9,10 +10,28 @@ describe('le journal', function () {
   const sessionId = 42;
   const situation = 'inventaire';
 
+  class EvenementTest extends Evenement {
+    nom () {
+      return 'test';
+    }
+  }
+
   beforeEach(function () {
     mockMaintenant = () => { return 123; };
     mockDepot = new MockDepot();
     journal = new Journal(mockMaintenant, sessionId, situation, mockDepot);
+  });
+
+  it('enregistre un événement', function () {
+    journal.enregistreEvenement(new EvenementTest());
+
+    const enregistrement = mockDepot.evenements();
+    expect(enregistrement.length).to.equal(1);
+    expect(enregistrement[0]).to.only.have.keys('date', 'sessionId', 'nom', 'donnees', 'situation');
+    expect(enregistrement[0]).to.have.property('nom', 'test');
+    expect(enregistrement[0]).to.have.property('date', 123);
+    expect(enregistrement[0]).to.have.property('sessionId', sessionId);
+    expect(enregistrement[0]).to.have.property('situation', situation);
   });
 
   it("enregistre l'appui sur le bouton de démarrage", function () {

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -32,31 +32,4 @@ describe('le journal', function () {
     expect(enregistrement[0]).to.have.property('sessionId', sessionId);
     expect(enregistrement[0]).to.have.property('situation', situation);
   });
-
-  it("enregistre la saisie d'inventaire", function () {
-    const detail = new Map();
-    detail.set('1', '42');
-    detail.set('2', '1');
-
-    journal.enregistreSaisieInventaire(true, detail);
-    journal.enregistreSaisieInventaire(false, detail);
-
-    const enregistrement = mockDepot.evenements();
-    expect(enregistrement.length).to.equal(2);
-    expect(enregistrement[0]).to.have.property('nom', 'saisieInventaire');
-    expect(enregistrement[0].donnees).to.eql({
-      resultat: true,
-      reponses: {
-        1: 42,
-        2: 1
-      }
-    });
-    expect(enregistrement[1].donnees).to.eql({
-      resultat: false,
-      reponses: {
-        1: 42,
-        2: 1
-      }
-    });
-  });
 });

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -33,14 +33,6 @@ describe('le journal', function () {
     expect(enregistrement[0]).to.have.property('situation', situation);
   });
 
-  it("enregistre l'ouverture de la saisie d'inventaire", function () {
-    journal.enregistreOuvertureSaisieInventaire();
-
-    const enregistrement = mockDepot.evenements();
-    expect(enregistrement.length).to.equal(1);
-    expect(enregistrement[0]).to.have.property('nom', 'ouvertureSaisieInventaire');
-  });
-
   it("enregistre la saisie d'inventaire", function () {
     const detail = new Map();
     detail.set('1', '42');

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -1,6 +1,5 @@
 import { Journal } from 'commun/modeles/journal.js';
 import Evenement from 'commun/modeles/evenement.js';
-import { Contenant } from 'inventaire/modeles/contenant.js';
 import { MockDepot } from '../aides/mockDepot.js';
 
 describe('le journal', function () {
@@ -32,17 +31,6 @@ describe('le journal', function () {
     expect(enregistrement[0]).to.have.property('date', 123);
     expect(enregistrement[0]).to.have.property('sessionId', sessionId);
     expect(enregistrement[0]).to.have.property('situation', situation);
-  });
-
-  it("enregistre l'ouverture d'un contenant", function () {
-    journal.enregistreOuvertureContenant(new Contenant({ idProduit: '9', quantite: 12 }, { nom: 'Nova Sky' }));
-    journal.enregistreOuvertureContenant(new Contenant({ idProduit: '4', quantite: 7 }, { nom: 'Gink Cola' }));
-
-    const enregistrement = mockDepot.evenements();
-    expect(enregistrement.length).to.equal(2);
-    expect(enregistrement[0]).to.have.property('nom', 'ouvertureContenant');
-    expect(enregistrement[0].donnees).to.eql({ idProduit: '9', quantite: 12, contenu: { nom: 'Nova Sky' } });
-    expect(enregistrement[1].donnees).to.eql({ idProduit: '4', quantite: 7, contenu: { nom: 'Gink Cola' } });
   });
 
   it("enregistre l'ouverture de la saisie d'inventaire", function () {

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -22,7 +22,7 @@ describe('le journal', function () {
   });
 
   it('enregistre un événement', function () {
-    journal.enregistreEvenement(new EvenementTest());
+    journal.enregistre(new EvenementTest());
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -34,14 +34,6 @@ describe('le journal', function () {
     expect(enregistrement[0]).to.have.property('situation', situation);
   });
 
-  it("enregistre l'appui sur le bouton de stop", function () {
-    journal.enregistreStop();
-
-    const enregistrement = mockDepot.evenements();
-    expect(enregistrement.length).to.equal(1);
-    expect(enregistrement[0]).to.have.property('nom', 'stop');
-  });
-
   it("enregistre l'ouverture d'un contenant", function () {
     journal.enregistreOuvertureContenant(new Contenant({ idProduit: '9', quantite: 12 }, { nom: 'Nova Sky' }));
     journal.enregistreOuvertureContenant(new Contenant({ idProduit: '4', quantite: 7 }, { nom: 'Gink Cola' }));

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -2,6 +2,7 @@
 import jsdom from 'jsdom-global';
 import { VueGo } from 'commun/vues/go.js';
 import { traduction } from 'commun/infra/internationalisation';
+import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 
 describe('vue Go', function () {
   let vue;
@@ -15,7 +16,7 @@ describe('vue Go', function () {
     jsdom('<div id="pointInsertion"></div>');
     $ = jQuery(window);
     mockJournal = {
-      enregistreDemarrage () {}
+      enregistreEvenement () {}
     };
     vue = new VueGo(mockVueConsigne, mockJournal);
   });
@@ -93,7 +94,10 @@ describe('vue Go', function () {
   });
 
   it("journalise l'événement lorsque le jeu est démarré", function (done) {
-    mockJournal.enregistreDemarrage = done;
+    mockJournal.enregistreEvenement = (evenement) => {
+      expect(evenement).to.be.a(EvenementDemarrage);
+      done();
+    };
 
     vue.affiche('#pointInsertion', $);
 

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -16,7 +16,7 @@ describe('vue Go', function () {
     jsdom('<div id="pointInsertion"></div>');
     $ = jQuery(window);
     mockJournal = {
-      enregistreEvenement () {}
+      enregistre () {}
     };
     vue = new VueGo(mockVueConsigne, mockJournal);
   });
@@ -94,7 +94,7 @@ describe('vue Go', function () {
   });
 
   it("journalise l'événement lorsque le jeu est démarré", function (done) {
-    mockJournal.enregistreEvenement = (evenement) => {
+    mockJournal.enregistre = (evenement) => {
       expect(evenement).to.be.a(EvenementDemarrage);
       done();
     };

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -18,7 +18,7 @@ describe('vue Stop', function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
     mockJournal = {
-      enregistreEvenement () {}
+      enregistre () {}
     };
     vue = new VueStop('#magasin', $, mockJournal, () => {
       retourAccueil = true;
@@ -47,7 +47,7 @@ describe('vue Stop', function () {
   });
 
   it("Enregistre l'événément quand on confirme la modale", function (done) {
-    mockJournal.enregistreEvenement = (evenement) => {
+    mockJournal.enregistre = (evenement) => {
       expect(evenement).to.be.a(EvenementStop);
       done();
     };

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -1,5 +1,6 @@
 import jsdom from 'jsdom-global';
 import { VueStop } from 'commun/vues/stop.js';
+import EvenementStop from 'commun/modeles/evenement_stop';
 import i18next from 'i18next';
 i18next.init({
   lng: 'fr',
@@ -17,7 +18,7 @@ describe('vue Stop', function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
     mockJournal = {
-      enregistreStop () {}
+      enregistreEvenement () {}
     };
     vue = new VueStop('#magasin', $, mockJournal, () => {
       retourAccueil = true;
@@ -46,7 +47,10 @@ describe('vue Stop', function () {
   });
 
   it("Enregistre l'événément quand on confirme la modale", function (done) {
-    mockJournal.enregistreStop = done;
+    mockJournal.enregistreEvenement = (evenement) => {
+      expect(evenement).to.be.a(EvenementStop);
+      done();
+    };
     vue.afficher();
     $('#magasin #stop').click();
     $('#OK-modale').click();

--- a/tests/situations/inventaire/modeles/evenement_ouverture_contenant.js
+++ b/tests/situations/inventaire/modeles/evenement_ouverture_contenant.js
@@ -1,0 +1,12 @@
+import EvenementOuvertureContenant from 'inventaire/modeles/evenement_ouverture_contenant';
+
+describe("l'événement d'ouverture de contenant", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementOuvertureContenant().nom()).to.eql('ouvertureContenant');
+  });
+
+  it('retourne ses donnees', function () {
+    const donnees = { contenant: '1' };
+    expect(new EvenementOuvertureContenant(donnees).donnees()).to.eql(donnees);
+  });
+});

--- a/tests/situations/inventaire/modeles/evenement_ouverture_saisie_inventaire.js
+++ b/tests/situations/inventaire/modeles/evenement_ouverture_saisie_inventaire.js
@@ -1,0 +1,7 @@
+import EvenementOuvertureSaisieInventaire from 'inventaire/modeles/evenement_ouverture_saisie_inventaire';
+
+describe("l'événement d'ouverture de saisie d'inventaire", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementOuvertureSaisieInventaire().nom()).to.eql('ouvertureSaisieInventaire');
+  });
+});

--- a/tests/situations/inventaire/modeles/evenement_saisie_inventaire.js
+++ b/tests/situations/inventaire/modeles/evenement_saisie_inventaire.js
@@ -1,0 +1,21 @@
+import EvenementSaisieInventaire from 'inventaire/modeles/evenement_saisie_inventaire';
+
+describe("l'événement d'ouverture de saisie d'inventaire", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementSaisieInventaire().nom()).to.eql('saisieInventaire');
+  });
+
+  it('retourne ses donnees', function () {
+    const reponses = new Map();
+    reponses.set('1', { quantite: 4 });
+    const donnees = { resultat: true, reponses };
+    expect(new EvenementSaisieInventaire(donnees).donnees()).to.eql({
+      resultat: true,
+      reponses: {
+        '1': {
+          quantite: 4
+        }
+      }
+    });
+  });
+});

--- a/tests/situations/inventaire/vues/contenants.js
+++ b/tests/situations/inventaire/vues/contenants.js
@@ -19,7 +19,7 @@ describe('vue contenants', function () {
     jsdom('<div id="stock"></div>');
     pointInsertion = document.getElementById('stock');
     journal = {
-      enregistreEvenement () {}
+      enregistre () {}
     };
     vue = new VueContenants(pointInsertion, journal);
   });
@@ -49,7 +49,7 @@ describe('vue contenants', function () {
   });
 
   it('journalise le contenant quand on clique dessus', function (done) {
-    journal.enregistreEvenement = (evenement) => {
+    journal.enregistre = (evenement) => {
       expect(evenement).to.be.a(EvenementOuvertureContenant);
       expect(evenement.donnees()).to.eql({ contenant: 'id_contenant' });
       done();

--- a/tests/situations/inventaire/vues/contenants.js
+++ b/tests/situations/inventaire/vues/contenants.js
@@ -2,12 +2,13 @@
 
 import { Contenant } from 'inventaire/modeles/contenant.js';
 import { VueContenants } from 'inventaire/vues/contenants.js';
+import EvenementOuvertureContenant from 'inventaire/modeles/evenement_ouverture_contenant';
 import jsdom from 'jsdom-global';
 
 describe('vue contenants', function () {
   let vue;
-  let contenantsJournalises;
   let pointInsertion;
+  let journal;
 
   let contenants = [
     new Contenant({ id: '0', idContenu: '0', quantite: 1, posX: 40, posY: 80 }, { nom: 'Nova Sky', image: 'chemin' }),
@@ -17,11 +18,8 @@ describe('vue contenants', function () {
   beforeEach(function () {
     jsdom('<div id="stock"></div>');
     pointInsertion = document.getElementById('stock');
-    contenantsJournalises = [];
-    let journal = {
-      enregistreOuvertureContenant: (contenant) => {
-        contenantsJournalises.push(contenant);
-      }
+    journal = {
+      enregistreEvenement () {}
     };
     vue = new VueContenants(pointInsertion, journal);
   });
@@ -50,13 +48,16 @@ describe('vue contenants', function () {
       .dispatchEvent(new Event('click'));
   });
 
-  it('journalise le contenant quand on clique dessus', function () {
+  it('journalise le contenant quand on clique dessus', function (done) {
+    journal.enregistreEvenement = (evenement) => {
+      expect(evenement).to.be.a(EvenementOuvertureContenant);
+      expect(evenement.donnees()).to.eql({ contenant: 'id_contenant' });
+      done();
+    };
     contenants[0].id = 'id_contenant';
     vue.afficheLesContenants(contenants, { affiche: () => {} });
 
     document.getElementsByClassName('contenant')[0]
       .dispatchEvent(new Event('click'));
-
-    expect(contenantsJournalises).to.eql([{ contenant: 'id_contenant' }]);
   });
 });

--- a/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -1,5 +1,6 @@
 import { Contenant } from 'inventaire/modeles/contenant.js';
 import { afficheCorrection, initialiseFormulaireSaisieInventaire } from 'inventaire/vues/formulaireSaisieInventaire.js';
+import EvenementOuvertureSaisieInventaire from 'inventaire/modeles/evenement_ouverture_saisie_inventaire.js';
 import { unMagasin, unMagasinVide } from '../aides/magasin.js';
 
 let jsdom = require('jsdom-global');
@@ -12,7 +13,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
     journal = {
-      enregistreOuvertureSaisieInventaire () {}
+      enregistreEvenement () {}
     };
   });
 
@@ -42,7 +43,10 @@ describe("Le formulaire de saisie d'inventaire", function () {
     });
 
     it("journalise l'événement", function (done) {
-      journal.enregistreOuvertureSaisieInventaire = done;
+      journal.enregistreEvenement = (evenement) => {
+        expect(evenement).to.be.a(EvenementOuvertureSaisieInventaire);
+        done();
+      };
       $('.affiche-saisie').click();
     });
   });
@@ -65,12 +69,12 @@ describe("Le formulaire de saisie d'inventaire", function () {
     });
 
     it("n'enregistre pas une ouverture de saisie d'inventaire", function () {
-      let evenementOuvertureSaisieInventaire = 0;
-      journal.enregistreOuvertureSaisieInventaire = () => {
-        evenementOuvertureSaisieInventaire++;
+      let evenements = 0;
+      journal.enregistreEvenement = () => {
+        evenements++;
       };
       $('.overlay').click();
-      expect(evenementOuvertureSaisieInventaire).to.eql(0);
+      expect(evenements).to.eql(0);
     });
   });
 

--- a/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -13,7 +13,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
     journal = {
-      enregistreEvenement () {}
+      enregistre () {}
     };
   });
 
@@ -43,7 +43,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
     });
 
     it("journalise l'événement", function (done) {
-      journal.enregistreEvenement = (evenement) => {
+      journal.enregistre = (evenement) => {
         expect(evenement).to.be.a(EvenementOuvertureSaisieInventaire);
         done();
       };
@@ -70,7 +70,7 @@ describe("Le formulaire de saisie d'inventaire", function () {
 
     it("n'enregistre pas une ouverture de saisie d'inventaire", function () {
       let evenements = 0;
-      journal.enregistreEvenement = () => {
+      journal.enregistre = () => {
         evenements++;
       };
       $('.overlay').click();


### PR DESCRIPTION
Dans le chapitre précédent, un homme, enthousiaste, avait décidé d'enregistrer plus d'événements dans la situation inventaire. Il avait alors ajouté des méthodes du type `enregistreDemarrage` ou encore `enregistreOuvertureContenant` pour faire cela. Mais le journal avait une autre destinée. En effet, la situation contrôle a pointé le bout de son nez. Le journal a été déplacé. Les méthodes sont restées. 

Dans ce nouveau chapitre, pour permettre l'enregistrement d'événements dans n'importe quelle ~partie du royaume~ des situations , il a été décidé de déplacer les méthodes dans des classes événement. Une méthode générique `enregistreEvenement` s'occupe ainsi de récupérer son nom et les données associés.

