### PR TITLE
Controle: détecte la fin

### DIFF
--- a/src/situations/controle/modeles/piece.js
+++ b/src/situations/controle/modeles/piece.js
@@ -1,14 +1,17 @@
+import EventEmitter from 'events';
+
 export const PIECE_CONFORME = true;
 export const PIECE_DEFECTUEUSE = false;
+export const CHANGEMENT_POSITION = 'changementPosition';
 
-export class Piece {
+export class Piece extends EventEmitter {
   constructor ({ x, y, conforme, image }) {
+    super();
     this.x = x;
     this.y = y;
     this.conforme = conforme;
     this.image = image;
     this.selectionnee = false;
-    this.abonnes = [];
   }
 
   position () {
@@ -23,11 +26,7 @@ export class Piece {
     this.x = x;
     this.y = y;
 
-    this.abonnes.forEach(a => a({ x: x, y: y }));
-  }
-
-  quandChangementPosition (nouvelAbonne) {
-    this.abonnes.push(nouvelAbonne);
+    this.emit(CHANGEMENT_POSITION, { x, y });
   }
 
   estSelectionnee () {

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -1,6 +1,8 @@
 import { Piece } from 'controle/modeles/piece';
 import SituationCommune from 'commun/modeles/situation';
 
+export const NOUVELLE_PIECE = 'nouvellePiece';
+
 export class Situation extends SituationCommune {
   constructor ({ cadence, scenario, dureeViePiece, positionApparitionPieces, consigneAudio }) {
     super();
@@ -9,6 +11,7 @@ export class Situation extends SituationCommune {
     this.positionApparition = positionApparitionPieces;
     this._dureeViePiece = dureeViePiece;
     this.consigneAudio = consigneAudio;
+    this._piecesEnCours = [];
   }
 
   cadenceArriveePieces () {
@@ -29,5 +32,27 @@ export class Situation extends SituationCommune {
       y: this.positionApparition.y,
       conforme: donneesPiece.conforme,
       image: donneesPiece.image });
+  }
+
+  piecesEnCours () {
+    return this._piecesEnCours;
+  }
+
+  demarre () {
+    const afficheProchainePiece = () => {
+      if (this.sequenceTerminee()) {
+        clearInterval(this.identifiantIntervalle);
+        return;
+      }
+
+      const piece = this.pieceSuivante();
+      this._piecesEnCours.push(piece);
+      this.emit(NOUVELLE_PIECE, piece);
+    };
+    afficheProchainePiece();
+    this.identifiantIntervalle = setInterval(
+      afficheProchainePiece,
+      this.cadence
+    );
   }
 }

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -2,6 +2,7 @@ import { Piece } from 'controle/modeles/piece';
 import SituationCommune from 'commun/modeles/situation';
 
 export const NOUVELLE_PIECE = 'nouvellePiece';
+export const DISPARITION_PIECE = 'disparitionPiece';
 
 export class Situation extends SituationCommune {
   constructor ({ cadence, scenario, dureeViePiece, positionApparitionPieces, consigneAudio }) {
@@ -45,14 +46,22 @@ export class Situation extends SituationCommune {
         return;
       }
 
-      const piece = this.pieceSuivante();
-      this._piecesEnCours.push(piece);
-      this.emit(NOUVELLE_PIECE, piece);
+      this.faitApparaitreLaNouvellePiece();
     };
     afficheProchainePiece();
     this.identifiantIntervalle = setInterval(
       afficheProchainePiece,
       this.cadence
     );
+  }
+
+  faitApparaitreLaNouvellePiece () {
+    const piece = this.pieceSuivante();
+    this._piecesEnCours.push(piece);
+    this.emit(NOUVELLE_PIECE, piece);
+    setTimeout(() => {
+      this._piecesEnCours.splice(this._piecesEnCours.indexOf(piece), 1);
+      piece.emit(DISPARITION_PIECE);
+    }, this.dureeViePiece());
   }
 }

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -2,6 +2,8 @@ import EventEmitter from 'events';
 
 import 'controle/styles/piece.scss';
 
+import { CHANGEMENT_POSITION } from 'controle/modeles/piece';
+
 export const DUREE_VIE_PIECE_INFINIE = undefined;
 export const DISPARITION_PIECE = 'disparition';
 
@@ -68,7 +70,7 @@ export class VuePiece extends EventEmitter {
       });
     });
 
