### PR TITLE
passage du point d'insertion à `VueGo.affiche(…)` et `VueConsigne.affiche(…)`

### DIFF
--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -20,10 +20,11 @@ function afficheSituation (pointInsertion, $) {
   const vueCadre = new VueCadre(vueSituationInventaire);
   const vueActions = new VueActions(journal);
   const vueConsigne = new VueConsigne(pointInsertion, sonConsigneDemarrage);
+  const vueGo = new VueGo(vueConsigne, journal);
 
   vueCadre.affiche(pointInsertion, $);
   vueActions.affiche(pointInsertion, $);
-  new VueGo(pointInsertion, vueConsigne, journal).afficher();
+  vueGo.affiche(pointInsertion);
 }
 
 initialiseInternationalisation().then(function () {

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -19,9 +19,10 @@ function afficheSituation (pointInsertion, $) {
   const vueSituationInventaire = new VueSituation(journal);
   const vueCadre = new VueCadre(vueSituationInventaire);
   const vueActions = new VueActions(journal);
-  const vueConsigne = new VueConsigne(pointInsertion, sonConsigneDemarrage);
+  const vueConsigne = new VueConsigne(sonConsigneDemarrage);
   const vueGo = new VueGo(vueConsigne, journal);
 
+  vueConsigne.affiche(pointInsertion);
   vueCadre.affiche(pointInsertion, $);
   vueActions.affiche(pointInsertion, $);
   vueGo.affiche(pointInsertion);

--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -1,10 +1,14 @@
 
 export class VueConsigne {
-  constructor (pointInsertion, sonConsigneDemarrage) {
+  constructor (sonConsigneDemarrage) {
+    this.sonConsigneDemarrage = sonConsigneDemarrage;
+  }
+
+  affiche (pointInsertion) {
     this.element = document.createElement('audio');
     this.element.type = 'audio/mp3';
     this.element.preload = 'none';
-    this.element.src = sonConsigneDemarrage;
+    this.element.src = this.sonConsigneDemarrage;
     document.querySelector(pointInsertion).appendChild(this.element);
 
     this.element.id = 'consigne';

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -3,15 +3,13 @@ import { traduction } from 'commun/infra/internationalisation';
 import 'commun/styles/go.scss';
 
 export class VueGo {
-  constructor (pointInsertion, vueConsigne, journal) {
-    const elementPointInsertion = document.querySelector(pointInsertion);
+  constructor (vueConsigne, journal) {
     this.overlay = document.createElement('div');
     this.overlay.id = 'overlay-go';
-    this.overlay.classList.add('invisible', 'overlay');
+    this.overlay.classList.add('overlay');
     this.overlay.addEventListener('click', (event) => {
       event.stopPropagation();
     });
-    elementPointInsertion.appendChild(this.overlay);
 
     this.boutonGo = document.createElement('button');
     this.boutonGo.id = 'go';
@@ -25,7 +23,7 @@ export class VueGo {
 
     this.boutonDemarrerConsigne = document.createElement('button');
     this.boutonDemarrerConsigne.id = 'demarrer-consigne';
-    this.boutonDemarrerConsigne.classList.add('invisible', 'bouton-centre', 'bouton-lire-consigne-demarrage');
+    this.boutonDemarrerConsigne.classList.add('bouton-centre', 'bouton-lire-consigne-demarrage');
     this.boutonDemarrerConsigne.addEventListener('click', () => {
       this.boutonDemarrerConsigne.classList.add('invisible');
       vueConsigne.jouerConsigneDemarrage(() => {
@@ -35,8 +33,7 @@ export class VueGo {
     this.overlay.appendChild(this.boutonDemarrerConsigne);
   }
 
-  afficher () {
-    this.overlay.classList.remove('invisible');
-    this.boutonDemarrerConsigne.classList.remove('invisible');
+  affiche (pointInsertion) {
+    document.querySelector(pointInsertion).appendChild(this.overlay);
   }
 }

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -7,8 +7,9 @@ describe('vue consigne', function () {
   let vue;
 
   beforeEach(function () {
-    jsdom('<div id="magasin"></div>');
-    vue = new VueConsigne('#magasin', 'chemin_vers_la_consigne');
+    jsdom('<div id="pointInsertion"></div>');
+    vue = new VueConsigne('chemin_vers_la_consigne');
+    vue.affiche('#pointInsertion');
     vue.element.play = () => {
       return new Promise(function (resolve, reject) {
         resolve();
@@ -17,7 +18,7 @@ describe('vue consigne', function () {
   });
 
   it("sait s'insérer dans une page web ", function () {
-    let element = document.querySelector('#magasin #consigne');
+    let element = document.querySelector('#pointInsertion #consigne');
     expect(element).to.eql(vue.element);
     expect(vue.element.tagName).to.equal('AUDIO');
   });

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -4,80 +4,88 @@ import { VueGo } from 'commun/vues/go.js';
 
 describe('vue Go', function () {
   let vue;
-  let overlay;
-  let boutonGo;
-  let boutonDemarrerConsigne;
   let mockVueConsigne = {
     jouerConsigneDemarrage () {}
   };
   let mockJournal;
 
   beforeEach(function () {
-    jsdom('<div id="magasin"></div>');
+    jsdom('<div id="pointInsertion"></div>');
     mockJournal = {
       enregistreDemarrage () {}
     };
-    vue = new VueGo('#magasin', mockVueConsigne, mockJournal);
-    overlay = document.querySelector('#magasin #overlay-go');
-    boutonGo = overlay.querySelector('#go');
-    boutonDemarrerConsigne = overlay.querySelector('#demarrer-consigne');
+    vue = new VueGo(mockVueConsigne, mockJournal);
   });
 
-  it('affiche un bouton "lire la consigne"', function () {
+  it('affiche un bouton "lire la consigne" mais pas le bouton "go" au démarrage', function () {
+    vue.affiche('#pointInsertion');
+
+    const overlay = document.querySelector('#pointInsertion #overlay-go');
     expect(overlay.classList).to.contain('overlay');
 
-    vue.afficher();
-    expect(overlay.classList).to.not.contain('invisible');
+    const boutonDemarrerConsigne = overlay.querySelector('#demarrer-consigne');
     expect(boutonDemarrerConsigne.classList).to.not.contain('invisible');
+
+    const boutonGo = overlay.querySelector('#go');
+    expect(boutonGo.classList).to.contain('invisible');
   });
 
   it('démarre la lecture de la consigne quand on appuie sur le bouton', function (done) {
+    vue.affiche('#pointInsertion');
+
+    const boutonDemarrerConsigne = document.querySelector('#demarrer-consigne');
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
+      expect(boutonDemarrerConsigne.classList).to.contain('invisible');
       done();
     };
-    vue.afficher();
 
     boutonDemarrerConsigne.dispatchEvent(new Event('click'));
-
-    expect(boutonDemarrerConsigne.classList).to.contain('invisible');
   });
 
   it('affiche un overlay pendant la lecture de la consigne', function () {
+    vue.affiche('#pointInsertion');
+
+    const overlay = document.querySelector('#overlay-go');
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
       expect(overlay.classList).to.not.contain('invisible');
     };
-    vue.afficher();
+
+    const boutonDemarrerConsigne = document.querySelector('#demarrer-consigne');
+    boutonDemarrerConsigne.dispatchEvent(new Event('click'));
 
     expect(overlay.classList).to.not.contain('invisible');
   });
 
   it('affiche un bouton GO à la fin de la lecture de la consigne', function () {
+    vue.affiche('#pointInsertion');
+
+    const boutonGo = document.querySelector('#go');
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
       expect(boutonGo.classList).to.contain('invisible');
       actionFinConsigne();
     };
-    vue.afficher();
+    const boutonDemarrerConsigne = document.querySelector('#demarrer-consigne');
     boutonDemarrerConsigne.dispatchEvent(new Event('click'));
 
     expect(boutonGo.classList).to.not.contain('invisible');
   });
 
   it("masque l'overlay et le bouton une fois le jeu démarré", function () {
-    mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
-      expect(boutonGo.classList).to.contain('invisible');
-      actionFinConsigne();
-    };
-    vue.afficher();
+    vue.affiche('#pointInsertion');
+
+    const boutonGo = document.querySelector('#overlay-go #go');
 
     boutonGo.dispatchEvent(new Event('click'));
 
+    const overlay = document.querySelector('#overlay-go');
     expect(overlay.classList).to.contain('invisible');
   });
 
   it("journalise l'événement lorsque le jeu est démarré", function (done) {
     mockJournal.enregistreDemarrage = done;
-    vue.afficher();
 
-    boutonGo.dispatchEvent(new Event('click'));
+    vue.affiche('#pointInsertion');
+
+    document.querySelector('#go').dispatchEvent(new Event('click'));
   });
 });


### PR DESCRIPTION
Cette PR contribue à l'issue #98 

- Refactoring de la vue Go pour passer le point d'insertion à la méthode affiche()
- Refactoring de la vue Consigne pour passer le point d'insertion à la méthode affiche() après avoir créer cette méthode.