### PR TITLE
Retourne une promesse dans le journal

### DIFF
--- a/src/situations/commun/infra/depot_journal.js
+++ b/src/situations/commun/infra/depot_journal.js
@@ -11,7 +11,7 @@ export class DepotJournal {
   enregistre (ligne) {
     this.lignes.push(ligne);
     window.localStorage.setItem('journal', JSON.stringify(this.lignes));
-    this.envoiEvenementAuServeur(ligne);
+    return this.envoiEvenementAuServeur(ligne);
   }
 
   evenements () {
@@ -19,7 +19,7 @@ export class DepotJournal {
   }
 
   envoiEvenementAuServeur (ligne) {
-    this.$.ajax({
+    return this.$.ajax({
       type: 'POST',
       url: `${process.env.URL_SERVEUR}/api/evenements`,
       data: JSON.stringify(this.recuperePayload(ligne)),

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -7,7 +7,7 @@ export class Journal {
   }
 
   enregistre (evenement) {
-    this.depot.enregistre(
+    return this.depot.enregistre(
       {
         date: this.maintenant(),
         sessionId: this.sessionId,

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -9,18 +9,31 @@ export class VueStop {
   constructor (pointInsertion, $, journal, retourAccueil = () => {
     window.location.assign('/');
   }) {
+    this.journal = journal;
+    this.retourAccueil = retourAccueil;
     this.$pointInsertion = $(pointInsertion);
     this.$boutonStop = $('<a id="stop" class="bouton-stop"></a>');
     this.$boutonStop.append(`<img src='${stop}'>`);
 
     this.$boutonStop.on('click', () => {
-      afficheFenetreModale(this.$pointInsertion, $,
+      afficheFenetreModale(
+        this.$pointInsertion,
+        $,
         traduction('situation.stop'),
-        () => { journal.enregistre(new EvenementStop()); retourAccueil(); });
+        this.clickSurOk.bind(this)
+      );
     });
   }
 
   afficher () {
     this.$pointInsertion.append(this.$boutonStop);
+  }
+
+  clickSurOk () {
+    return this.journal
+      .enregistre(new EvenementStop())
+      .then(() => {
+        this.retourAccueil();
+      });
   }
 }

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -38,21 +38,14 @@ describe('vue Stop', function () {
     expect($('label').text()).to.equal('situation.stop');
   });
 
-  it("Redirige vers l'accueil quand on confirme la modale", function () {
-    vue.afficher();
-    $('#magasin #stop').click();
-    $('#OK-modale').click();
-
-    expect(retourAccueil).to.equal(true);
-  });
-
-  it("Enregistre l'événément quand on confirme la modale", function (done) {
+  it("Enregistre l'événément et redirige vers l'accueil quand on confirme la modale", function (done) {
     mockJournal.enregistre = (evenement) => {
       expect(evenement).to.be.a(EvenementStop);
-      done();
+      return Promise.resolve();
     };
-    vue.afficher();
-    $('#magasin #stop').click();
-    $('#OK-modale').click();
+    vue.clickSurOk().then(() => {
+      expect(retourAccueil).to.equal(true);
+      done();
+    });
   });
 });


### PR DESCRIPTION
L'événement stop n'est pas correctement envoyé coté serveur actuellement, car on revient à l'accueil  immédiatement. 
Du coup, j'ai retourné une promesse dans le retour du dépot journal, qui est renvoyé lors de l'enregistrement dans le journal, qui est utilisé pour finalement revenir a l'accueil.

J'ai pu vérifier ainsi que l'événement stop est bien correctement sauvegardé.