### PR TITLE
Corrige l'utilisation de NODE_ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM node:10 as node
 
 ARG URL_SERVEUR
 ENV URL_SERVEUR ${URL_SERVEUR}
-ENV NODE_ENV production
 
 WORKDIR /app/
 COPY package.json package-lock.json ./
-RUN npm install --production=false
+RUN npm install
 
 COPY . ./
 RUN npm run build

--- a/src/situations/commun/infra/internationalisation.js
+++ b/src/situations/commun/infra/internationalisation.js
@@ -4,7 +4,7 @@ import locales from '../../../locales/fr.json';
 export function initialise () {
   return i18next.init({
     lng: 'fr',
-    debug: process.NODE_ENV !== 'production',
+    debug: process.env.NODE_ENV !== 'development',
     resources: {
       fr: {
         translation: locales

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -116,7 +116,7 @@ module.exports = {
       inject: 'head'
     }),
     new webpack.ProvidePlugin({ jQuery: 'jquery' }),
-    new webpack.EnvironmentPlugin(['NODE_ENV', 'URL_SERVEUR'])
+    new webpack.EnvironmentPlugin(['URL_SERVEUR'])
   ],
   devServer: {
     contentBase: './src/public',


### PR DESCRIPTION
Lorsque j'avais branché l'internationalisation j'avais utilisé `process.NODE_ENV` au lieu de `process.env.NODE_ENV`. En remarquant que en prod on avait le message dans la console de *i18next*, j'ai voulu corriger dans #102. Mais en fait ce n'était pas nécessaire.