### PR TITLE
Donne à la vue cadre la responsabilité de créer la vue action

### DIFF
--- a/src/app/situationControle.js
+++ b/src/app/situationControle.js
@@ -4,7 +4,6 @@ import 'controle/styles/app.scss';
 
 import { DepotJournal } from 'commun/infra/depot_journal.js';
 import { Journal } from 'commun/modeles/journal.js';
-import { VueActions } from 'commun/vues/actions.js';
 import { VueCadre } from 'commun/vues/cadre.js';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
 
@@ -22,11 +21,9 @@ function afficheSituation (pointInsertion, $) {
     dureeViePiece: 12000
   });
   const vueSituation = new VueSituation(situation);
-  const vueCadre = new VueCadre(vueSituation);
-  const vueActions = new VueActions(journal);
+  const vueCadre = new VueCadre(vueSituation, journal);
 
   vueCadre.affiche(pointInsertion, $);
-  vueActions.affiche(pointInsertion, $);
 }
 
 initialiseInternationalisation().then(function () {

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -4,7 +4,6 @@ import 'inventaire/styles/app.scss';
 
 import { DepotJournal } from 'commun/infra/depot_journal.js';
 import { Journal } from 'commun/modeles/journal.js';
-import { VueActions } from 'commun/vues/actions.js';
 import { VueCadre } from 'commun/vues/cadre.js';
 import { VueConsigne } from 'commun/vues/consigne.js';
 import { VueGo } from 'commun/vues/go.js';
@@ -17,14 +16,12 @@ function afficheSituation (pointInsertion, $) {
   const session = uuidv4();
   const journal = new Journal(Date.now, session, 'inventaire', new DepotJournal());
   const vueSituationInventaire = new VueSituation(journal);
-  const vueCadre = new VueCadre(vueSituationInventaire);
-  const vueActions = new VueActions(journal);
+  const vueCadre = new VueCadre(vueSituationInventaire, journal);
   const vueConsigne = new VueConsigne(sonConsigneDemarrage);
   const vueGo = new VueGo(vueConsigne, journal);
 
   vueConsigne.affiche(pointInsertion);
   vueCadre.affiche(pointInsertion, $);
-  vueActions.affiche(pointInsertion, $);
   vueGo.affiche(pointInsertion);
 }
 

--- a/src/situations/commun/styles/cadre.scss
+++ b/src/situations/commun/styles/cadre.scss
@@ -1,4 +1,4 @@
-.cadre {
+.scene {
   position: relative;
   width: 100%;
   flex: 1;

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -1,13 +1,16 @@
 import 'commun/styles/cadre.scss';
+import { VueActions } from 'commun/vues/actions.js';
 
 export class VueCadre {
-  constructor (vueSituation) {
+  constructor (vueSituation, journal) {
     this.vueSituation = vueSituation;
+    this.vueActions = new VueActions(journal);
   }
 
   affiche (pointInsertion, $) {
-    const $cadre = $('<div class="cadre"></div>');
-    $(pointInsertion).append($cadre);
-    this.vueSituation.affiche('.cadre', $);
+    const $scene = $('<div class="scene"></div>');
+    $(pointInsertion).append($scene);
+    this.vueSituation.affiche('.scene', $);
+    this.vueActions.affiche(pointInsertion, $);
   }
 }

--- a/src/situations/inventaire/styles/app.scss
+++ b/src/situations/inventaire/styles/app.scss
@@ -2,7 +2,7 @@
 @import 'commun/styles/conteneur.scss';
 @import 'inventaire/styles/etageres.scss';
 
-.cadre.magasin {
+.scene.magasin {
   background-image: url('../assets/fond-situation.png') ;
   background-repeat: repeat-x;
   background-size: contain;

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -14,22 +14,30 @@ describe('Une vue du cadre', function () {
     $ = jQuery(window);
   });
 
-  it("s'affiche", function () {
+  it("Affiche une scene comme point d'insertion de la vue situation", function () {
     const vueSituation = uneVue();
     const vueCadre = new VueCadre(vueSituation);
-    expect($('#une-situation .cadre').length).to.equal(0);
+    expect($('#une-situation .scene').length).to.equal(0);
 
     vueCadre.affiche('#une-situation', $);
-    expect($('#une-situation .cadre').length).to.equal(1);
+    expect($('#une-situation .scene').length).to.equal(1);
   });
 
   it('affiche une situation donnée', function (done) {
     const vueSituation = uneVue(function (pointInsertion, jQuery) {
-      expect(pointInsertion).to.equal('.cadre');
+      expect(pointInsertion).to.equal('.scene');
       expect(jQuery).to.equal($);
       done();
     });
     const vueCadre = new VueCadre(vueSituation);
     vueCadre.affiche('#une-situation', $);
+  });
+
+  it("affiche la barre d'action", function () {
+    const vueSituation = uneVue();
+    const vueCadre = new VueCadre(vueSituation);
+    vueCadre.affiche('#une-situation', $);
+
+    expect($('.actions').length).to.equal(1);
   });
 });


### PR DESCRIPTION
Cette PR participe à l'issue #98 

La vue cadre à la responsabilité de créer l'élément `<scene>` (pour accueillir la
vue situation) et la barre d'action.

Ces deux éléments doivent se partage l'espace verticale de l'écran et c'est la
responsabilité de cette classe VueCadre de porter ce partage de ressource.

Cela diminue aussi la duplication de la création de la barre d'action.