### PR TITLE
 Donne à la vue cadre la responsabilité de créer l'élement racine

### DIFF
--- a/src/app/situationControle.js
+++ b/src/app/situationControle.js
@@ -14,7 +14,6 @@ import sonConsigneDemarrage from 'controle/assets/consigne_demarrage.mp3';
 function afficheSituation (pointInsertion, $) {
   const session = uuidv4();
   const journal = new Journal(Date.now, session, 'controle', new DepotJournal());
-
   const situation = new Situation({
     scenario: [true, false, true],
     cadence: 3000,
@@ -22,6 +21,7 @@ function afficheSituation (pointInsertion, $) {
     dureeViePiece: 12000,
     consigneAudio: sonConsigneDemarrage
   });
+
   const vueSituation = new VueSituation(situation, journal);
   const vueCadre = new VueCadre(vueSituation, situation, journal);
 
@@ -31,8 +31,6 @@ function afficheSituation (pointInsertion, $) {
 initialiseInternationalisation().then(function () {
   jQuery(function () {
     document.title = traduction('controle.titre');
-    jQuery('body').append('<div id="situation-controle" class="conteneur"></div>');
-
-    afficheSituation('#situation-controle', jQuery);
+    afficheSituation('body', jQuery);
   });
 });

--- a/src/app/situationInventaire.js
+++ b/src/app/situationInventaire.js
@@ -18,8 +18,8 @@ function afficheSituation (pointInsertion, $) {
   const journal = new Journal(Date.now, session, 'inventaire', new DepotJournal());
   const situation = new Situation({ contenants, contenus }, sonConsigneDemarrage);
 
-  const vueSituationInventaire = new VueSituation(situation, journal);
-  const vueCadre = new VueCadre(vueSituationInventaire, situation, journal);
+  const vueSituation = new VueSituation(situation, journal);
+  const vueCadre = new VueCadre(vueSituation, situation, journal);
 
   vueCadre.affiche(pointInsertion, $);
 }
@@ -27,7 +27,6 @@ function afficheSituation (pointInsertion, $) {
 initialiseInternationalisation().then(function () {
   jQuery(function () {
     document.title = traduction('inventaire.titre');
-    jQuery('body').append(`<div id="magasin" class='conteneur'> </div>`);
-    afficheSituation('#magasin', jQuery);
+    afficheSituation('body', jQuery);
   });
 });

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -12,12 +12,15 @@ export class VueCadre {
   }
 
   affiche (pointInsertion, $) {
-    const $scene = $('<div class="scene"></div>');
-    $(pointInsertion).append($scene);
-    this.vueSituation.affiche('.scene', $);
-    this.vueActions.affiche(pointInsertion, $);
+    const $cadre = $('<div id="cadre" class="conteneur"></div>');
+    $(pointInsertion).append($cadre);
 
-    this.vueConsigne.affiche(pointInsertion);
-    this.vueGo.affiche(pointInsertion, $);
+    $cadre.append($('<div class="scene"></div>'));
+    this.vueSituation.affiche('.scene', $);
+
+    const selecteurCadre = '#cadre';
+    this.vueActions.affiche(selecteurCadre, $);
+    this.vueConsigne.affiche(selecteurCadre);
+    this.vueGo.affiche(selecteurCadre, $);
   }
 }

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -11,20 +11,27 @@ describe('Une vue du cadre', function () {
   let situation;
 
   beforeEach(function () {
-    jsdom('<div id="une-situation"></div>');
+    jsdom('<div id="point-insertion"></div>');
     $ = jQuery(window);
     situation = {
       consigneAudio: 'chemin_vers_la_consigne_audio'
     };
   });
 
-  it("Affiche une scene comme point d'insertion de la vue situation", function () {
-    const vueSituation = uneVue();
-    const vueCadre = new VueCadre(vueSituation, situation);
-    expect($('#une-situation .scene').length).to.equal(0);
+  it("Crée l'élément cadre", function () {
+    const vueCadre = new VueCadre(uneVue(), situation);
+    expect($('#point-insertion #cadre').length).to.equal(0);
 
-    vueCadre.affiche('#une-situation', $);
-    expect($('#une-situation .scene').length).to.equal(1);
+    vueCadre.affiche('#point-insertion', $);
+    expect($('#point-insertion #cadre.conteneur').length).to.equal(1);
+  });
+
+  it("Affiche une scene comme point d'insertion de la vue situation", function () {
+    const vueCadre = new VueCadre(uneVue(), situation);
+    expect($('#cadre .scene').length).to.equal(0);
+
+    vueCadre.affiche('#point-insertion', $);
+    expect($('#cadre .scene').length).to.equal(1);
   });
 
   it('affiche une situation donnée', function (done) {
@@ -34,27 +41,27 @@ describe('Une vue du cadre', function () {
       done();
     });
     const vueCadre = new VueCadre(vueSituation, situation);
-    vueCadre.affiche('#une-situation', $);
+    vueCadre.affiche('#point-insertion', $);
   });
 
   it("affiche la barre d'action", function () {
     const vueCadre = new VueCadre(uneVue(), situation);
-    vueCadre.affiche('#une-situation', $);
+    vueCadre.affiche('#point-insertion', $);
 
-    expect($('.actions').length).to.equal(1);
+    expect($('#cadre .actions').length).to.equal(1);
   });
 
   it('affiche la consigne audio', function () {
     const vueCadre = new VueCadre(uneVue(), situation);
-    vueCadre.affiche('#une-situation', $);
+    vueCadre.affiche('#point-insertion', $);
 
-    expect($('#consigne').length).to.equal(1);
+    expect($('#cadre #consigne').length).to.equal(1);
   });
 
   it("affiche l'overlay de démarrage", function () {
     const vueCadre = new VueCadre(uneVue(), situation);
-    vueCadre.affiche('#une-situation', $);
+    vueCadre.affiche('#point-insertion', $);
 
-    expect($('#overlay-go').length).to.equal(1);
+    expect($('#cadre #overlay-go').length).to.equal(1);
   });
 });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -16,21 +16,21 @@ describe('La situation « Contrôle »', function () {
   let $;
 
   beforeEach(function () {
-    jsdom('<div id="situation-controle"></div>');
+    jsdom('<div id="point-insertion"></div>');
     $ = jQuery(window);
   });
 
   it('affiche les bacs et le tapis', function () {
     const vueSituation = vueSituationMinimaliste();
-    expect($('#situation-controle .bac.pieces-conformes').length).to.equal(0);
-    expect($('#situation-controle .bac.pieces-defectueuses').length).to.equal(0);
+    expect($('#point-insertion .bac.pieces-conformes').length).to.equal(0);
+    expect($('#point-insertion .bac.pieces-defectueuses').length).to.equal(0);
 
-    vueSituation.affiche('#situation-controle', $);
+    vueSituation.affiche('#point-insertion', $);
 
-    expect($('#situation-controle').hasClass('controle')).to.be(true);
-    expect($('#situation-controle .bac.pieces-conformes').length).to.equal(1);
-    expect($('#situation-controle .bac.pieces-defectueuses').length).to.equal(1);
-    expect($('#situation-controle .tapis').length).to.equal(1);
+    expect($('#point-insertion').hasClass('controle')).to.be(true);
+    expect($('#point-insertion .bac.pieces-conformes').length).to.equal(1);
+    expect($('#point-insertion .bac.pieces-defectueuses').length).to.equal(1);
+    expect($('#point-insertion .tapis').length).to.equal(1);
   });
 
   it('connaît les bacs associés à la vue', function () {
@@ -61,7 +61,7 @@ describe('La situation « Contrôle »', function () {
       if (nbPiecesAffichees >= 2) { done(); }
     });
 
-    vueSituation.affiche('#situation-controle', $);
+    vueSituation.affiche('#point-insertion', $);
     situation.notifie(new EvenementDemarrage());
   });
 
@@ -87,7 +87,7 @@ describe('La situation « Contrôle »', function () {
       setTimeout(() => { vuePiece.emit(DISPARITION_PIECE, { position: { x: 45, y: 5 } }); });
       return vuePiece;
     };
-    vueSituation.affiche('#situation-controle', $);
-    vueSituation.demarre('#situation-controle', $);
+    vueSituation.affiche('#point-insertion', $);
+    vueSituation.demarre('#point-insertion', $);
   });
 });

--- a/tests/situations/inventaire/vues/situation.js
+++ b/tests/situations/inventaire/vues/situation.js
@@ -10,7 +10,7 @@ describe('La situation « Inventaire »', function () {
   let vue;
 
   beforeEach(function () {
-    jsdom('<div id="situation"></div>');
+    jsdom('<div id="point-insertion"></div>');
     $ = jQuery(window);
     mockJournal = {
       enregistre: () => {}
@@ -20,11 +20,11 @@ describe('La situation « Inventaire »', function () {
   });
 
   it('affiche les étagères', function () {
-    expect($('#situation .etageres').length).to.equal(0);
+    expect($('#point-insertion .etageres').length).to.equal(0);
 
-    vue.affiche('#situation', $);
+    vue.affiche('#point-insertion', $);
 
-    expect($('#situation .etageres').length).to.equal(1);
+    expect($('#point-insertion .etageres').length).to.equal(1);
   });
 
   it("incrit le journal à l'événement démarrage", function (done) {


### PR DESCRIPTION
Cette PR termine l'issue #98 

La vue cadre crée la structure suivante : 
```
<cadre>
  <scene></scene>
  <actions></actions>
  <consigne></consigne>
  <go></go>
</cadre>
```