-    this.piece.quandChangementPosition(function (nouvellePosition) {
+    this.piece.on(CHANGEMENT_POSITION, (nouvellePosition) => {
       metsAJourPosition($piece, nouvellePosition, dimensionsElementParent);
     });
     $elementParent.append($piece);

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -3,9 +3,7 @@ import EventEmitter from 'events';
 import 'controle/styles/piece.scss';
 
 import { CHANGEMENT_POSITION } from 'controle/modeles/piece';
-
-export const DUREE_VIE_PIECE_INFINIE = undefined;
-export const DISPARITION_PIECE = 'disparition';
+import { DISPARITION_PIECE } from 'controle/modeles/situation';
 
 export function animationInitiale ($element) {
   $element.animate({ left: '-10%' }, 10000, 'linear');
@@ -17,13 +15,11 @@ export function animationFinale ($element, done) {
 
 export class VuePiece extends EventEmitter {
   constructor (piece,
-    dureeVie = DUREE_VIE_PIECE_INFINIE,
     callbackApresApparition = animationInitiale,
     callbackAvantSuppression = animationFinale) {
     super();
 
     this.piece = piece;
-    this.dureeVie = dureeVie;
     this.callbackApresApparition = callbackApresApparition;
     this.callbackAvantSuppression = callbackAvantSuppression;
   }
@@ -76,13 +72,10 @@ export class VuePiece extends EventEmitter {
     $elementParent.append($piece);
     $piece.show(() => { this.callbackApresApparition($piece); });
 
-    if (this.dureeVie !== DUREE_VIE_PIECE_INFINIE) {
-      setTimeout(() => {
-        this.callbackAvantSuppression($piece, () => {
-          $piece.remove();
-          this.emit(DISPARITION_PIECE, { position: this.piece.position() });
-        });
-      }, this.dureeVie);
-    }
+    this.piece.on(DISPARITION_PIECE, () => {
+      this.callbackAvantSuppression($piece, () => {
+        $piece.remove();
+      });
+    });
   }
 }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,5 +1,5 @@
 import { Bac } from 'controle/modeles/bac';
-import { CHANGEMENT_ETAT, DEMARRE } from 'commun/modeles/situation';
+import { CHANGEMENT_ETAT, DEMARRE, FINI } from 'commun/modeles/situation';
 import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_piece';
 import { NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
 import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
@@ -59,6 +59,9 @@ export class VueSituation {
       vuePiece.affiche(pointInsertion, $);
       piece.on(DISPARITION_PIECE, (e) => {
         this.journal.enregistre(new EvenementDisparitionPiece({ position: piece.position() }));
+        if (this.situation.piecesEnCours().length === 0 && this.situation.sequenceTerminee()) {
+          this.situation.modifieEtat(FINI);
+        }
       });
     });
     this.situation.demarre();

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -8,7 +8,7 @@ import { VuePiece } from 'controle/vues/piece';
 import VueTapis from 'controle/vues/tapis';
 
 export class VueSituation {
-  constructor (situation, journal, callbackApresCreationPiece) {
+  constructor (situation, journal) {
     function nouveauBac (categorie, { x, y }) {
       return new Bac({ categorie, x, y, largeur: 24.2, hauteur: 44 });
     }
@@ -22,7 +22,6 @@ export class VueSituation {
 
     this.situation = situation;
     this.journal = journal;
-    this.callbackApresCreationPiece = callbackApresCreationPiece;
     this._bacs = creeBacs();
     this.tapis = new VueTapis(situation);
   }
@@ -32,7 +31,7 @@ export class VueSituation {
   }
 
   creeVuePiece (piece) {
-    return new VuePiece(piece, this.callbackApresCreationPiece);
+    return new VuePiece(piece);
   }
 
   affiche (pointInsertion, $) {

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,6 +1,7 @@
 import { Bac } from 'controle/modeles/bac';
 import { CHANGEMENT_ETAT, DEMARRE } from 'commun/modeles/situation';
 import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_piece';
+import { NOUVELLE_PIECE } from 'controle/modeles/situation';
 import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
 import { VueBac } from 'controle/vues/bac';
 import { VuePiece, DISPARITION_PIECE } from 'controle/vues/piece';
@@ -53,21 +54,11 @@ export class VueSituation {
   }
 
   demarre (pointInsertion, $) {
-    const afficheProchainePiece = () => {
-      if (this.situation.sequenceTerminee()) {
-        clearInterval(this.identifiantIntervalle);
-        return;
-      }
-
-      const piece = this.situation.pieceSuivante();
-      let vuePiece = this.creeVuePiece(piece);
+    this.situation.on(NOUVELLE_PIECE, (piece) => {
+      const vuePiece = this.creeVuePiece(piece);
       vuePiece.on(DISPARITION_PIECE, (e) => this.journal.enregistre(new EvenementDisparitionPiece(e)));
       vuePiece.affiche(pointInsertion, $);
-    };
-    afficheProchainePiece();
-    this.identifiantIntervalle = setInterval(
-      afficheProchainePiece,
-      this.situation.cadenceArriveePieces()
-    );
+    });
+    this.situation.demarre();
   }
 }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,5 +1,5 @@
 import { Bac } from 'controle/modeles/bac';
-import { CHANGEMENT_ETAT, DEMARRE, FINI } from 'commun/modeles/situation';
+import { CHANGEMENT_ETAT, DEMARRE } from 'commun/modeles/situation';
 import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_piece';
 import { NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
 import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
@@ -58,9 +58,6 @@ export class VueSituation {
       vuePiece.affiche(pointInsertion, $);
       piece.on(DISPARITION_PIECE, (e) => {
         this.journal.enregistre(new EvenementDisparitionPiece({ position: piece.position() }));
-        if (this.situation.piecesEnCours().length === 0 && this.situation.sequenceTerminee()) {
-          this.situation.modifieEtat(FINI);
-        }
       });
     });
     this.situation.demarre();

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -57,7 +57,9 @@ export class VueSituation {
     this.situation.on(NOUVELLE_PIECE, (piece) => {
       const vuePiece = this.creeVuePiece(piece);
       vuePiece.affiche(pointInsertion, $);
-      piece.on(DISPARITION_PIECE, (e) => this.journal.enregistre(new EvenementDisparitionPiece({ position: piece.position() })));
+      piece.on(DISPARITION_PIECE, (e) => {
+        this.journal.enregistre(new EvenementDisparitionPiece({ position: piece.position() }));
+      });
     });
     this.situation.demarre();
   }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,10 +1,10 @@
 import { Bac } from 'controle/modeles/bac';
 import { CHANGEMENT_ETAT, DEMARRE } from 'commun/modeles/situation';
 import EvenementDisparitionPiece from 'controle/modeles/evenement_disparition_piece';
-import { NOUVELLE_PIECE } from 'controle/modeles/situation';
+import { NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
 import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
 import { VueBac } from 'controle/vues/bac';
-import { VuePiece, DISPARITION_PIECE } from 'controle/vues/piece';
+import { VuePiece } from 'controle/vues/piece';
 import VueTapis from 'controle/vues/tapis';
 
 export class VueSituation {
@@ -32,7 +32,7 @@ export class VueSituation {
   }
 
   creeVuePiece (piece) {
-    return new VuePiece(piece, this.situation.dureeViePiece(), this.callbackApresCreationPiece);
+    return new VuePiece(piece, this.callbackApresCreationPiece);
   }
 
   affiche (pointInsertion, $) {
@@ -56,8 +56,8 @@ export class VueSituation {
   demarre (pointInsertion, $) {
     this.situation.on(NOUVELLE_PIECE, (piece) => {
       const vuePiece = this.creeVuePiece(piece);
-      vuePiece.on(DISPARITION_PIECE, (e) => this.journal.enregistre(new EvenementDisparitionPiece(e)));
       vuePiece.affiche(pointInsertion, $);
+      piece.on(DISPARITION_PIECE, (e) => this.journal.enregistre(new EvenementDisparitionPiece({ position: piece.position() })));
     });
     this.situation.demarre();
   }

--- a/tests/situations/controle/modeles/piece.js
+++ b/tests/situations/controle/modeles/piece.js
@@ -1,4 +1,4 @@
-import { Piece } from 'controle/modeles/piece';
+import { Piece, CHANGEMENT_POSITION } from 'controle/modeles/piece';
 
 describe('Une pièce', function () {
   it('a une position de départ', function () {
@@ -24,7 +24,7 @@ describe('Une pièce', function () {
 
   it('notifie ses abonnés des changements de position', function (done) {
     let piece = new Piece({ x: 90, y: 50 });
-    piece.quandChangementPosition(function ({ x, y }) {
+    piece.on(CHANGEMENT_POSITION, ({ x, y }) => {
       expect(x).to.equal(35);
       expect(y).to.equal(20);
       done();

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -1,4 +1,6 @@
+import { FINI } from 'commun/modeles/situation';
 import { Situation, NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
+import { Piece } from 'controle/modeles/piece';
 
 function creeSituationMinimale () {
   return new Situation({
@@ -37,9 +39,9 @@ describe('La situation « Contrôle »', function () {
 
   it('démarre la situation et ajoute la piece dans les pieces en cours', function () {
     const situation = creeSituationMinimale();
-    expect(situation.piecesEnCours().length).to.eql(0);
+    expect(situation.piecesAffichees().length).to.eql(0);
     situation.demarre();
-    expect(situation.piecesEnCours().length).to.eql(1);
+    expect(situation.piecesAffichees().length).to.eql(1);
   });
 
   it("démarre la situation et déclenche un événement a l'ajout de la piece dans les pieces en cours", function (done) {
@@ -54,10 +56,23 @@ describe('La situation « Contrôle »', function () {
     const situation = creeSituationMinimale();
     situation.on(NOUVELLE_PIECE, (piece) => {
       piece.on(DISPARITION_PIECE, () => {
-        expect(situation.piecesEnCours().length).to.eql(0);
+        expect(situation.piecesAffichees().length).to.eql(0);
         done();
       });
     });
     situation.demarre();
+  });
+
+  it('passe la situation en fini une fois que toutes les pieces ont disparu', function () {
+    const piece1 = new Piece({});
+    const piece2 = new Piece({});
+    const situation = new Situation({ scenario: [] });
+
+    situation.ajoutePiece(piece1);
+    situation.ajoutePiece(piece2);
+    situation.faisDisparaitrePiece(piece1);
+    expect(situation.etat()).to.not.eql(FINI);
+    situation.faisDisparaitrePiece(piece2);
+    expect(situation.etat()).to.eql(FINI);
   });
 });

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -1,4 +1,12 @@
-import { Situation } from 'controle/modeles/situation';
+import { Situation, NOUVELLE_PIECE } from 'controle/modeles/situation';
+
+function creeSituationMinimale () {
+  return new Situation({
+    cadence: 0,
+    scenario: [{ conforme: false }],
+    positionApparitionPieces: { x: 25, y: 50 }
+  });
+}
 
 describe('La situation « Contrôle »', function () {
   it('connaît la cadence à laquelle arrivent les pièces', function () {
@@ -24,5 +32,20 @@ describe('La situation « Contrôle »', function () {
     expect(situation.sequenceTerminee()).to.be(true);
     expect(piece.estConforme()).to.be(false);
     expect(piece.position()).to.eql({ x: 25, y: 50 });
+  });
+
+  it('démarre la situation et ajoute la piece dans les pieces en cours', function () {
+    const situation = creeSituationMinimale();
+    expect(situation.piecesEnCours().length).to.eql(0);
+    situation.demarre();
+    expect(situation.piecesEnCours().length).to.eql(1);
+  });
+
+  it("démarre la situation et déclenche un événement a l'ajout de la piece dans les pieces en cours", function (done) {
+    const situation = creeSituationMinimale();
+    situation.on(NOUVELLE_PIECE, () => {
+      done();
+    });
+    situation.demarre();
   });
 });

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -1,10 +1,11 @@
-import { Situation, NOUVELLE_PIECE } from 'controle/modeles/situation';
+import { Situation, NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
 
 function creeSituationMinimale () {
   return new Situation({
     cadence: 0,
     scenario: [{ conforme: false }],
-    positionApparitionPieces: { x: 25, y: 50 }
+    positionApparitionPieces: { x: 25, y: 50 },
+    dureeViePiece: 1
   });
 }
 
@@ -45,6 +46,17 @@ describe('La situation « Contrôle »', function () {
     const situation = creeSituationMinimale();
     situation.on(NOUVELLE_PIECE, () => {
       done();
+    });
+    situation.demarre();
+  });
+
+  it('enleve la piece des pieces en cours apres le temps défini', function (done) {
+    const situation = creeSituationMinimale();
+    situation.on(NOUVELLE_PIECE, (piece) => {
+      piece.on(DISPARITION_PIECE, () => {
+        expect(situation.piecesEnCours().length).to.eql(0);
+        done();
+      });
     });
     situation.demarre();
   });

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -1,9 +1,10 @@
 import jsdom from 'jsdom-global';
+import { DISPARITION_PIECE } from 'controle/modeles/situation';
 import { Piece } from 'controle/modeles/piece';
-import { VuePiece, DUREE_VIE_PIECE_INFINIE, DISPARITION_PIECE } from 'controle/vues/piece';
+import { VuePiece } from 'controle/vues/piece';
 
 function creeVueMinimale (piece) {
-  return new VuePiece(piece, DUREE_VIE_PIECE_INFINIE, () => {}, () => {});
+  return new VuePiece(piece, () => {}, () => {});
 }
 
 describe('Une pièce', function () {
@@ -63,7 +64,7 @@ describe('Une pièce', function () {
 
   it("suit une séquence d'animation pour apparaître", function (done) {
     const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = new VuePiece(piece, DUREE_VIE_PIECE_INFINIE, function ($element) {
+    const vuePiece = new VuePiece(piece, function ($element) {
       expect($element.hasClass('.piece'));
       done();
     });
@@ -76,7 +77,7 @@ describe('Une pièce', function () {
     const sequenceAnimation = function ($element) {
       $element.animate({ left: '80px' }, 0).delay(5).animate({ left: '10px' }, 0);
     };
-    const vuePiece = new VuePiece(piece, DUREE_VIE_PIECE_INFINIE, sequenceAnimation);
+    const vuePiece = new VuePiece(piece, sequenceAnimation);
 
     vuePiece.affiche('#controle', $);
 
@@ -91,7 +92,7 @@ describe('Une pièce', function () {
     }, 10);
   });
 
-  it("disparaît au bout d'un certain temps", function (done) {
+  it("au moment de l'événement DISPARITION_PIECE, disparait", function (done) {
     const piece = new Piece({ x: 90, y: 40 });
 
     const callbackAvantSuppression = (_, callbackSuppression) => {
@@ -100,20 +101,9 @@ describe('Une pièce', function () {
       done();
     };
 
-    const vuePiece = new VuePiece(piece, 5, () => {}, callbackAvantSuppression);
+    const vuePiece = new VuePiece(piece, () => {}, callbackAvantSuppression);
     vuePiece.affiche('#controle', $);
     expect($('.piece').length).to.equal(1);
-  });
-
-  it('émet un événement à sa disparition', function (done) {
-    const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = new VuePiece(piece, 5, () => {}, (_, done) => done());
-
-    vuePiece.on(DISPARITION_PIECE, (e) => {
-      expect(e).to.eql({ position: { x: 90, y: 40 } });
-      done();
-    });
-
-    vuePiece.affiche('#controle', $);
+    piece.emit(DISPARITION_PIECE);
   });
 });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -1,10 +1,8 @@
 import jsdom from 'jsdom-global';
 
-import { Journal } from 'commun/modeles/journal';
 import { CHANGEMENT_ETAT, DEMARRE } from 'commun/modeles/situation';
 import { PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
 import { Situation } from 'controle/modeles/situation';
-import { DISPARITION_PIECE, DUREE_VIE_PIECE_INFINIE, VuePiece } from 'controle/vues/piece';
 import { VueSituation } from 'controle/vues/situation';
 
 function vueSituationMinimaliste (journal) {
@@ -47,10 +45,12 @@ describe('La situation « Contrôle »', function () {
       cadence: 0,
       scenario: [{ conforme: true, image: 'image-conforme' }, { conforme: false, image: 'image-defectueuse' }],
       positionApparitionPieces: { x: 10, y: 20 },
-      dureeViePiece: DUREE_VIE_PIECE_INFINIE
+      dureeViePiece: 1
     });
 
-    const journal = new Journal();
+    const journal = {
+      enregistre () {}
+    };
 
     let nbPiecesAffichees = 0;
     let imagesAttendues = ['image-conforme', 'image-defectueuse'];
@@ -65,7 +65,7 @@ describe('La situation « Contrôle »', function () {
     situation.emit(CHANGEMENT_ETAT, DEMARRE);
   });
 
-  it('écoute les événements de disparition de pièce', function (done) {
+  it('écoute les événements de disparition de pièce pour enregistrer dans le journal', function (done) {
     const situation = new Situation({
       cadence: 0,
       scenario: [true],
@@ -75,18 +75,13 @@ describe('La situation « Contrôle »', function () {
 
     const journal = {
       enregistre (e) {
-        expect(e.donnees()).to.eql({ position: { x: 45, y: 5 } });
+        expect(e.donnees()).to.eql({ position: { x: 10, y: 20 } });
         done();
       }
     };
 
     const vueSituation = new VueSituation(situation, journal, () => {});
 
-    vueSituation.creeVuePiece = (piece) => {
-      const vuePiece = new VuePiece(piece, 5, () => {}, () => {});
-      setTimeout(() => { vuePiece.emit(DISPARITION_PIECE, { position: { x: 45, y: 5 } }); });
-      return vuePiece;
-    };
     vueSituation.affiche('#point-insertion', $);
     vueSituation.demarre('#point-insertion', $);
   });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -1,12 +1,15 @@
 import jsdom from 'jsdom-global';
 
-import { NON_DEMARRE, FINI } from 'commun/modeles/situation';
 import { Piece, PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
-import { Situation, NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
+import { Situation } from 'controle/modeles/situation';
 import { VueSituation } from 'controle/vues/situation';
 
+class SituationDeTest extends Situation {
+  demarre () {}
+}
+
 function vueSituationMinimaliste (journal) {
-  const situation = new Situation({ scenario: [] });
+  const situation = new SituationDeTest({ scenario: [] });
   return new VueSituation(situation, journal);
 }
 
@@ -50,6 +53,7 @@ describe('La situation « Contrôle »', function () {
   });
 
   it('écoute les événements de disparition de pièce pour enregistrer dans le journal', function (done) {
+    $.fx.off = true;
     const journal = {
       enregistre (e) {
         expect(e.donnees()).to.eql({ position: { x: 10, y: 20 } });
@@ -58,29 +62,11 @@ describe('La situation « Contrôle »', function () {
     };
     const piece = new Piece({});
     const vueSituation = vueSituationMinimaliste(journal);
-    vueSituation.situation.demarre = () => {};
 
     vueSituation.affiche('#point-insertion', $);
     vueSituation.demarre('#point-insertion', $);
-    vueSituation.situation.emit(NOUVELLE_PIECE, piece);
+    vueSituation.situation.ajoutePiece(piece);
     piece.changePosition({ x: 10, y: 20 });
-    piece.emit(DISPARITION_PIECE);
-  });
-
-  it('passe la situation en fini une fois que toutes les pieces ont disparu', function () {
-    const journal = { enregistre (e) {} };
-    const piece = new Piece({});
-    const vueSituation = vueSituationMinimaliste(journal);
-    vueSituation.situation.demarre = () => {};
-
-    vueSituation.affiche('#point-insertion', $);
-    vueSituation.demarre('#point-insertion', $);
-    vueSituation.situation.emit(NOUVELLE_PIECE, piece);
-    vueSituation.situation.piecesEnCours().push(piece);
-    piece.emit(DISPARITION_PIECE);
-    expect(vueSituation.situation.etat()).to.eql(NON_DEMARRE);
-    vueSituation.situation.piecesEnCours().pop();
-    piece.emit(DISPARITION_PIECE);
-    expect(vueSituation.situation.etat()).to.eql(FINI);
+    vueSituation.situation.faisDisparaitrePiece(piece);
   });
 });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -1,5 +1,6 @@
 import jsdom from 'jsdom-global';
 
+import { NON_DEMARRE, FINI } from 'commun/modeles/situation';
 import { Piece, PIECE_CONFORME, PIECE_DEFECTUEUSE } from 'controle/modeles/piece';
 import { Situation, NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
 import { VueSituation } from 'controle/vues/situation';
@@ -64,5 +65,22 @@ describe('La situation « Contrôle »', function () {
     vueSituation.situation.emit(NOUVELLE_PIECE, piece);
     piece.changePosition({ x: 10, y: 20 });
     piece.emit(DISPARITION_PIECE);
+  });
+
+  it('passe la situation en fini une fois que toutes les pieces ont disparu', function () {
+    const journal = { enregistre (e) {} };
+    const piece = new Piece({});
+    const vueSituation = vueSituationMinimaliste(journal);
+    vueSituation.situation.demarre = () => {};
+
+    vueSituation.affiche('#point-insertion', $);
+    vueSituation.demarre('#point-insertion', $);
+    vueSituation.situation.emit(NOUVELLE_PIECE, piece);
+    vueSituation.situation.piecesEnCours().push(piece);
+    piece.emit(DISPARITION_PIECE);
+    expect(vueSituation.situation.etat()).to.eql(NON_DEMARRE);
+    vueSituation.situation.piecesEnCours().pop();
+    piece.emit(DISPARITION_PIECE);
+    expect(vueSituation.situation.etat()).to.eql(FINI);
   });
 });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -7,7 +7,7 @@ import { VueSituation } from 'controle/vues/situation';
 
 function vueSituationMinimaliste (journal) {
   const situation = new Situation({ scenario: [] });
-  return new VueSituation(situation, journal, () => {});
+  return new VueSituation(situation, journal);
 }
 
 describe('La situation « Contrôle »', function () {


### PR DESCRIPTION
Cette PR ajoute la gestion de la fin de la situation contrôle, une fois toutes les pièces disparu.

Elle apporte en plus un refactoring pour déplacer la logique dans le modèle contrôle, plutôt que dans la vue.

Trêve de bavardage, voici le résultat:

![controle-fin](https://user-images.githubusercontent.com/86659/55827162-db160f00-5b09-11e9-9b00-e4b1701aa69a.gif)

Contribue à #54 
