### PR TITLE
Situation « Contrôle » : génère et enregistre un événement à la disparition de chaque pièce

### DIFF
--- a/src/app/situationControle.js
+++ b/src/app/situationControle.js
@@ -22,7 +22,7 @@ function afficheSituation (pointInsertion, $) {
     dureeViePiece: 12000,
     consigneAudio: sonConsigneDemarrage
   });
-  const vueSituation = new VueSituation(situation);
+  const vueSituation = new VueSituation(situation, journal);
   const vueCadre = new VueCadre(vueSituation, situation, journal);
 
   vueCadre.affiche(pointInsertion, $);

--- a/src/situations/controle/modeles/evenement_disparition_piece.js
+++ b/src/situations/controle/modeles/evenement_disparition_piece.js
@@ -1,8 +1,8 @@
 import Evenement from 'commun/modeles/evenement';
 
 export default class EvenementDisparitionPiece extends Evenement {
-  constructor () {
-    super();
+  constructor (donneesPiece) {
+    super(donneesPiece);
     this._nom = 'disparitionPiece';
   }
 

--- a/src/situations/controle/modeles/evenement_disparition_piece.js
+++ b/src/situations/controle/modeles/evenement_disparition_piece.js
@@ -1,0 +1,12 @@
+import Evenement from 'commun/modeles/evenement';
+
+export default class EvenementDisparitionPiece extends Evenement {
+  constructor () {
+    super();
+    this._nom = 'disparitionPiece';
+  }
+
+  nom () {
+    return this._nom;
+  }
+}

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -1,7 +1,10 @@
+import EventEmitter from 'events';
+
 import 'controle/styles/piece.scss';
 import { imagePieceConforme, imagesPiecesNonConformes } from 'controle/data/pieces';
 
 export const DUREE_VIE_PIECE_INFINIE = undefined;
+export const DISPARITION_PIECE = 'disparition';
 
 export function animationInitiale ($element) {
   $element.animate({ left: '-10%' }, 10000, 'linear');
@@ -11,11 +14,13 @@ export function animationFinale ($element, done) {
   $element.fadeOut(500, () => { done($element); });
 }
 
-export class VuePiece {
+export class VuePiece extends EventEmitter {
   constructor (piece,
     dureeVie = DUREE_VIE_PIECE_INFINIE,
     callbackApresApparition = animationInitiale,
     callbackAvantSuppression = animationFinale) {
+    super();
+
     this.piece = piece;
     this.dureeVie = dureeVie;
     this.callbackApresApparition = callbackApresApparition;
@@ -84,7 +89,10 @@ export class VuePiece {
 
     if (this.dureeVie !== DUREE_VIE_PIECE_INFINIE) {
       setTimeout(() => {
-        this.callbackAvantSuppression($piece, () => { $piece.remove(); });
+        this.callbackAvantSuppression($piece, () => {
+          $piece.remove();
+          this.emit(DISPARITION_PIECE, { position: this.piece.position() });
+        });
       }, this.dureeVie);
     }
   }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,11 +1,12 @@
 import { Bac } from 'controle/modeles/bac';
+import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_piece';
 import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 import { VueBac } from 'controle/vues/bac';
-import { VuePiece } from 'controle/vues/piece';
+import { VuePiece, DISPARITION_PIECE } from 'controle/vues/piece';
 
 export class VueSituation {
-  constructor (situation, callbackApresCreationPiece) {
+  constructor (situation, journal, callbackApresCreationPiece) {
     function nouveauBac (categorie, { x, y }) {
       return new Bac({ categorie, x, y, largeur: 30, hauteur: 40 });
     }
@@ -18,12 +19,17 @@ export class VueSituation {
     }
 
     this.situation = situation;
+    this.journal = journal;
     this.callbackApresCreationPiece = callbackApresCreationPiece;
     this._bacs = creeBacs();
   }
 
   bacs () {
     return this._bacs;
+  }
+
+  creeVuePiece (piece) {
+    return new VuePiece(piece, this.situation.dureeViePiece(), this.callbackApresCreationPiece);
   }
 
   affiche (pointInsertion, $) {
@@ -47,7 +53,8 @@ export class VueSituation {
       }
 
       const piece = this.situation.pieceSuivante();
-      const vuePiece = new VuePiece(piece, this.situation.dureeViePiece(), this.callbackApresCreationPiece);
+      let vuePiece = this.creeVuePiece(piece);
+      vuePiece.on(DISPARITION_PIECE, (e) => this.journal.enregistre(new EvenementDisparitionPiece(e)));
       vuePiece.affiche(pointInsertion, $);
     };
     afficheProchainePiece();

--- a/tests/situations/controle/modeles/evenement_disparition_piece.js
+++ b/tests/situations/controle/modeles/evenement_disparition_piece.js
@@ -1,8 +1,23 @@
 import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_piece';
+import { PIECE_CONFORME } from 'controle/modeles/piece';
 
 describe("L'événement de disparition d'une pièce", function () {
   it('retourne son nom', function () {
     const evenement = new EvenementDisparitionPiece();
     expect(evenement.nom()).to.equal('disparitionPiece');
+  });
+
+  it('connaît les données relatives à la pièce qui disparaît', function () {
+    const evenement = new EvenementDisparitionPiece({
+      position: { x: 10, y: 25 },
+      dimensions: { largeur: 20, hauteur: 45 },
+      categorie: PIECE_CONFORME
+    });
+
+    expect(evenement.donnees()).to.eql({
+      position: { x: 10, y: 25 },
+      dimensions: { largeur: 20, hauteur: 45 },
+      categorie: PIECE_CONFORME
+    });
   });
 });

--- a/tests/situations/controle/modeles/evenement_disparition_piece.js
+++ b/tests/situations/controle/modeles/evenement_disparition_piece.js
@@ -1,0 +1,8 @@
+import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_piece';
+
+describe("L'événement de disparition d'une pièce", function () {
+  it('retourne son nom', function () {
+    const evenement = new EvenementDisparitionPiece();
+    expect(evenement.nom()).to.equal('disparitionPiece');
+  });
+});

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
 import { Piece } from 'controle/modeles/piece';
-import { VuePiece, DUREE_VIE_PIECE_INFINIE } from 'controle/vues/piece';
+import { VuePiece, DUREE_VIE_PIECE_INFINIE, DISPARITION_PIECE } from 'controle/vues/piece';
 
 function creeVueMinimale (piece) {
   return new VuePiece(piece, DUREE_VIE_PIECE_INFINIE, () => {}, () => {});
@@ -112,5 +112,17 @@ describe('Une pièce', function () {
     const vuePiece = new VuePiece(piece, 5, () => {}, callbackAvantSuppression);
     vuePiece.affiche('#controle', $);
     expect($('.piece').length).to.equal(1);
+  });
+
+  it('émet un événement à sa disparition', function (done) {
+    const piece = new Piece({ x: 90, y: 40 });
+    const vuePiece = new VuePiece(piece, 5, () => {}, (_, done) => done());
+
+    vuePiece.on(DISPARITION_PIECE, (e) => {
+      expect(e).to.eql({ position: { x: 90, y: 40 } });
+      done();
+    });
+
+    vuePiece.affiche('#controle', $);
   });
 });


### PR DESCRIPTION
Contribue à #105.

L'idée est de commencer par enregistrer un événement, pour pouvoir plus tard ensuite affiner l'information enregistrée.

_(Note : on peut remarquer que si on ne touche pas à la pièce, elle conserve ses coordonnées de départ jusqu'à sa disparition… Ce point sera corrigé dans une autre PR.)_