### PR TITLE
Controle: nettoyage de quelques comportements

### DIFF
--- a/src/situations/controle/modeles/bac.js
+++ b/src/situations/controle/modeles/bac.js
@@ -1,8 +1,8 @@
 export class Bac {
   constructor ({ categorie, x, y, largeur, hauteur }) {
     this._categorie = categorie;
-    this._dimensions = { largeur: largeur, hauteur: hauteur };
-    this._position = { x: x, y: y };
+    this._dimensions = { largeur, hauteur };
+    this._position = { x, y };
   }
 
   dimensions () {

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -33,15 +33,24 @@ export class VueSituation {
 
     this._bacs.forEach(afficheBac);
 
-    let identifiantIntervalle = setInterval(() => {
+    this.demarre(pointInsertion, $);
+  }
+
+  demarre (pointInsertion, $) {
+    const afficheProchainePiece = () => {
       if (this.situation.sequenceTerminee()) {
-        clearInterval(identifiantIntervalle);
+        clearInterval(this.identifiantIntervalle);
         return;
       }
 
-      let piece = this.situation.pieceSuivante();
-      let vuePiece = new VuePiece(piece, this.situation.dureeViePiece(), this.callbackApresCreationPiece);
+      const piece = this.situation.pieceSuivante();
+      const vuePiece = new VuePiece(piece, this.situation.dureeViePiece(), this.callbackApresCreationPiece);
       vuePiece.affiche(pointInsertion, $);
-    }, this.situation.cadenceArriveePieces());
+    };
+    afficheProchainePiece();
+    this.identifiantIntervalle = setInterval(
+      afficheProchainePiece,
+      this.situation.cadenceArriveePieces()
+    );
   }
 }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -12,7 +12,7 @@ export class VueSituation {
     function creeBacs () {
       const bacs = [];
       bacs.push(nouveauBac(PIECE_CONFORME, { x: 10, y: 10 }));
-      bacs.push(nouveauBac(PIECE_DEFECTUEUSE, { x: 10, y: 10 }));
+      bacs.push(nouveauBac(PIECE_DEFECTUEUSE, { x: 60, y: 10 }));
       return bacs;
     }
 
@@ -26,14 +26,12 @@ export class VueSituation {
   }
 
   affiche (pointInsertion, $) {
-    function afficheBac (categorie, { x, y }) {
-      const bac = new Bac({ categorie: categorie, x: x, y: y, largeur: 30, hauteur: 40 });
+    function afficheBac (bac) {
       const vueBac = new VueBac(bac);
       vueBac.affiche(pointInsertion, $);
     }
 
-    afficheBac(PIECE_CONFORME, { x: 10, y: 10 });
-    afficheBac(PIECE_DEFECTUEUSE, { x: 60, y: 10 });
+    this._bacs.forEach(afficheBac);
 
     let identifiantIntervalle = setInterval(() => {
       if (this.situation.sequenceTerminee()) {


### PR DESCRIPTION
La situation contrôle n'utilisait pas correctement les modèles de bac instanciés dans le constructeur. Nous avons corrigé cela.

De plus nous faisons apparaître la première pièce immédiatement au démarrage.

Un petit peu de code a été simplifié.

Ces 3 modifications vous sont vendues dans une seule PR, composée de 3 commits. Comme la vente liée est interdite, nous pouvons vous proposer les 3 choses dans 3 PRs. Mais c'est plus cher.