### PR TITLE
Utilise la classe plutot que la methode nom d'un événement dans le modèle situation.

### DIFF
--- a/src/situations/commun/modeles/situation.js
+++ b/src/situations/commun/modeles/situation.js
@@ -4,18 +4,18 @@ export default class Situation {
     this.evenements = new Map();
   }
 
-  observateurs (nomEvenement) {
-    if (!this.evenements.has(nomEvenement)) {
-      this.evenements.set(nomEvenement, []);
+  observateurs (classe) {
+    if (!this.evenements.has(classe)) {
+      this.evenements.set(classe, []);
     }
-    return this.evenements.get(nomEvenement);
+    return this.evenements.get(classe);
   }
 
-  observe (evenement, action) {
-    this.observateurs(evenement.nom()).push(action);
+  observe (classe, action) {
+    this.observateurs(classe).push(action);
   }
 
   notifie (evenement) {
-    this.observateurs(evenement.nom()).forEach(action => action(evenement));
+    this.observateurs(evenement.constructor).forEach(action => action(evenement));
   }
 }

--- a/src/situations/inventaire/vues/situation.js
+++ b/src/situations/inventaire/vues/situation.js
@@ -9,7 +9,7 @@ export class VueSituation {
     this.journal = journal;
     this.situation = situation;
 
-    situation.observe(new EvenementDemarrage(), (evenement) => {
+    situation.observe(EvenementDemarrage, (evenement) => {
       this.journal.enregistre(evenement);
     });
   }

--- a/tests/situations/commun/modeles/situation.js
+++ b/tests/situations/commun/modeles/situation.js
@@ -5,7 +5,7 @@ describe('toutes les situations', function () {
   it("peuvent être notifié d'un evement", function (done) {
     const uneSituation = new Situation();
     const unEvenement = new Evenement();
-    uneSituation.observe(new Evenement(), (evenement) => {
+    uneSituation.observe(Evenement, (evenement) => {
       expect(evenement).to.equal(unEvenement);
       done();
     });
@@ -16,10 +16,10 @@ describe('toutes les situations', function () {
   it("peuvent enregistrer plusieurs observateurs d'un evenement", function () {
     const uneSituation = new Situation();
     let notifications = 0;
-    uneSituation.observe(new Evenement(), () => {
+    uneSituation.observe(Evenement, () => {
       notifications++;
     });
-    uneSituation.observe(new Evenement(), () => {
+    uneSituation.observe(Evenement, () => {
       notifications++;
     });
 

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -75,7 +75,7 @@ describe('vue Go', function () {
   it('notifie la situation du démarrage', function (done) {
     vue.affiche('#pointInsertion', $);
     vue.afficheEtat(vue.etats.go);
-    situation.observe(new EvenementDemarrage(), () => {
+    situation.observe(EvenementDemarrage, () => {
       done();
     });
 


### PR DESCRIPTION
Cela change la manière de s'enregistrer au modèle situation pour ne pas
à avoir a instancier un événement inutile.