### PR TITLE
Enlève les .js des imports.

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,7 +1,7 @@
 import 'accueil/styles/app.scss';
 
-import { situations } from 'src/situations.js';
-import { VueAccueil } from 'accueil/vues/accueil.js';
+import { situations } from 'src/situations';
+import { VueAccueil } from 'accueil/vues/accueil';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
 
 function afficheAccueil (situations, pointInsertion, $) {

--- a/src/app/restitutionSituationInventaire.js
+++ b/src/app/restitutionSituationInventaire.js
@@ -1,8 +1,8 @@
 import uuidv4 from 'uuid/v4';
 
-import { DepotJournal } from 'commun/infra/depot_journal.js';
-import { Journal } from 'commun/modeles/journal.js';
-import { VueJournal } from 'inventaire/vues/journal.js';
+import { DepotJournal } from 'commun/infra/depot_journal';
+import { Journal } from 'commun/modeles/journal';
+import { VueJournal } from 'inventaire/vues/journal';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
 
 initialiseInternationalisation().then(function () {

--- a/src/app/situationControle.js
+++ b/src/app/situationControle.js
@@ -2,13 +2,13 @@ import uuidv4 from 'uuid/v4';
 
 import 'controle/styles/app.scss';
 
-import { DepotJournal } from 'commun/infra/depot_journal.js';
-import { Journal } from 'commun/modeles/journal.js';
-import { VueCadre } from 'commun/vues/cadre.js';
+import { DepotJournal } from 'commun/infra/depot_journal';
+import { Journal } from 'commun/modeles/journal';
+import { VueCadre } from 'commun/vues/cadre';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
 
-import { Situation } from 'controle/modeles/situation.js';
-import { VueSituation } from 'controle/vues/situation.js';
+import { Situation } from 'controle/modeles/situation';
+import { VueSituation } from 'controle/vues/situation';
 
 function afficheSituation (pointInsertion, $) {
   const session = uuidv4();

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -2,15 +2,15 @@ import uuidv4 from 'uuid/v4';
 
 import 'inventaire/styles/app.scss';
 
-import { contenants, contenus } from 'inventaire/data/stock.js';
-import { Situation } from 'inventaire/modeles/situation.js';
+import { contenants, contenus } from 'inventaire/data/stock';
+import { Situation } from 'inventaire/modeles/situation';
 
-import { DepotJournal } from 'commun/infra/depot_journal.js';
-import { Journal } from 'commun/modeles/journal.js';
-import { VueCadre } from 'commun/vues/cadre.js';
-import { VueConsigne } from 'commun/vues/consigne.js';
-import { VueGo } from 'commun/vues/go.js';
-import { VueSituation } from 'inventaire/vues/situation.js';
+import { DepotJournal } from 'commun/infra/depot_journal';
+import { Journal } from 'commun/modeles/journal';
+import { VueCadre } from 'commun/vues/cadre';
+import { VueConsigne } from 'commun/vues/consigne';
+import { VueGo } from 'commun/vues/go';
+import { VueSituation } from 'inventaire/vues/situation';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
 
 import sonConsigneDemarrage from 'inventaire/assets/consigne_demarrage.mp3';

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -1,7 +1,7 @@
 import 'commun/styles/actions.scss';
 import 'commun/styles/stop.scss';
 
-import { VueStop } from 'commun/vues/stop.js';
+import { VueStop } from 'commun/vues/stop';
 
 export class VueActions {
   constructor (journal) {

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -1,5 +1,5 @@
 import 'commun/styles/cadre.scss';
-import { VueActions } from 'commun/vues/actions.js';
+import { VueActions } from 'commun/vues/actions';
 
 export class VueCadre {
   constructor (vueSituation, journal) {

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -3,7 +3,7 @@ import EvenementStop from 'commun/modeles/evenement_stop';
 import stop from 'commun/assets/stop.svg';
 
 import 'commun/styles/stop.scss';
-import { afficheFenetreModale } from 'commun/vues/modale.js';
+import { afficheFenetreModale } from 'commun/vues/modale';
 
 export class VueStop {
   constructor (pointInsertion, $, journal, retourAccueil = () => {

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -1,5 +1,5 @@
-import { Piece } from 'controle/modeles/piece.js';
-import SituationCommune from 'commun/modeles/situation.js';
+import { Piece } from 'controle/modeles/piece';
+import SituationCommune from 'commun/modeles/situation';
 
 export class Situation extends SituationCommune {
   constructor ({ cadence, scenario, dureeViePiece, positionApparitionPieces }) {

--- a/src/situations/controle/vues/bac.js
+++ b/src/situations/controle/vues/bac.js
@@ -1,6 +1,6 @@
 import 'controle/styles/bac.scss';
 
-import { PIECE_CONFORME } from 'controle/modeles/piece.js';
+import { PIECE_CONFORME } from 'controle/modeles/piece';
 
 export class VueBac {
   constructor (bac) {

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,7 +1,7 @@
-import { Bac } from 'controle/modeles/bac.js';
-import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece.js';
-import { VueBac } from 'controle/vues/bac.js';
-import { VuePiece } from 'controle/vues/piece.js';
+import { Bac } from 'controle/modeles/bac';
+import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
+import { VueBac } from 'controle/vues/bac';
+import { VuePiece } from 'controle/vues/piece';
 
 export class VueSituation {
   constructor (situation, callbackApresCreationPiece) {

--- a/src/situations/inventaire/modeles/contenant.js
+++ b/src/situations/inventaire/modeles/contenant.js
@@ -1,4 +1,4 @@
-import { scene, formes } from 'inventaire/data/stock.js';
+import { scene, formes } from 'inventaire/data/stock';
 
 function pourcentage (dimension, dimensionScene) {
   return dimension / dimensionScene * 100;

--- a/src/situations/inventaire/modeles/situation.js
+++ b/src/situations/inventaire/modeles/situation.js
@@ -1,6 +1,6 @@
-import SituationCommune from 'commun/modeles/situation.js';
-import { nouvelInventaireReference } from './inventaireReference.js';
-import { Contenant } from './contenant.js';
+import SituationCommune from 'commun/modeles/situation';
+import { nouvelInventaireReference } from './inventaireReference';
+import { Contenant } from './contenant';
 
 function inventaireProduits ({ contenants, contenus }) {
   var inventaire = new Map();

--- a/src/situations/inventaire/vues/contenants.js
+++ b/src/situations/inventaire/vues/contenants.js
@@ -1,4 +1,4 @@
-import { VueContenant } from './contenant.js';
+import { VueContenant } from './contenant';
 import EvenementOuvertureContenant from 'inventaire/modeles/evenement_ouverture_contenant';
 
 export class VueContenants {

--- a/src/situations/inventaire/vues/etageres.js
+++ b/src/situations/inventaire/vues/etageres.js
@@ -1,5 +1,5 @@
-import { VueContenants } from './contenants.js';
-import { VueContenu } from './contenu.js';
+import { VueContenants } from './contenants';
+import { VueContenu } from './contenu';
 import imageEtageres from 'inventaire/assets/etageres.png';
 
 export class VueEtageres {

--- a/src/situations/inventaire/vues/situation.js
+++ b/src/situations/inventaire/vues/situation.js
@@ -1,7 +1,7 @@
 import { traduction } from 'commun/infra/internationalisation';
 import EvenementSaisieInventaire from 'inventaire/modeles/evenement_saisie_inventaire';
-import { VueEtageres } from 'inventaire/vues/etageres.js';
-import { initialiseFormulaireSaisieInventaire } from 'inventaire/vues/formulaireSaisieInventaire.js';
+import { VueEtageres } from 'inventaire/vues/etageres';
+import { initialiseFormulaireSaisieInventaire } from 'inventaire/vues/formulaireSaisieInventaire';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 
 export class VueSituation {

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
 
-import { VueAccueil } from 'accueil/vues/accueil.js';
+import { VueAccueil } from 'accueil/vues/accueil';
 
 describe('La vue accueil', function () {
   let $;

--- a/tests/situations/commun/infra/depot_journal.js
+++ b/tests/situations/commun/infra/depot_journal.js
@@ -1,4 +1,4 @@
-import { DepotJournal } from 'commun/infra/depot_journal.js';
+import { DepotJournal } from 'commun/infra/depot_journal';
 import jsdom from 'jsdom-global';
 
 describe('le depot du journal', function () {

--- a/tests/situations/commun/modale.js
+++ b/tests/situations/commun/modale.js
@@ -1,5 +1,5 @@
 import jsdom from 'jsdom-global';
-import { afficheFenetreModale } from 'commun/vues/modale.js';
+import { afficheFenetreModale } from 'commun/vues/modale';
 
 describe('fenetre modale', function () {
   let $;

--- a/tests/situations/commun/modeles/evenement.js
+++ b/tests/situations/commun/modeles/evenement.js
@@ -1,4 +1,4 @@
-import Evenement from 'commun/modeles/evenement.js';
+import Evenement from 'commun/modeles/evenement';
 
 describe("l'événement", function () {
   it("renvoit une exception lorsqu'on lui demande son nom", function () {

--- a/tests/situations/commun/modeles/evenement_demarrage.js
+++ b/tests/situations/commun/modeles/evenement_demarrage.js
@@ -1,4 +1,4 @@
-import EvenementDemarrage from 'commun/modeles/evenement_demarrage.js';
+import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 
 describe("l'événement de demarrage", function () {
   it('retourne son nom', function () {

--- a/tests/situations/commun/modeles/evenement_stop.js
+++ b/tests/situations/commun/modeles/evenement_stop.js
@@ -1,4 +1,4 @@
-import EvenementStop from 'commun/modeles/evenement_stop.js';
+import EvenementStop from 'commun/modeles/evenement_stop';
 
 describe("l'événement de stop", function () {
   it('retourne son nom', function () {

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -1,6 +1,6 @@
-import { Journal } from 'commun/modeles/journal.js';
-import Evenement from 'commun/modeles/evenement.js';
-import { MockDepot } from '../aides/mockDepot.js';
+import { Journal } from 'commun/modeles/journal';
+import Evenement from 'commun/modeles/evenement';
+import { MockDepot } from '../aides/mockDepot';
 
 describe('le journal', function () {
   let journal;

--- a/tests/situations/commun/modeles/situation.js
+++ b/tests/situations/commun/modeles/situation.js
@@ -1,4 +1,4 @@
-import Situation from 'commun/modeles/situation.js';
+import Situation from 'commun/modeles/situation';
 import Evenement from 'commun/modeles/evenement_stop';
 
 describe('toutes les situations', function () {

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -1,5 +1,5 @@
 import jsdom from 'jsdom-global';
-import { VueActions } from 'commun/vues/actions.js';
+import { VueActions } from 'commun/vues/actions';
 
 describe('Affiche les éléments communs aux situations', function () {
   let vueActions;

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
 
-import { VueCadre } from 'commun/vues/cadre.js';
+import { VueCadre } from 'commun/vues/cadre';
 
 function uneVue (callbackAffichage = () => {}) {
   return { affiche: callbackAffichage };

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -1,6 +1,6 @@
 /* global Event */
 
-import { VueConsigne } from 'commun/vues/consigne.js';
+import { VueConsigne } from 'commun/vues/consigne';
 import jsdom from 'jsdom-global';
 
 describe('vue consigne', function () {

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -1,8 +1,8 @@
 import jsdom from 'jsdom-global';
-import { VueGo } from 'commun/vues/go.js';
+import { VueGo } from 'commun/vues/go';
 import { traduction } from 'commun/infra/internationalisation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
-import Situation from 'commun/modeles/situation.js';
+import Situation from 'commun/modeles/situation';
 
 describe('vue Go', function () {
   let vue;

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -1,5 +1,5 @@
 import jsdom from 'jsdom-global';
-import { VueStop } from 'commun/vues/stop.js';
+import { VueStop } from 'commun/vues/stop';
 import EvenementStop from 'commun/modeles/evenement_stop';
 import i18next from 'i18next';
 i18next.init({

--- a/tests/situations/controle/modeles/bac.js
+++ b/tests/situations/controle/modeles/bac.js
@@ -1,5 +1,5 @@
-import { Bac } from 'controle/modeles/bac.js';
-import { PIECE_CONFORME } from 'controle/modeles/piece.js';
+import { Bac } from 'controle/modeles/bac';
+import { PIECE_CONFORME } from 'controle/modeles/piece';
 
 describe('un bac', function () {
   it('connaît ses dimensions', function () {

--- a/tests/situations/controle/modeles/piece.js
+++ b/tests/situations/controle/modeles/piece.js
@@ -1,4 +1,4 @@
-import { Piece } from 'controle/modeles/piece.js';
+import { Piece } from 'controle/modeles/piece';
 
 describe('Une pièce', function () {
   it('a une position de départ', function () {

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -1,4 +1,4 @@
-import { Situation } from 'controle/modeles/situation.js';
+import { Situation } from 'controle/modeles/situation';
 
 describe('La situation « Contrôle »', function () {
   it('connaît la cadence à laquelle arrivent les pièces', function () {

--- a/tests/situations/controle/vues/bac.js
+++ b/tests/situations/controle/vues/bac.js
@@ -1,8 +1,8 @@
 import jsdom from 'jsdom-global';
 
-import { Bac } from 'controle/modeles/bac.js';
-import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece.js';
-import { VueBac } from 'controle/vues/bac.js';
+import { Bac } from 'controle/modeles/bac';
+import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
+import { VueBac } from 'controle/vues/bac';
 
 describe("La vue d'un bac", function () {
   let $;

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
-import { Piece } from 'controle/modeles/piece.js';
-import { VuePiece, DUREE_VIE_PIECE_INFINIE } from 'controle/vues/piece.js';
+import { Piece } from 'controle/modeles/piece';
+import { VuePiece, DUREE_VIE_PIECE_INFINIE } from 'controle/vues/piece';
 
 function creeVueMinimale (piece) {
   return new VuePiece(piece, DUREE_VIE_PIECE_INFINIE, () => {}, () => {});

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -1,8 +1,8 @@
 import jsdom from 'jsdom-global';
-import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece.js';
-import { Situation } from 'controle/modeles/situation.js';
-import { DUREE_VIE_PIECE_INFINIE } from 'controle/vues/piece.js';
-import { VueSituation } from 'controle/vues/situation.js';
+import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
+import { Situation } from 'controle/modeles/situation';
+import { DUREE_VIE_PIECE_INFINIE } from 'controle/vues/piece';
+import { VueSituation } from 'controle/vues/situation';
 
 function vueSituationMinimaliste () {
   const situation = new Situation({ scenario: [] });

--- a/tests/situations/inventaire/aides/magasin.js
+++ b/tests/situations/inventaire/aides/magasin.js
@@ -1,4 +1,4 @@
-import { Situation } from 'inventaire/modeles/situation.js';
+import { Situation } from 'inventaire/modeles/situation';
 
 class MagasinEnDevenir {
   constructor () {

--- a/tests/situations/inventaire/modeles/inventaireReference.js
+++ b/tests/situations/inventaire/modeles/inventaireReference.js
@@ -1,4 +1,4 @@
-import { nouvelInventaireReference } from 'inventaire/modeles/inventaireReference.js';
+import { nouvelInventaireReference } from 'inventaire/modeles/inventaireReference';
 
 describe("L'inventaire de référence", function () {
   it('sait valider les réponses correctes', function () {

--- a/tests/situations/inventaire/modeles/magasin.js
+++ b/tests/situations/inventaire/modeles/magasin.js
@@ -1,5 +1,5 @@
-import { Contenant } from 'inventaire/modeles/contenant.js';
-import { unMagasin } from '../aides/magasin.js';
+import { Contenant } from 'inventaire/modeles/contenant';
+import { unMagasin } from '../aides/magasin';
 
 describe('Le magasin', function () {
   it('connaît les produits en stock', function () {

--- a/tests/situations/inventaire/vues/contenant.js
+++ b/tests/situations/inventaire/vues/contenant.js
@@ -1,7 +1,7 @@
 /* global Event */
 
-import { Contenant } from 'inventaire/modeles/contenant.js';
-import { VueContenant } from 'inventaire/vues/contenant.js';
+import { Contenant } from 'inventaire/modeles/contenant';
+import { VueContenant } from 'inventaire/vues/contenant';
 import jsdom from 'jsdom-global';
 
 describe('vue contenant', function () {

--- a/tests/situations/inventaire/vues/contenants.js
+++ b/tests/situations/inventaire/vues/contenants.js
@@ -1,7 +1,7 @@
 /* global Event */
 
-import { Contenant } from 'inventaire/modeles/contenant.js';
-import { VueContenants } from 'inventaire/vues/contenants.js';
+import { Contenant } from 'inventaire/modeles/contenant';
+import { VueContenants } from 'inventaire/vues/contenants';
 import EvenementOuvertureContenant from 'inventaire/modeles/evenement_ouverture_contenant';
 import jsdom from 'jsdom-global';
 

--- a/tests/situations/inventaire/vues/contenu.js
+++ b/tests/situations/inventaire/vues/contenu.js
@@ -1,7 +1,7 @@
 /* global Event */
 
-import { Contenant } from 'inventaire/modeles/contenant.js';
-import { DELAY_FERMETURE_CONTENANT_MILLISEC, VueContenu } from 'inventaire/vues/contenu.js';
+import { Contenant } from 'inventaire/modeles/contenant';
+import { DELAY_FERMETURE_CONTENANT_MILLISEC, VueContenu } from 'inventaire/vues/contenu';
 import jsdom from 'jsdom-global';
 
 describe('vue contenu', function () {

--- a/tests/situations/inventaire/vues/etageres.js
+++ b/tests/situations/inventaire/vues/etageres.js
@@ -1,7 +1,7 @@
 /* global Event */
 
-import { Contenant } from 'inventaire/modeles/contenant.js';
-import { VueEtageres } from 'inventaire/vues/etageres.js';
+import { Contenant } from 'inventaire/modeles/contenant';
+import { VueEtageres } from 'inventaire/vues/etageres';
 import jsdom from 'jsdom-global';
 
 describe('vue etagères', function () {

--- a/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
+++ b/tests/situations/inventaire/vues/formulaireSaisieInventaire.js
@@ -1,7 +1,7 @@
-import { Contenant } from 'inventaire/modeles/contenant.js';
-import { afficheCorrection, initialiseFormulaireSaisieInventaire } from 'inventaire/vues/formulaireSaisieInventaire.js';
-import EvenementOuvertureSaisieInventaire from 'inventaire/modeles/evenement_ouverture_saisie_inventaire.js';
-import { unMagasin, unMagasinVide } from '../aides/magasin.js';
+import { Contenant } from 'inventaire/modeles/contenant';
+import { afficheCorrection, initialiseFormulaireSaisieInventaire } from 'inventaire/vues/formulaireSaisieInventaire';
+import EvenementOuvertureSaisieInventaire from 'inventaire/modeles/evenement_ouverture_saisie_inventaire';
+import { unMagasin, unMagasinVide } from '../aides/magasin';
 
 let jsdom = require('jsdom-global');
 

--- a/tests/situations/inventaire/vues/journal.js
+++ b/tests/situations/inventaire/vues/journal.js
@@ -1,4 +1,4 @@
-import { VueJournal } from 'inventaire/vues/journal.js';
+import { VueJournal } from 'inventaire/vues/journal';
 import jsdom from 'jsdom-global';
 
 describe('vue journal', function () {

--- a/tests/situations/inventaire/vues/situation.js
+++ b/tests/situations/inventaire/vues/situation.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
-import { unMagasinVide } from '../aides/magasin.js';
-import { VueSituation } from 'inventaire/vues/situation.js';
+import { unMagasinVide } from '../aides/magasin';
+import { VueSituation } from 'inventaire/vues/situation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 
 describe('La situation « Inventaire »', function () {


### PR DESCRIPTION
Certains imports incluaient un `.js`, certains autres non. J'ai harmonisé tout cela en supprimant le suffixe .js qui n'est pas utile.

Fix #130 