### PR TITLE
applique le style bleu au bouton go

### DIFF
--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -15,7 +15,7 @@ export class VueGo {
 
     this.$overlay = $('<div id="overlay-go" class="overlay"></div>');
 
-    this.$boutonGo = $('<div id="go" class="invisible bouton-centre bouton-lire-consigne-demarrage"></div>');
+    this.$boutonGo = $('<div id="go" class="invisible bouton-centre bouton-go"></div>');
     this.$boutonGo.append(`<img src='${go}'>`);
 
     this.$boutonGo.on('click', () => {

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -28,9 +28,11 @@ describe('vue Go', function () {
 
     const boutonDemarrerConsigne = overlay.querySelector('#demarrer-consigne');
     expect(boutonDemarrerConsigne.classList).to.not.contain('invisible');
+    expect(boutonDemarrerConsigne.classList).to.contain('bouton-lire-consigne-demarrage');
 
     const boutonGo = overlay.querySelector('#go');
     expect(boutonGo.classList).to.contain('invisible');
+    expect(boutonGo.classList).to.contain('bouton-go');
 
     const consigne = $('.consigne-texte', overlay);
     expect(consigne.text()).to.eql(traduction('situation.ecouter-consigne'));


### PR DESCRIPTION
Corrige (et teste) un problème de style intervenu dans un précédent refactoring

<img width="1035" alt="Capture d’écran 2019-03-27 à 14 22 28" src="https://user-images.githubusercontent.com/28393/55079083-c95d5200-509b-11e9-8db8-03da5f4c9f06.png">
