### PR TITLE
Met les nouveaux messages de la vue Go. Change la place des messages

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -5,8 +5,8 @@
       "ok": "OK",
       "annuler": "annuler"
     },
-    "ecouter-consigne": "Écoutez la consigne",
-    "go": "C'est à vous"
+    "ecouter-consigne": "Commencez par écouter la consigne",
+    "go": "Vous pouvez commencer"
   },
   "inventaire": {
     "titre": "Stock de boissons",

--- a/src/situations/commun/styles/go.scss
+++ b/src/situations/commun/styles/go.scss
@@ -33,9 +33,9 @@
   @include bouton-carre-before($couleur-fond-bouton-vert, $couleur-fond-bouton-vert-focus);
 }
 
-.consigne-texte {
+.message {
   position:absolute;
-  bottom:0;
+  top: 7rem;
   color: $blanc;
   text-align: center;
   width: 100%;

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -11,7 +11,7 @@ export class VueGo {
   }
 
   affiche (pointInsertion, $) {
-    this.$consigneTexte = $("<div class='consigne-texte'></div>");
+    this.$message = $("<div class='message'></div>");
 
     this.$overlay = $('<div id="overlay-go" class="overlay"></div>');
 
@@ -29,17 +29,17 @@ export class VueGo {
 
     this.$boutonDemarrerConsigne.on('click', () => {
       this.$boutonDemarrerConsigne.addClass('invisible');
-      this.$consigneTexte.text('');
+      this.$message.text('');
 
       this.vueConsigne.jouerConsigneDemarrage(() => {
         this.$boutonGo.removeClass('invisible');
-        this.$consigneTexte.text(traduction('situation.go'));
+        this.$message.text(traduction('situation.go'));
       });
     });
 
-    this.$consigneTexte.text(traduction('situation.ecouter-consigne'));
+    this.$message.text(traduction('situation.ecouter-consigne'));
     this.$overlay.append(this.$boutonDemarrerConsigne);
-    this.$overlay.append(this.$consigneTexte);
+    this.$overlay.append(this.$message);
     $(pointInsertion).append(this.$overlay);
   }
 }

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -34,8 +34,8 @@ describe('vue Go', function () {
     expect(boutonGo.classList).to.contain('invisible');
     expect(boutonGo.classList).to.contain('bouton-go');
 
-    const consigne = $('.consigne-texte', overlay);
-    expect(consigne.text()).to.eql(traduction('situation.ecouter-consigne'));
+    const $message = $('.message', overlay);
+    expect($message.text()).to.eql(traduction('situation.ecouter-consigne'));
   });
 
   it('démarre la lecture de la consigne quand on appuie sur le bouton', function (done) {
@@ -63,8 +63,8 @@ describe('vue Go', function () {
 
     expect(overlay.classList).to.not.contain('invisible');
 
-    const consigne = $('.consigne-texte', '#overlay-go');
-    expect(consigne.text()).to.eql('');
+    const $message = $('.message', '#overlay-go');
+    expect($message.text()).to.eql('');
   });
 
   it('affiche un bouton GO à la fin de la lecture de la consigne', function () {
@@ -79,8 +79,8 @@ describe('vue Go', function () {
     boutonDemarrerConsigne.dispatchEvent(new Event('click'));
 
     expect(boutonGo.classList).to.not.contain('invisible');
-    const consigne = $('.consigne-texte', '#overlay-go');
-    expect(consigne.text()).to.eql(traduction('situation.go'));
+    const $message = $('.message', '#overlay-go');
+    expect($message.text()).to.eql(traduction('situation.go'));
   });
 
   it("masque l'overlay et le bouton une fois le jeu démarré", function () {


### PR DESCRIPTION
Cette PR contribue à l'issure #78

Elle prend en compte les messages tel que sur les images dans le répertoire de Thibault sur le drive.

J'ai renommé le nom de la variable et le style de `consigne-texte` vers `message` puis qu'il ne s'agit pas uniquement du message pour le bouton "lecture consigne"