### PR TITLE
Affiche une confirmation avant de quitter si la situation a démarré.

### DIFF
--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -31,6 +31,7 @@ export default class VueCadre {
     this.$ = $;
     this.afficheEtat(this.situation.etat());
     this.situation.on(CHANGEMENT_ETAT, this.afficheEtat.bind(this));
+    this.previentLaFermetureDeLaSituation($);
   }
 
   afficheEtat (etat) {
@@ -46,5 +47,14 @@ export default class VueCadre {
     if (etat === FINI) {
       this.vueActions.cache();
     }
+  }
+
+  previentLaFermetureDeLaSituation ($) {
+    $(window).on('beforeunload', (e) => {
+      if (![NON_DEMARRE, FINI].includes(this.situation.etat())) {
+        e.preventDefault();
+        return '';
+      }
+    });
   }
 }

--- a/src/situations/commun/vues/terminer.js
+++ b/src/situations/commun/vues/terminer.js
@@ -10,4 +10,6 @@ export default class VueTerminer {
     $actions.append(`<div class='message-succes'>${traduction('situation.reussite')}</div>`);
     $(pointInsertion).append($actions);
   }
+
+  cache () {}
 }

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -2,7 +2,7 @@
 
 import jsdom from 'jsdom-global';
 
-import SituationCommune, { CHANGEMENT_ETAT, NON_DEMARRE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, FINI } from 'commun/modeles/situation';
+import SituationCommune, { CHANGEMENT_ETAT, NON_DEMARRE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI } from 'commun/modeles/situation';
 import VueCadre from 'commun/vues/cadre';
 
 function uneVue (callbackAffichage = () => {}) {
@@ -88,5 +88,27 @@ describe('Une vue du cadre', function () {
     situation.emit(CHANGEMENT_ETAT, FINI);
     expect($('.actions').length).to.equal(2);
     expect($('.actions.invisible').length).to.equal(1);
+  });
+
+  it('demande une confirmation pour quitter la page lorsque la situation est démarré', function () {
+    const vueCadre = new VueCadre(uneVue(), situation);
+    vueCadre.affiche('#point-insertion', $);
+    [LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE].forEach((etat) => {
+      situation.modifieEtat(etat);
+      const event = $.Event('beforeunload');
+      $(window).trigger(event);
+      expect(event.isDefaultPrevented()).to.be.ok();
+    });
+  });
+
+  it("ne demande pas une confirmation pour quitter la page lorsque la situation n'a pas démarré", function () {
+    const vueCadre = new VueCadre(uneVue(), situation);
+    vueCadre.affiche('#point-insertion', $);
+    [FINI, NON_DEMARRE].forEach((etat) => {
+      situation.modifieEtat(etat);
+      const event = $.Event('beforeunload');
+      $(window).trigger(event);
+      expect(event.isDefaultPrevented()).to.not.be.ok();
+    });
   });
 });


### PR DESCRIPTION
Lorsque la situation a démarré, le fait de quitter la situation en voulant revenir en arrière ou en fermant l'onglet va afficher une fenêtre de confirmation à l'utilisateur·trice.

![confirm](https://user-images.githubusercontent.com/86659/55727298-fa317580-5a11-11e9-9724-7ad8c513676d.gif)

J'ai regardé, il n'y a pas moyen d'envoyer l'événement de fin a ce moment la au serveur.

Fix #66 
