### PR TITLE
Controle: Le tapis démarre une fois la situation démarré, et s'arrête une fois fini

### DIFF
--- a/src/situations/controle/styles/app.scss
+++ b/src/situations/controle/styles/app.scss
@@ -1,6 +1,5 @@
 @import 'commun/styles/commun.scss';
 @import 'commun/styles/conteneur.scss';
-@import 'controle/styles/tapis.scss';
 
 .scene.controle {
   background-image: url('../assets/fond-situation.png'), url('../assets/fond-repetable.png') ;

--- a/src/situations/controle/styles/tapis.scss
+++ b/src/situations/controle/styles/tapis.scss
@@ -5,7 +5,10 @@
   width: 100%;
   height: 34%;
   bottom: 3.5%;
-  animation: slide 18s linear infinite;
+
+  &.en-marche {
+    animation: slide 18s linear infinite;
+  }
 }
 
 @keyframes slide {

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -4,6 +4,7 @@ import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_pi
 import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
 import { VueBac } from 'controle/vues/bac';
 import { VuePiece, DISPARITION_PIECE } from 'controle/vues/piece';
+import VueTapis from 'controle/vues/tapis';
 
 export class VueSituation {
   constructor (situation, journal, callbackApresCreationPiece) {
@@ -22,6 +23,7 @@ export class VueSituation {
     this.journal = journal;
     this.callbackApresCreationPiece = callbackApresCreationPiece;
     this._bacs = creeBacs();
+    this.tapis = new VueTapis(situation);
   }
 
   bacs () {
@@ -38,10 +40,10 @@ export class VueSituation {
       vueBac.affiche(pointInsertion, $);
     }
 
-    $(pointInsertion).append('<div class="tapis"></div>');
     $(pointInsertion).addClass('controle');
 
     this._bacs.forEach(afficheBac);
+    this.tapis.affiche(pointInsertion, $);
 
     this.situation.on(CHANGEMENT_ETAT, (etat) => {
       if (etat === DEMARRE) {

--- a/src/situations/controle/vues/tapis.js
+++ b/src/situations/controle/vues/tapis.js
@@ -1,0 +1,22 @@
+import 'controle/styles/tapis.scss';
+
+import { DEMARRE, CHANGEMENT_ETAT } from 'commun/modeles/situation';
+
+export default class VueTapis {
+  constructor (situation) {
+    this.situation = situation;
+  }
+
+  affiche (pointInsertion, $) {
+    $(pointInsertion).append('<div class="tapis"></div>');
+    this.changeEtat(pointInsertion, $);
+    this.situation.on(CHANGEMENT_ETAT, () => {
+      this.changeEtat(pointInsertion, $);
+    });
+  }
+
+  changeEtat (pointInsertion, $) {
+    const enMarche = this.situation.etat() === DEMARRE;
+    $('.tapis', pointInsertion).toggleClass('en-marche', enMarche);
+  }
+}

--- a/tests/situations/controle/vues/tapis.js
+++ b/tests/situations/controle/vues/tapis.js
@@ -1,0 +1,41 @@
+import jsdom from 'jsdom-global';
+
+import { DEMARRE, FINI } from 'commun/modeles/situation';
+import { Situation } from 'controle/modeles/situation';
+import VueTapis from 'controle/vues/tapis';
+
+describe('La vue du tapis', () => {
+  let $;
+  let situation;
+  let vue;
+
+  beforeEach(() => {
+    jsdom('<div id="pointInsertion"></div>');
+    $ = jQuery(window);
+    situation = new Situation({});
+    vue = new VueTapis(situation);
+  });
+
+  it("s'affiche à partir d'un point d'insertion", () => {
+    expect($('.tapis').length).to.equal(0);
+
+    vue.affiche('#pointInsertion', $);
+
+    expect($('#pointInsertion .tapis').length).to.equal(1);
+    expect($('#pointInsertion .tapis').hasClass('en-marche')).to.not.be.ok();
+  });
+
+  it("met en marche le tapis lorsque l'état est DEMARRE", () => {
+    situation.modifieEtat(DEMARRE);
+    vue.affiche('#pointInsertion', $);
+
+    expect($('#pointInsertion .tapis').hasClass('en-marche')).to.be.ok();
+  });
+
+  it("stoppe le tapis lorsque c'est fini", () => {
+    situation.modifieEtat(DEMARRE);
+    vue.affiche('#pointInsertion', $);
+    situation.modifieEtat(FINI);
+    expect($('#pointInsertion .tapis').hasClass('en-marche')).to.not.be.ok();
+  });
+});


### PR DESCRIPTION
J'ai sorti la gestion du tapis dans une classe a part. Le tapis est en mouvement que dans l'état `démarré`. Cela gère par avance la gestion de la fin de la situation.

Voici le résultat avec un overlay invisible pour mettre en exergue ce comportement:

![tapis](https://user-images.githubusercontent.com/86659/55727847-33b6b080-5a13-11e9-9b59-c1c11445ed1e.gif)


