### PR TITLE
corrige la hauteur de la scène sur les petits écrans

### DIFF
--- a/src/situations/commun/styles/cadre.scss
+++ b/src/situations/commun/styles/cadre.scss
@@ -1,7 +1,7 @@
 .scene {
   position: relative;
   width: 100%;
-  flex: 1;
+  height: 35.375rem;
   background: ivory;
   overflow: hidden;
 }

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -11,7 +11,7 @@ body {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   min-height: 100%;
   align-items: center;
-  flex-direction: column-reverse;
+  flex-direction: column;
 }
 
 * {

--- a/src/situations/commun/styles/conteneur.scss
+++ b/src/situations/commun/styles/conteneur.scss
@@ -2,7 +2,5 @@
   width: 63rem;
   height: 41.875rem;
   margin: auto;
-  display: flex;
-  flex-direction: column;
   position: relative;
 }


### PR DESCRIPTION
la conséquence est de remettre le lien vers le code en haut de page

<img width="1552" alt="Capture d’écran 2019-03-27 à 15 10 51" src="https://user-images.githubusercontent.com/28393/55082770-936f9c00-50a2-11e9-9cd0-3cbea005a7b8.png">
