### PR TITLE
Contrôle: Détection du survol d'un bac

### DIFF
--- a/src/situations/controle/modeles/bac.js
+++ b/src/situations/controle/modeles/bac.js
@@ -38,4 +38,13 @@ export class Bac extends EventEmitter {
   etatSurvole () {
     return this._survole;
   }
+
+  contient (piece) {
+    const { x, y } = piece.position();
+    function estEntre (positionPiece, positionBac, tailleBac) {
+      return positionPiece >= positionBac && positionPiece <= positionBac + tailleBac;
+    }
+    return estEntre(x, this._position.x, this._dimensions.largeur) &&
+        estEntre(y, this._position.y, this._dimensions.hauteur);
+  }
 }

--- a/src/situations/controle/modeles/bac.js
+++ b/src/situations/controle/modeles/bac.js
@@ -1,8 +1,13 @@
-export class Bac {
+import EventEmitter from 'events';
+export const CHANGEMENT_ETAT_SURVOLE = 'changementEtatSurvole';
+
+export class Bac extends EventEmitter {
   constructor ({ categorie, x, y, largeur, hauteur }) {
+    super();
     this._categorie = categorie;
     this._dimensions = { largeur, hauteur };
     this._position = { x, y };
+    this._survole = false;
   }
 
   dimensions () {
@@ -15,5 +20,22 @@ export class Bac {
 
   categorie () {
     return this._categorie;
+  }
+
+  passeEnEtatSurvole () {
+    this.changeEtatSurvole(true);
+  }
+
+  reinitialiseEtatSurvole () {
+    this.changeEtatSurvole(false);
+  }
+
+  changeEtatSurvole (etat) {
+    this._survole = etat;
+    this.emit(CHANGEMENT_ETAT_SURVOLE, this._survole);
+  }
+
+  etatSurvole () {
+    return this._survole;
   }
 }

--- a/src/situations/controle/modeles/piece.js
+++ b/src/situations/controle/modeles/piece.js
@@ -3,6 +3,7 @@ import EventEmitter from 'events';
 export const PIECE_CONFORME = true;
 export const PIECE_DEFECTUEUSE = false;
 export const CHANGEMENT_POSITION = 'changementPosition';
+export const CHANGEMENT_SELECTION = 'changementSelection';
 
 export class Piece extends EventEmitter {
   constructor ({ x, y, conforme, image }) {
@@ -35,11 +36,16 @@ export class Piece extends EventEmitter {
 
   selectionne ({ x, y }) {
     this.decalageSelection = { dx: x - this.x, dy: y - this.y };
-    this.selectionnee = true;
+    this.changeSelection(true);
   }
 
   deselectionne () {
-    this.selectionnee = false;
+    this.changeSelection(false);
+  }
+
+  changeSelection (selectionne) {
+    this.selectionnee = selectionne;
+    this.emit(CHANGEMENT_SELECTION, selectionne);
   }
 
   deplaceSiSelectionnee ({ x, y }) {

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -1,4 +1,4 @@
-import { Piece } from 'controle/modeles/piece';
+import { Piece, CHANGEMENT_POSITION, CHANGEMENT_SELECTION } from 'controle/modeles/piece';
 import SituationCommune, { FINI } from 'commun/modeles/situation';
 
 export const NOUVELLE_PIECE = 'nouvellePiece';
@@ -77,6 +77,8 @@ export class Situation extends SituationCommune {
   ajoutePiece (piece) {
     this._piecesAffichees.push(piece);
     this.emit(NOUVELLE_PIECE, piece);
+    piece.on(CHANGEMENT_POSITION, () => this.detecteSurvol(piece));
+    piece.on(CHANGEMENT_SELECTION, () => this.reinitialiseBacs(piece));
   }
 
   faisDisparaitrePiece (piece) {
@@ -84,6 +86,22 @@ export class Situation extends SituationCommune {
     piece.emit(DISPARITION_PIECE);
     if (this.nAPlusRienAFaire()) {
       this.modifieEtat(FINI);
+    }
+  }
+
+  detecteSurvol (piece) {
+    this.bacs().forEach((bac) => {
+      if (bac.contient(piece)) {
+        bac.passeEnEtatSurvole();
+      } else {
+        bac.reinitialiseEtatSurvole();
+      }
+    });
+  }
+
+  reinitialiseBacs (piece) {
+    if (!piece.estSelectionnee()) {
+      this.bacs().forEach(bac => bac.reinitialiseEtatSurvole());
     }
   }
 }

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -13,6 +13,7 @@ export class Situation extends SituationCommune {
     this._dureeViePiece = dureeViePiece;
     this.consigneAudio = consigneAudio;
     this._piecesAffichees = [];
+    this._bacs = [];
   }
 
   cadenceArriveePieces () {
@@ -29,6 +30,14 @@ export class Situation extends SituationCommune {
 
   nAPlusRienAFaire () {
     return this._piecesAffichees.length === 0 && this.sequenceTerminee();
+  }
+
+  bacs () {
+    return this._bacs;
+  }
+
+  ajouteBac (bac) {
+    this._bacs.push(bac);
   }
 
   pieceSuivante () {

--- a/src/situations/controle/styles/bac.scss
+++ b/src/situations/controle/styles/bac.scss
@@ -1,28 +1,9 @@
 .bac {
   position: absolute;
-  border: 5px dashed;
-  opacity: .5;
-  border-radius: 1.25rem;
 
-  &.pieces-conformes {
-    background: palegreen;
-    border-color: limegreen;
-    background-image: repeating-linear-gradient(-45deg,
-      transparent,
-      transparent 20px,
-      rgba(0, 0, 0, 0.1) 20px,
-      rgba(0, 0, 0, 0.1) 40px
-    );
-  }
-
-  &.pieces-defectueuses {
-    background: lightcoral;
-    border-color: crimson;
-    background-image: repeating-linear-gradient(45deg,
-      transparent,
-      transparent 20px,
-      rgba(0, 0, 0, 0.1) 20px,
-      rgba(0, 0, 0, 0.1) 40px
-    );
+  &.survole {
+    background: white;
+    opacity: .5;
+    border-radius: 1.25rem;
   }
 }

--- a/src/situations/controle/vues/bac.js
+++ b/src/situations/controle/vues/bac.js
@@ -1,6 +1,7 @@
 import 'controle/styles/bac.scss';
 
 import { PIECE_CONFORME } from 'controle/modeles/piece';
+import { CHANGEMENT_ETAT_SURVOLE } from 'controle/modeles/bac';
 
 export class VueBac {
   constructor (bac) {
@@ -22,13 +23,18 @@ export class VueBac {
       largeurParent: $elementParent.width(),
       hauteurParent: $elementParent.height()
     };
-    const $bac = creeElementBac(
+    this.$bac = creeElementBac(
       this.bac.categorie(),
       this.bac.position(),
       this.bac.dimensions(),
       dimensionsElementParent
     );
 
-    $elementParent.append($bac);
+    $elementParent.append(this.$bac);
+    this.bac.on(CHANGEMENT_ETAT_SURVOLE, (etat) => this.changeEtatSurvole(etat));
+  }
+
+  changeEtatSurvole (etatSurvole) {
+    this.$bac.toggleClass('survole', etatSurvole);
   }
 }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -15,21 +15,15 @@ export class VueSituation {
     }
 
     function creeBacs () {
-      const bacs = [];
-      bacs.push(nouveauBac(PIECE_CONFORME, { x: 15.6, y: 12 }));
-      bacs.push(nouveauBac(PIECE_DEFECTUEUSE, { x: 60, y: 12 }));
-      return bacs;
+      situation.ajouteBac(nouveauBac(PIECE_CONFORME, { x: 15.6, y: 12 }));
+      situation.ajouteBac(nouveauBac(PIECE_DEFECTUEUSE, { x: 60, y: 12 }));
     }
+    creeBacs();
 
     this.situation = situation;
     this.journal = journal;
-    this._bacs = creeBacs();
     this.tapis = new VueTapis(situation);
     this.fondSonore = new VueFondSonore(situation);
-  }
-
-  bacs () {
-    return this._bacs;
   }
 
   creeVuePiece (piece) {
@@ -44,7 +38,7 @@ export class VueSituation {
 
     $(pointInsertion).addClass('controle');
 
-    this._bacs.forEach(afficheBac);
+    this.situation.bacs().forEach(afficheBac);
     this.tapis.affiche(pointInsertion, $);
     this.fondSonore.affiche(pointInsertion, $);
 

--- a/tests/situations/controle/modeles/bac.js
+++ b/tests/situations/controle/modeles/bac.js
@@ -1,4 +1,4 @@
-import { Bac } from 'controle/modeles/bac';
+import { Bac, CHANGEMENT_ETAT_SURVOLE } from 'controle/modeles/bac';
 import { PIECE_CONFORME } from 'controle/modeles/piece';
 
 describe('un bac', function () {
@@ -15,5 +15,32 @@ describe('un bac', function () {
   it('sait quel catégorie de pièces accueillir', function () {
     const bac = new Bac({ categorie: PIECE_CONFORME });
     expect(bac.categorie()).to.equal(PIECE_CONFORME);
+  });
+
+  it('peut être passé en état survolé', function () {
+    const bac = new Bac({ categorie: PIECE_CONFORME });
+    expect(bac.etatSurvole()).to.be(false);
+    bac.passeEnEtatSurvole();
+    expect(bac.etatSurvole()).to.be(true);
+  });
+
+  it("l'état survolé peut être réinitialisé", function () {
+    const bac = new Bac({ categorie: PIECE_CONFORME });
+    bac.passeEnEtatSurvole();
+    expect(bac.etatSurvole()).to.be(true);
+    bac.reinitialiseEtatSurvole();
+    expect(bac.etatSurvole()).to.be(false);
+  });
+
+  it("notifie le changement d'état survolé", function () {
+    let changementEtatSurvole = 0;
+    const bac = new Bac({});
+    bac.on(CHANGEMENT_ETAT_SURVOLE, () => {
+      changementEtatSurvole++;
+    });
+    bac.passeEnEtatSurvole();
+    expect(changementEtatSurvole).to.equal(1);
+    bac.reinitialiseEtatSurvole();
+    expect(changementEtatSurvole).to.equal(2);
   });
 });

--- a/tests/situations/controle/modeles/bac.js
+++ b/tests/situations/controle/modeles/bac.js
@@ -1,5 +1,5 @@
 import { Bac, CHANGEMENT_ETAT_SURVOLE } from 'controle/modeles/bac';
-import { PIECE_CONFORME } from 'controle/modeles/piece';
+import { Piece, PIECE_CONFORME } from 'controle/modeles/piece';
 
 describe('un bac', function () {
   it('connaît ses dimensions', function () {
@@ -42,5 +42,23 @@ describe('un bac', function () {
     expect(changementEtatSurvole).to.equal(1);
     bac.reinitialiseEtatSurvole();
     expect(changementEtatSurvole).to.equal(2);
+  });
+
+  it('il sait si une pièce est posé dessus', function () {
+    const bac = new Bac({ x: 10, y: 20, largeur: 10, hauteur: 20 });
+    const piece = new Piece({ x: 13, y: 30 });
+    expect(bac.contient(piece)).to.be(true);
+  });
+
+  it("il sait si une pièce n'est pas posé dessus", function () {
+    const bac = new Bac({ x: 10, y: 20, largeur: 10, hauteur: 20 });
+    const piece = new Piece({ x: 5, y: 5 });
+    expect(bac.contient(piece)).to.be(false);
+  });
+
+  it("il sait si une autre pièce n'est pas posé dessus", function () {
+    const bac = new Bac({ x: 10, y: 20, largeur: 10, hauteur: 20 });
+    const piece = new Piece({ x: 15, y: 45 });
+    expect(bac.contient(piece)).to.be(false);
   });
 });

--- a/tests/situations/controle/modeles/piece.js
+++ b/tests/situations/controle/modeles/piece.js
@@ -1,4 +1,4 @@
-import { Piece, CHANGEMENT_POSITION } from 'controle/modeles/piece';
+import { Piece, CHANGEMENT_POSITION, CHANGEMENT_SELECTION } from 'controle/modeles/piece';
 
 describe('Une pièce', function () {
   it('a une position de départ', function () {
@@ -48,6 +48,12 @@ describe('Une pièce', function () {
 
     piece.deselectionne();
     expect(piece.estSelectionnee()).to.be(false);
+  });
+
+  it("notifie lorsqu'elle est sélectionné ou non", function (done) {
+    const piece = new Piece({ x: 90, y: 50 });
+    piece.on(CHANGEMENT_SELECTION, () => done());
+    piece.selectionne({ x: 95, y: 65 });
   });
 
   it('peut être déplacée quand sélectionnée', function () {

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -1,5 +1,6 @@
 import { FINI } from 'commun/modeles/situation';
 import { Situation, NOUVELLE_PIECE, DISPARITION_PIECE } from 'controle/modeles/situation';
+import { Bac } from 'controle/modeles/bac';
 import { Piece } from 'controle/modeles/piece';
 
 function creeSituationMinimale () {
@@ -74,5 +75,11 @@ describe('La situation « Contrôle »', function () {
     expect(situation.etat()).to.not.eql(FINI);
     situation.faisDisparaitrePiece(piece2);
     expect(situation.etat()).to.eql(FINI);
+  });
+
+  it('on peut lui ajouter des bacs', function () {
+    const situation = new Situation({ scenario: [] });
+    situation.ajouteBac(new Bac({}));
+    expect(situation.bacs().length).to.eql(1);
   });
 });

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -82,4 +82,41 @@ describe('La situation « Contrôle »', function () {
     situation.ajouteBac(new Bac({}));
     expect(situation.bacs().length).to.eql(1);
   });
+
+  describe('avec un bac et une pièce sélectionnée', function () {
+    let piece;
+    let bac;
+    let situation;
+
+    beforeEach(function () {
+      piece = new Piece({});
+      bac = new Bac({});
+      situation = new Situation({ scenario: [] });
+
+      situation.ajouteBac(bac);
+      situation.ajoutePiece(piece);
+
+      piece.selectionne({ x: 0, y: 0 });
+    });
+
+    it("il change l'état survolé du bac", function (done) {
+      bac.contient = () => true;
+      bac.passeEnEtatSurvole = done;
+
+      piece.deplaceSiSelectionnee({ x: 0, y: 0 });
+    });
+
+    it("réinitialise l'état survolé du bac", function (done) {
+      bac.contient = () => false;
+      bac.reinitialiseEtatSurvole = done;
+
+      piece.deplaceSiSelectionnee({ x: 0, y: 0 });
+    });
+
+    it('réinitialise au changement de sélection', function (done) {
+      bac.reinitialiseEtatSurvole = done;
+
+      piece.deselectionne();
+    });
+  });
 });

--- a/tests/situations/controle/vues/bac.js
+++ b/tests/situations/controle/vues/bac.js
@@ -56,4 +56,15 @@ describe("La vue d'un bac", function () {
     expect($('.bac.pieces-defectueuses').length).to.equal(1);
     expect($('.bac.pieces-conformes').length).to.equal(0);
   });
+
+  it("s'abonne au changement d'état survolé", function () {
+    const bac = new Bac({});
+    const vue = new VueBac(bac);
+    vue.affiche('#controle', $);
+    expect($('.bac.survole').length).to.equal(0);
+    bac.passeEnEtatSurvole();
+    expect($('.bac.survole').length).to.equal(1);
+    bac.reinitialiseEtatSurvole();
+    expect($('.bac.survole').length).to.equal(0);
+  });
 });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -34,9 +34,9 @@ describe('La situation « Contrôle »', function () {
     expect($('#point-insertion .tapis').length).to.equal(1);
   });
 
-  it('connaît les bacs associés à la vue', function () {
+  it('enregistre les bacs associés à la situation', function () {
     const vueSituation = vueSituationMinimaliste();
-    const bacs = vueSituation.bacs();
+    const bacs = vueSituation.situation.bacs();
 
     expect(bacs.length).to.equal(2);
     expect(bacs[0].categorie()).to.equal(PIECE_CONFORME);


### PR DESCRIPTION
- La situation connaît désormais ses bacs.
- Les bacs peuvent avoir un effet survolé
- Les pièces émettent des événement lorsqu'ils sont {dé,}-sélectionné
- Les bacs ont une méthode `contient(piece)`
- La situation écoute les différents événements des pièces pour détecter le survol d'un bac et changer l'état des bacs en conséquence

La détection pour savoir si la pièce est au dessus d'un bac est plutôt basique pour le moment. Mais on pourra l'améliorer plus tard quand on connaîtra les dimensions d'une pièce.

![drag_bac](https://user-images.githubusercontent.com/86659/56037731-5527dd00-5d30-11e9-98ae-2a266bf3005f.gif)
