### PR TITLE
78 bouton consigne en cours

### DIFF
--- a/src/situations/commun/assets/lecture-en-cours.svg
+++ b/src/situations/commun/assets/lecture-en-cours.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="64px" height="64px" viewBox="0 0 64 64" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>Icn/LectureEnCours</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Icn/LectureEnCours" fill="#FFFFFF">
+            <path d="M20,36 C17.790861,36 16,34.209139 16,32 C16,29.790861 17.790861,28 20,28 C22.209139,28 24,29.790861 24,32 C24,34.209139 22.209139,36 20,36 Z M32,36 C29.790861,36 28,34.209139 28,32 C28,29.790861 29.790861,28 32,28 C34.209139,28 36,29.790861 36,32 C36,34.209139 34.209139,36 32,36 Z M44,36 C41.790861,36 40,34.209139 40,32 C40,29.790861 41.790861,28 44,28 C46.209139,28 48,29.790861 48,32 C48,34.209139 46.209139,36 44,36 Z" id="dots"></path>
+        </g>
+    </g>
+</svg>

--- a/src/situations/commun/styles/bouton.scss
+++ b/src/situations/commun/styles/bouton.scss
@@ -1,11 +1,11 @@
 @import 'commun/styles/couleurs.scss';
 
-@mixin bouton-carre($couleur-fond, $couleur-fond-focus) {
+@mixin bouton-carre($couleur-fond, $couleur-fond-focus, $couleur-bordure: $blanc) {
   cursor: pointer;
   height: 4rem;
   width: 4rem;
   border-radius: 1rem;
-  border: solid 3px $blanc;
+  border: solid 3px $couleur-bordure;
   background-color: $couleur-fond;
   box-shadow: inset 0px 0px 0px 3px $couleur-fond-focus;
   display: flex;
@@ -13,7 +13,6 @@
 
   &:hover {
     background-color: $couleur-fond-focus;
-    border-color: $couleur-fond-focus;
   }
 
   &:active {
@@ -28,14 +27,13 @@
   }
 }
 
-@mixin bouton-carre-before($couleur-fond, $couleur-fond-focus) {
+@mixin bouton-carre-before($couleur-fond, $couleur-fond-focus, $couleur-bordure: $blanc) {
   &:before {
-    @include bouton-carre($couleur-fond, $couleur-fond-focus);
+    @include bouton-carre($couleur-fond, $couleur-fond-focus, $couleur-bordure);
   }
 
   &:hover:before {
     background-color: $couleur-fond-focus;
-    border-color: $couleur-fond-focus;
   }
 
   &:active:before {

--- a/src/situations/commun/styles/go.scss
+++ b/src/situations/commun/styles/go.scss
@@ -33,6 +33,15 @@
   @include bouton-carre-before($couleur-fond-bouton-vert, $couleur-fond-bouton-vert-focus);
 }
 
+.bouton-lecture-en-cours {
+  @include bouton-carre-before($couleur-fond-bouton-vert, $couleur-fond-bouton-vert, $couleur-fond-bouton-vert);
+  cursor: default;
+
+  img {
+    height: 4rem;
+  }
+}
+
 .message {
   position:absolute;
   top: 7rem;

--- a/src/situations/commun/styles/overlay.scss
+++ b/src/situations/commun/styles/overlay.scss
@@ -5,4 +5,5 @@
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
+  outline: none;
 }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -13,34 +13,37 @@ export class VueGo {
   }
 
   affiche (pointInsertion, $) {
+    this.$ = $;
     this.$message = $("<div class='message'></div>");
-
     this.$overlay = $('<div id="overlay-go" class="overlay"></div>');
 
-    this.$boutonGo = $('<div id="go" class="invisible bouton-centre bouton-go"></div>');
-    this.$boutonGo.append(`<img src='${go}'>`);
-
-    this.$boutonGo.on('click', () => {
-      this.$overlay.addClass('invisible');
-      this.journal.enregistre(new EvenementDemarrage());
+    this.$boutonGo = this.$bouton({
+      id: 'go', classe: 'bouton-go', image: go, visibilite: 'invisible',
+      click: () => {
+        this.$overlay.addClass('invisible');
+        this.journal.enregistre(new EvenementDemarrage());
+      }
     });
 
-    this.$boutonDemarrerConsigne = $('<div id="demarrer-consigne" class="bouton-centre bouton-lire-consigne-demarrage"></div>');
-    this.$boutonDemarrerConsigne.append(`<img src='${play}'>`);
-
-    this.$boutonDemarrerConsigne.on('click', () => {
-      this.$boutonDemarrerConsigne.addClass('invisible');
-      this.$boutonLectureEnCours.removeClass('invisible');
-      this.$message.text('');
-
-      this.vueConsigne.jouerConsigneDemarrage(() => {
-        this.$boutonGo.removeClass('invisible');
-        this.$message.text(traduction('situation.go'));
-      });
+    this.$boutonLectureEnCours = this.$bouton({
+      id: 'lecture-en-cours', classe: 'bouton-lecture-en-cours',
+      image: lectureEnCours, visibilite: 'invisible'
     });
 
-    this.$boutonLectureEnCours = $('<div id="lecture-en-cours" class="invisible bouton-centre bouton-lecture-en-cours"></div>');
-    this.$boutonLectureEnCours.append(`<img src='${lectureEnCours}'>`);
+    this.$boutonDemarrerConsigne = this.$bouton({
+      id: 'demarrer-consigne', classe: 'bouton-lire-consigne-demarrage',
+      image: play, visibilite: 'visible',
+      click: () => {
+        this.$boutonDemarrerConsigne.addClass('invisible');
+        this.$boutonLectureEnCours.removeClass('invisible');
+        this.$message.text('');
+
+        this.vueConsigne.jouerConsigneDemarrage(() => {
+          this.$boutonGo.removeClass('invisible');
+          this.$message.text(traduction('situation.go'));
+        });
+      }
+    });
 
     this.$message.text(traduction('situation.ecouter-consigne'));
     this.$overlay.append(this.$boutonDemarrerConsigne);
@@ -48,5 +51,13 @@ export class VueGo {
     this.$overlay.append(this.$boutonGo);
     this.$overlay.append(this.$message);
     $(pointInsertion).append(this.$overlay);
+  }
+
+  $bouton (parametres) {
+    const $ = this.$;
+    const $bouton = $(`<div id="${parametres.id}" class="${parametres.visibilite} bouton-centre ${parametres.classe}"></div>`);
+    $bouton.append(`<img src='${parametres.image}'>`);
+    $bouton.on('click', parametres.click);
+    return $bouton;
   }
 }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -1,6 +1,7 @@
 import 'commun/styles/go.scss';
 import go from 'commun/assets/go.svg';
 import play from 'commun/assets/play.svg';
+import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 
 import { traduction } from 'commun/infra/internationalisation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
@@ -23,13 +24,13 @@ export class VueGo {
       this.$overlay.addClass('invisible');
       this.journal.enregistre(new EvenementDemarrage());
     });
-    this.$overlay.append(this.$boutonGo);
 
     this.$boutonDemarrerConsigne = $('<div id="demarrer-consigne" class="bouton-centre bouton-lire-consigne-demarrage"></div>');
     this.$boutonDemarrerConsigne.append(`<img src='${play}'>`);
 
     this.$boutonDemarrerConsigne.on('click', () => {
       this.$boutonDemarrerConsigne.addClass('invisible');
+      this.$boutonLectureEnCours.removeClass('invisible');
       this.$message.text('');
 
       this.vueConsigne.jouerConsigneDemarrage(() => {
@@ -38,8 +39,13 @@ export class VueGo {
       });
     });
 
+    this.$boutonLectureEnCours = $('<div id="lecture-en-cours" class="invisible bouton-centre bouton-lecture-en-cours"></div>');
+    this.$boutonLectureEnCours.append(`<img src='${lectureEnCours}'>`);
+
     this.$message.text(traduction('situation.ecouter-consigne'));
     this.$overlay.append(this.$boutonDemarrerConsigne);
+    this.$overlay.append(this.$boutonLectureEnCours);
+    this.$overlay.append(this.$boutonGo);
     this.$overlay.append(this.$message);
     $(pointInsertion).append(this.$overlay);
   }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -54,6 +54,7 @@ export class VueGo {
     this.$overlay.append(this.$message);
 
     $(pointInsertion).append(this.$overlay);
+    this.afficheEtatGoSiAppuiToucheS();
   }
 
   afficheEtat (parametres) {
@@ -62,5 +63,15 @@ export class VueGo {
     this.$bouton.off('click');
     this.$bouton.on('click', parametres.click);
     this.$message.text(parametres.texte);
+  }
+
+  afficheEtatGoSiAppuiToucheS () {
+    this.$overlay.attr('tabindex', 0);
+    this.$overlay.keydown((event) => {
+      if (event.which === 'S'.charCodeAt()) {
+        this.afficheEtat(this.etats.go);
+      }
+    });
+    this.$overlay.focus();
   }
 }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -10,54 +10,57 @@ export class VueGo {
   constructor (vueConsigne, journal) {
     this.vueConsigne = vueConsigne;
     this.journal = journal;
+
+    this.etats = {
+      aDemarrer: {
+        image: play,
+        texte: traduction('situation.ecouter-consigne'),
+        classe: 'bouton-lire-consigne-demarrage',
+        click: () => {
+          this.afficheEtat(this.etats.lectureEnCours);
+
+          this.vueConsigne.jouerConsigneDemarrage(() => {
+            this.afficheEtat(this.etats.go);
+          });
+        }
+      },
+
+      lectureEnCours: {
+        image: lectureEnCours,
+        texte: '',
+        classe: 'bouton-lecture-en-cours'
+      },
+
+      go: {
+        image: go,
+        texte: traduction('situation.go'),
+        classe: 'bouton-go',
+        click: () => {
+          this.$overlay.addClass('invisible');
+          this.journal.enregistre(new EvenementDemarrage());
+        }
+      }
+    };
   }
 
   affiche (pointInsertion, $) {
-    this.$ = $;
     this.$message = $("<div class='message'></div>");
+    this.$bouton = $(`<div class="bouton-centre"></div>`);
     this.$overlay = $('<div id="overlay-go" class="overlay"></div>');
 
-    this.$boutonGo = this.$bouton({
-      id: 'go', classe: 'bouton-go', image: go, visibilite: 'invisible',
-      click: () => {
-        this.$overlay.addClass('invisible');
-        this.journal.enregistre(new EvenementDemarrage());
-      }
-    });
+    this.afficheEtat(this.etats.aDemarrer);
 
-    this.$boutonLectureEnCours = this.$bouton({
-      id: 'lecture-en-cours', classe: 'bouton-lecture-en-cours',
-      image: lectureEnCours, visibilite: 'invisible'
-    });
-
-    this.$boutonDemarrerConsigne = this.$bouton({
-      id: 'demarrer-consigne', classe: 'bouton-lire-consigne-demarrage',
-      image: play, visibilite: 'visible',
-      click: () => {
-        this.$boutonDemarrerConsigne.addClass('invisible');
-        this.$boutonLectureEnCours.removeClass('invisible');
-        this.$message.text('');
-
-        this.vueConsigne.jouerConsigneDemarrage(() => {
-          this.$boutonGo.removeClass('invisible');
-          this.$message.text(traduction('situation.go'));
-        });
-      }
-    });
-
-    this.$message.text(traduction('situation.ecouter-consigne'));
-    this.$overlay.append(this.$boutonDemarrerConsigne);
-    this.$overlay.append(this.$boutonLectureEnCours);
-    this.$overlay.append(this.$boutonGo);
+    this.$overlay.append(this.$bouton);
     this.$overlay.append(this.$message);
+
     $(pointInsertion).append(this.$overlay);
   }
 
-  $bouton (parametres) {
-    const $ = this.$;
-    const $bouton = $(`<div id="${parametres.id}" class="${parametres.visibilite} bouton-centre ${parametres.classe}"></div>`);
-    $bouton.append(`<img src='${parametres.image}'>`);
-    $bouton.on('click', parametres.click);
-    return $bouton;
+  afficheEtat (parametres) {
+    this.$bouton.attr('class', `bouton-centre ${parametres.classe}`);
+    this.$bouton.html(`<img src='${parametres.image}'>`);
+    this.$bouton.off('click');
+    this.$bouton.on('click', parametres.click);
+    this.$message.text(parametres.texte);
   }
 }

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -84,4 +84,16 @@ describe('vue Go', function () {
 
     $('.bouton-centre', '#overlay-go').click();
   });
+
+  it('permet de passer directement au bouton go', function () {
+    vue.affiche('#pointInsertion', $);
+    const $overlay = $('#overlay-go');
+
+    const appuiSurS = $.Event('keydown');
+    appuiSurS.which = 'S'.charCodeAt();
+    $overlay.trigger(appuiSurS);
+
+    const $bouton = $('.bouton-centre', '#overlay-go');
+    expect($bouton.attr('class')).to.contain('bouton-go');
+  });
 });

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -31,6 +31,10 @@ describe('vue Go', function () {
     expect(boutonDemarrerConsigne.classList).to.not.contain('invisible');
     expect(boutonDemarrerConsigne.classList).to.contain('bouton-lire-consigne-demarrage');
 
+    const boutonLectureEnCours = overlay.querySelector('#lecture-en-cours');
+    expect(boutonLectureEnCours.classList).to.contain('invisible');
+    expect(boutonLectureEnCours.classList).to.contain('bouton-lecture-en-cours');
+
     const boutonGo = overlay.querySelector('#go');
     expect(boutonGo.classList).to.contain('invisible');
     expect(boutonGo.classList).to.contain('bouton-go');
@@ -63,6 +67,9 @@ describe('vue Go', function () {
     boutonDemarrerConsigne.dispatchEvent(new Event('click'));
 
     expect(overlay.classList).to.not.contain('invisible');
+
+    const boutonLectureEnCours = overlay.querySelector('#lecture-en-cours');
+    expect(boutonLectureEnCours.classList).to.not.contain('invisible');
 
     const $message = $('.message', '#overlay-go');
     expect($message.text()).to.eql('');

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -1,4 +1,3 @@
-/* global Event */
 import jsdom from 'jsdom-global';
 import { VueGo } from 'commun/vues/go.js';
 import { traduction } from 'commun/infra/internationalisation';
@@ -21,82 +20,54 @@ describe('vue Go', function () {
     vue = new VueGo(mockVueConsigne, mockJournal);
   });
 
-  it('affiche un bouton "lire la consigne" mais pas le bouton "go" au démarrage', function () {
+  it('affiche un bouton "lire la consigne" et le texte associé', function () {
     vue.affiche('#pointInsertion', $);
 
     const overlay = document.querySelector('#pointInsertion #overlay-go');
     expect(overlay.classList).to.contain('overlay');
 
-    const boutonDemarrerConsigne = overlay.querySelector('#demarrer-consigne');
-    expect(boutonDemarrerConsigne.classList).to.not.contain('invisible');
-    expect(boutonDemarrerConsigne.classList).to.contain('bouton-lire-consigne-demarrage');
-
-    const boutonLectureEnCours = overlay.querySelector('#lecture-en-cours');
-    expect(boutonLectureEnCours.classList).to.contain('invisible');
-    expect(boutonLectureEnCours.classList).to.contain('bouton-lecture-en-cours');
-
-    const boutonGo = overlay.querySelector('#go');
-    expect(boutonGo.classList).to.contain('invisible');
-    expect(boutonGo.classList).to.contain('bouton-go');
-
+    const $bouton = $('.bouton-centre', overlay);
     const $message = $('.message', overlay);
+
+    expect($bouton.attr('class')).to.contain('bouton-lire-consigne-demarrage');
     expect($message.text()).to.eql(traduction('situation.ecouter-consigne'));
   });
 
   it('démarre la lecture de la consigne quand on appuie sur le bouton', function (done) {
     vue.affiche('#pointInsertion', $);
 
-    const boutonDemarrerConsigne = document.querySelector('#demarrer-consigne');
+    const $message = $('.message', '#overlay-go');
+    const $bouton = $('.bouton-centre', '#overlay-go');
+
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
-      expect(boutonDemarrerConsigne.classList).to.contain('invisible');
+      expect($bouton.attr('class')).to.contain('bouton-lecture-en-cours');
+      expect($message.text()).to.eql('');
       done();
     };
 
-    boutonDemarrerConsigne.dispatchEvent(new Event('click'));
-  });
-
-  it('affiche un overlay pendant la lecture de la consigne', function () {
-    vue.affiche('#pointInsertion', $);
-
-    const overlay = document.querySelector('#overlay-go');
-    mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
-      expect(overlay.classList).to.not.contain('invisible');
-    };
-
-    const boutonDemarrerConsigne = document.querySelector('#demarrer-consigne');
-    boutonDemarrerConsigne.dispatchEvent(new Event('click'));
-
-    expect(overlay.classList).to.not.contain('invisible');
-
-    const boutonLectureEnCours = overlay.querySelector('#lecture-en-cours');
-    expect(boutonLectureEnCours.classList).to.not.contain('invisible');
-
-    const $message = $('.message', '#overlay-go');
-    expect($message.text()).to.eql('');
+    $bouton.click();
   });
 
   it('affiche un bouton GO à la fin de la lecture de la consigne', function () {
     vue.affiche('#pointInsertion', $);
 
-    const boutonGo = document.querySelector('#go');
+    const $bouton = $('.bouton-centre', '#overlay-go');
+
     mockVueConsigne.jouerConsigneDemarrage = (actionFinConsigne) => {
-      expect(boutonGo.classList).to.contain('invisible');
       actionFinConsigne();
     };
-    const boutonDemarrerConsigne = document.querySelector('#demarrer-consigne');
-    boutonDemarrerConsigne.dispatchEvent(new Event('click'));
 
-    expect(boutonGo.classList).to.not.contain('invisible');
+    $bouton.click();
+
     const $message = $('.message', '#overlay-go');
     expect($message.text()).to.eql(traduction('situation.go'));
   });
 
   it("masque l'overlay et le bouton une fois le jeu démarré", function () {
     vue.affiche('#pointInsertion', $);
+    vue.afficheEtat(vue.etats.go);
 
-    const boutonGo = document.querySelector('#overlay-go #go');
-
-    boutonGo.dispatchEvent(new Event('click'));
+    $('.bouton-centre', '#overlay-go').click();
 
     const overlay = document.querySelector('#overlay-go');
     expect(overlay.classList).to.contain('invisible');
@@ -109,7 +80,8 @@ describe('vue Go', function () {
     };
 
     vue.affiche('#pointInsertion', $);
+    vue.afficheEtat(vue.etats.go);
 
-    document.querySelector('#go').dispatchEvent(new Event('click'));
+    $('.bouton-centre', '#overlay-go').click();
   });
 });


### PR DESCRIPTION
Fix #78 

Affiche le bouton de consigne en cours et introduit une machine à états pour supprimer la duplication dans `VueGo` et simplifier le HTML

Cette PR permet également de passer la lecture de la consigne en appuyant sur la touche S

![Capture d’écran 2019-03-28 à 11 55 00](https://user-images.githubusercontent.com/28393/55152333-742f4800-5150-11e9-9d0e-4a82e429e6a8.png)

