### PR TITLE
Supprime le fichier config.json

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 FROM node:10 as node
 
+ARG URL_SERVEUR
+ENV URL_SERVEUR ${URL_SERVEUR}
+ENV NODE_ENV production
+
 WORKDIR /app/
 COPY package.json package-lock.json ./
-RUN npm install
+RUN npm install --production=false
 
 COPY . ./
 RUN npm run build

--- a/config.json
+++ b/config.json
@@ -1,5 +1,0 @@
-{
-  "config": {
-    "hote_serveur": "http://localhost:3000"
-  }
-}

--- a/src/situations/commun/infra/depot_journal.js
+++ b/src/situations/commun/infra/depot_journal.js
@@ -1,5 +1,3 @@
-import { config } from '../../../../config.json';
-
 export class DepotJournal {
   constructor ($ = require('jquery')) {
     this.lignes = JSON.parse(window.localStorage.getItem('journal'));
@@ -23,7 +21,7 @@ export class DepotJournal {
   envoiEvenementAuServeur (ligne) {
     this.$.ajax({
       type: 'POST',
-      url: config.hote_serveur + '/api/evenements',
+      url: `${process.env.HOTE_SERVEUR}/api/evenements`,
       data: JSON.stringify(this.recuperePayload(ligne)),
       contentType: 'application/json; charset=utf-8',
       retryTimeout: 60000,

--- a/src/situations/commun/infra/depot_journal.js
+++ b/src/situations/commun/infra/depot_journal.js
@@ -21,7 +21,7 @@ export class DepotJournal {
   envoiEvenementAuServeur (ligne) {
     this.$.ajax({
       type: 'POST',
-      url: `${process.env.HOTE_SERVEUR}/api/evenements`,
+      url: `${process.env.URL_SERVEUR}/api/evenements`,
       data: JSON.stringify(this.recuperePayload(ligne)),
       contentType: 'application/json; charset=utf-8',
       retryTimeout: 60000,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,7 +115,8 @@ module.exports = {
       chunks: ['restitutionSituationInventaire'],
       inject: 'head'
     }),
-    new webpack.ProvidePlugin({ jQuery: 'jquery' })
+    new webpack.ProvidePlugin({ jQuery: 'jquery' }),
+    new webpack.EnvironmentPlugin(['NODE_ENV', 'HOTE_SERVEUR'])
   ],
   devServer: {
     contentBase: './src/public',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -116,7 +116,7 @@ module.exports = {
       inject: 'head'
     }),
     new webpack.ProvidePlugin({ jQuery: 'jquery' }),
-    new webpack.EnvironmentPlugin(['NODE_ENV', 'HOTE_SERVEUR'])
+    new webpack.EnvironmentPlugin(['NODE_ENV', 'URL_SERVEUR'])
   ],
   devServer: {
     contentBase: './src/public',


### PR DESCRIPTION
Le fichier de configuration pour le client qui stocke l'url du serveur n'est pas super pratique. En fonction de son environnement on doit le modifier en développement, et en production c'est la même galère. 

Je l'ai donc supprimé pour utiliser une variable d'environnement, `URL_SERVEUR` qui peut facilement être injecté comme on veut sans modifier des fichiers. 

La pr coté orchestrateur arrive juste après celle ci !