### PR TITLE
consignes textuelles

### DIFF
--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -22,7 +22,7 @@ function afficheSituation (pointInsertion, $) {
 
   vueConsigne.affiche(pointInsertion);
   vueCadre.affiche(pointInsertion, $);
-  vueGo.affiche(pointInsertion);
+  vueGo.affiche(pointInsertion, $);
 }
 
 initialiseInternationalisation().then(function () {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -4,7 +4,9 @@
     "modale": {
       "ok": "OK",
       "annuler": "annuler"
-    }
+    },
+    "ecouter-consigne": "Écoutez la consigne",
+    "go": "C'est à vous"
   },
   "inventaire": {
     "titre": "Stock de boissons",

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -8,7 +8,7 @@ html, body {
 body {
   background: $couleur-fond;
   display: flex;
-  font-family: Helvetica, Arial, sans-serif;
+  font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   min-height: 100%;
   align-items: center;
   flex-direction: column-reverse;

--- a/src/situations/commun/styles/go.scss
+++ b/src/situations/commun/styles/go.scss
@@ -32,3 +32,14 @@
 .bouton-lire-consigne-demarrage {
   @include bouton-carre-before($couleur-fond-bouton-vert, $couleur-fond-bouton-vert-focus);
 }
+
+.consigne-texte {
+  position:absolute;
+  bottom:0;
+  color: $blanc;
+  text-align: center;
+  width: 100%;
+  line-height: 6.5rem;
+  font-size: 2.25rem;
+  font-weight: bold;
+}

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -13,33 +13,33 @@ export class VueGo {
   affiche (pointInsertion, $) {
     this.$consigneTexte = $("<div class='consigne-texte'></div>");
 
-    this.overlay = $('<div id="overlay-go" class="overlay"></div>');
+    this.$overlay = $('<div id="overlay-go" class="overlay"></div>');
 
-    this.boutonGo = $('<div id="go" class="invisible bouton-centre bouton-lire-consigne-demarrage"></div>');
-    this.boutonGo.append(`<img src='${go}'>`);
+    this.$boutonGo = $('<div id="go" class="invisible bouton-centre bouton-lire-consigne-demarrage"></div>');
+    this.$boutonGo.append(`<img src='${go}'>`);
 
-    this.boutonGo.on('click', () => {
-      this.overlay.addClass('invisible');
+    this.$boutonGo.on('click', () => {
+      this.$overlay.addClass('invisible');
       this.journal.enregistreDemarrage();
     });
-    this.overlay.append(this.boutonGo);
+    this.$overlay.append(this.$boutonGo);
 
-    this.boutonDemarrerConsigne = $('<div id="demarrer-consigne" class="bouton-centre bouton-lire-consigne-demarrage"></div>');
-    this.boutonDemarrerConsigne.append(`<img src='${play}'>`);
+    this.$boutonDemarrerConsigne = $('<div id="demarrer-consigne" class="bouton-centre bouton-lire-consigne-demarrage"></div>');
+    this.$boutonDemarrerConsigne.append(`<img src='${play}'>`);
 
-    this.boutonDemarrerConsigne.on('click', () => {
-      this.boutonDemarrerConsigne.addClass('invisible');
+    this.$boutonDemarrerConsigne.on('click', () => {
+      this.$boutonDemarrerConsigne.addClass('invisible');
       this.$consigneTexte.text('');
 
       this.vueConsigne.jouerConsigneDemarrage(() => {
-        this.boutonGo.removeClass('invisible');
+        this.$boutonGo.removeClass('invisible');
         this.$consigneTexte.text(traduction('situation.go'));
       });
     });
 
     this.$consigneTexte.text(traduction('situation.ecouter-consigne'));
-    this.overlay.append(this.boutonDemarrerConsigne);
-    this.overlay.append(this.$consigneTexte);
-    $(pointInsertion).append(this.overlay);
+    this.$overlay.append(this.$boutonDemarrerConsigne);
+    this.$overlay.append(this.$consigneTexte);
+    $(pointInsertion).append(this.$overlay);
   }
 }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -4,41 +4,34 @@ import play from 'commun/assets/play.svg';
 
 export class VueGo {
   constructor (vueConsigne, journal) {
-    this.overlay = document.createElement('div');
-    this.overlay.id = 'overlay-go';
-    this.overlay.classList.add('overlay');
-    this.overlay.addEventListener('click', (event) => {
-      event.stopPropagation();
-    });
-
-    this.boutonGo = document.createElement('div');
-    this.boutonGo.id = 'go';
-    const imageGo = document.createElement('img');
-    imageGo.src = go;
-    this.boutonGo.appendChild(imageGo);
-    this.boutonGo.classList.add('invisible', 'bouton-centre', 'bouton-go');
-    this.boutonGo.addEventListener('click', () => {
-      this.overlay.classList.add('invisible');
-      journal.enregistreDemarrage();
-    });
-    this.overlay.appendChild(this.boutonGo);
-
-    this.boutonDemarrerConsigne = document.createElement('div');
-    this.boutonDemarrerConsigne.id = 'demarrer-consigne';
-    const imagePlay = document.createElement('img');
-    imagePlay.src = play;
-    this.boutonDemarrerConsigne.appendChild(imagePlay);
-    this.boutonDemarrerConsigne.classList.add('bouton-centre', 'bouton-lire-consigne-demarrage');
-    this.boutonDemarrerConsigne.addEventListener('click', () => {
-      this.boutonDemarrerConsigne.classList.add('invisible');
-      vueConsigne.jouerConsigneDemarrage(() => {
-        this.boutonGo.classList.remove('invisible');
-      });
-    });
-    this.overlay.appendChild(this.boutonDemarrerConsigne);
+    this.vueConsigne = vueConsigne;
+    this.journal = journal;
   }
 
-  affiche (pointInsertion) {
-    document.querySelector(pointInsertion).appendChild(this.overlay);
+  affiche (pointInsertion, $) {
+    this.overlay = $('<div id="overlay-go" class="overlay"></div>');
+
+    this.boutonGo = $('<div id="go" class="invisible bouton-centre bouton-lire-consigne-demarrage"></div>');
+    this.boutonGo.append(`<img src='${go}'>`);
+
+
+    this.boutonGo.on('click', () => {
+      this.overlay.addClass('invisible');
+      this.journal.enregistreDemarrage();
+    });
+    this.overlay.append(this.boutonGo);
+
+    this.boutonDemarrerConsigne = $('<div id="demarrer-consigne" class="bouton-centre bouton-lire-consigne-demarrage"></div>');
+    this.boutonDemarrerConsigne.append(`<img src='${play}'>`);
+
+    this.boutonDemarrerConsigne.on('click', () => {
+      this.boutonDemarrerConsigne.addClass('invisible');
+      this.vueConsigne.jouerConsigneDemarrage(() => {
+        this.boutonGo.removeClass('invisible');
+      });
+    });
+
+    this.overlay.append(this.boutonDemarrerConsigne);
+    $(pointInsertion).append(this.overlay);
   }
 }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -2,6 +2,8 @@ import 'commun/styles/go.scss';
 import go from 'commun/assets/go.svg';
 import play from 'commun/assets/play.svg';
 
+import { traduction } from 'commun/infra/internationalisation';
+
 export class VueGo {
   constructor (vueConsigne, journal) {
     this.vueConsigne = vueConsigne;
@@ -9,11 +11,12 @@ export class VueGo {
   }
 
   affiche (pointInsertion, $) {
+    this.$consigneTexte = $("<div class='consigne-texte'></div>");
+
     this.overlay = $('<div id="overlay-go" class="overlay"></div>');
 
     this.boutonGo = $('<div id="go" class="invisible bouton-centre bouton-lire-consigne-demarrage"></div>');
     this.boutonGo.append(`<img src='${go}'>`);
-
 
     this.boutonGo.on('click', () => {
       this.overlay.addClass('invisible');
@@ -26,12 +29,17 @@ export class VueGo {
 
     this.boutonDemarrerConsigne.on('click', () => {
       this.boutonDemarrerConsigne.addClass('invisible');
+      this.$consigneTexte.text('');
+
       this.vueConsigne.jouerConsigneDemarrage(() => {
         this.boutonGo.removeClass('invisible');
+        this.$consigneTexte.text(traduction('situation.go'));
       });
     });
 
+    this.$consigneTexte.text(traduction('situation.ecouter-consigne'));
     this.overlay.append(this.boutonDemarrerConsigne);
+    this.overlay.append(this.$consigneTexte);
     $(pointInsertion).append(this.overlay);
   }
 }

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -8,9 +8,11 @@ describe('vue Go', function () {
     jouerConsigneDemarrage () {}
   };
   let mockJournal;
+  let $;
 
   beforeEach(function () {
     jsdom('<div id="pointInsertion"></div>');
+    $ = jQuery(window);
     mockJournal = {
       enregistreDemarrage () {}
     };
@@ -18,7 +20,7 @@ describe('vue Go', function () {
   });
 
   it('affiche un bouton "lire la consigne" mais pas le bouton "go" au démarrage', function () {
-    vue.affiche('#pointInsertion');
+    vue.affiche('#pointInsertion', $);
 
     const overlay = document.querySelector('#pointInsertion #overlay-go');
     expect(overlay.classList).to.contain('overlay');
@@ -31,7 +33,7 @@ describe('vue Go', function () {
   });
 
   it('démarre la lecture de la consigne quand on appuie sur le bouton', function (done) {
-    vue.affiche('#pointInsertion');
+    vue.affiche('#pointInsertion', $);
 
     const boutonDemarrerConsigne = document.querySelector('#demarrer-consigne');
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
@@ -43,7 +45,7 @@ describe('vue Go', function () {
   });
 
   it('affiche un overlay pendant la lecture de la consigne', function () {
-    vue.affiche('#pointInsertion');
+    vue.affiche('#pointInsertion', $);
 
     const overlay = document.querySelector('#overlay-go');
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
@@ -57,7 +59,7 @@ describe('vue Go', function () {
   });
 
   it('affiche un bouton GO à la fin de la lecture de la consigne', function () {
-    vue.affiche('#pointInsertion');
+    vue.affiche('#pointInsertion', $);
 
     const boutonGo = document.querySelector('#go');
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
@@ -71,7 +73,7 @@ describe('vue Go', function () {
   });
 
   it("masque l'overlay et le bouton une fois le jeu démarré", function () {
-    vue.affiche('#pointInsertion');
+    vue.affiche('#pointInsertion', $);
 
     const boutonGo = document.querySelector('#overlay-go #go');
 
@@ -84,7 +86,7 @@ describe('vue Go', function () {
   it("journalise l'événement lorsque le jeu est démarré", function (done) {
     mockJournal.enregistreDemarrage = done;
 
-    vue.affiche('#pointInsertion');
+    vue.affiche('#pointInsertion', $);
 
     document.querySelector('#go').dispatchEvent(new Event('click'));
   });

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -1,6 +1,7 @@
 /* global Event */
 import jsdom from 'jsdom-global';
 import { VueGo } from 'commun/vues/go.js';
+import { traduction } from 'commun/infra/internationalisation';
 
 describe('vue Go', function () {
   let vue;
@@ -30,6 +31,9 @@ describe('vue Go', function () {
 
     const boutonGo = overlay.querySelector('#go');
     expect(boutonGo.classList).to.contain('invisible');
+
+    const consigne = $('.consigne-texte', overlay);
+    expect(consigne.text()).to.eql(traduction('situation.ecouter-consigne'));
   });
 
   it('démarre la lecture de la consigne quand on appuie sur le bouton', function (done) {
@@ -56,6 +60,9 @@ describe('vue Go', function () {
     boutonDemarrerConsigne.dispatchEvent(new Event('click'));
 
     expect(overlay.classList).to.not.contain('invisible');
+
+    const consigne = $('.consigne-texte', '#overlay-go');
+    expect(consigne.text()).to.eql('');
   });
 
   it('affiche un bouton GO à la fin de la lecture de la consigne', function () {
@@ -70,6 +77,8 @@ describe('vue Go', function () {
     boutonDemarrerConsigne.dispatchEvent(new Event('click'));
 
     expect(boutonGo.classList).to.not.contain('invisible');
+    const consigne = $('.consigne-texte', '#overlay-go');
+    expect(consigne.text()).to.eql(traduction('situation.go'));
   });
 
   it("masque l'overlay et le bouton une fois le jeu démarré", function () {


### PR DESCRIPTION
Avance #78 en intégrant les consignes textuelles. Cette PR simplifie également la vue Go en utilisant jQuery.

![Capture d’écran 2019-03-26 à 14 49 11](https://user-images.githubusercontent.com/28393/55002242-89806700-4fd6-11e9-98da-2b4f1c993d66.png)
![Capture d’écran 2019-03-26 à 14 50 15](https://user-images.githubusercontent.com/28393/55002246-8be2c100-4fd6-11e9-91b2-246cb683392d.png)
