### PR TITLE
Fix la confirmation pour quitter la page lors de l'appui sur stop

### DIFF
--- a/src/situations/commun/modeles/situation.js
+++ b/src/situations/commun/modeles/situation.js
@@ -5,6 +5,7 @@ export const LECTURE_CONSIGNE = 'lectureConsigne';
 export const CONSIGNE_ECOUTEE = 'consigneEcoutée';
 export const DEMARRE = 'démarré';
 export const FINI = 'fini';
+export const STOPPEE = 'stoppée';
 
 export const CHANGEMENT_ETAT = 'changementEtat';
 

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -10,9 +10,10 @@ export default class VueActions {
 
   affiche (pointInsertion, $) {
     this.$actions = $('<div class="actions"></div>');
-    const stop = new VueStop(this.$actions, $, this.journal);
-    stop.affiche();
     $(pointInsertion).append(this.$actions);
+
+    const stop = new VueStop(this.journal);
+    stop.affiche('.actions', $);
   }
 
   cache () {

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -4,7 +4,8 @@ import 'commun/styles/stop.scss';
 import VueStop from 'commun/vues/stop';
 
 export default class VueActions {
-  constructor (journal) {
+  constructor (situation, journal) {
+    this.situation = situation;
     this.journal = journal;
   }
 
@@ -12,7 +13,7 @@ export default class VueActions {
     this.$actions = $('<div class="actions"></div>');
     $(pointInsertion).append(this.$actions);
 
-    const stop = new VueStop(this.journal);
+    const stop = new VueStop(this.situation, this.journal);
     stop.affiche('.actions', $);
   }
 

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -10,7 +10,7 @@ export default class VueCadre {
   constructor (vueSituation, situation, journal) {
     this.vueSituation = vueSituation;
     this.situation = situation;
-    this.vueActions = new VueActions(journal);
+    this.vueActions = new VueActions(situation, journal);
     this.etats = new Map();
     this.etats.set(NON_DEMARRE, VueJoue);
     this.etats.set(LECTURE_CONSIGNE, VueConsigne);

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -1,5 +1,5 @@
 import 'commun/styles/cadre.scss';
-import { NON_DEMARRE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, FINI, CHANGEMENT_ETAT } from 'commun/modeles/situation';
+import { NON_DEMARRE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, FINI, CHANGEMENT_ETAT, STOPPEE } from 'commun/modeles/situation';
 import VueActions from 'commun/vues/actions';
 import VueJoue from 'commun/vues/joue';
 import VueConsigne from 'commun/vues/consigne';
@@ -51,7 +51,7 @@ export default class VueCadre {
 
   previentLaFermetureDeLaSituation ($) {
     $(window).on('beforeunload', (e) => {
-      if (![NON_DEMARRE, FINI].includes(this.situation.etat())) {
+      if (![NON_DEMARRE, FINI, STOPPEE].includes(this.situation.etat())) {
         e.preventDefault();
         return '';
       }

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -1,14 +1,16 @@
 import { traduction } from 'commun/infra/internationalisation';
 import EvenementStop from 'commun/modeles/evenement_stop';
+import { STOPPEE } from 'commun/modeles/situation';
 import stop from 'commun/assets/stop.svg';
 
 import 'commun/styles/stop.scss';
 import { afficheFenetreModale } from 'commun/vues/modale';
 
 export default class VueStop {
-  constructor (journal, retourAccueil = () => {
+  constructor (situation, journal, retourAccueil = () => {
     window.location.assign('/');
   }) {
+    this.situation = situation;
     this.journal = journal;
     this.retourAccueil = retourAccueil;
   }
@@ -28,6 +30,7 @@ export default class VueStop {
   }
 
   clickSurOk () {
+    this.situation.modifieEtat(STOPPEE);
     return this.journal
       .enregistre(new EvenementStop())
       .then(() => {

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -6,27 +6,25 @@ import 'commun/styles/stop.scss';
 import { afficheFenetreModale } from 'commun/vues/modale';
 
 export default class VueStop {
-  constructor (pointInsertion, $, journal, retourAccueil = () => {
+  constructor (journal, retourAccueil = () => {
     window.location.assign('/');
   }) {
     this.journal = journal;
     this.retourAccueil = retourAccueil;
-    this.$pointInsertion = $(pointInsertion);
+  }
+
+  affiche (pointInsertion, $) {
     this.$boutonStop = $('<a id="stop" class="bouton-stop"></a>');
     this.$boutonStop.append(`<img src='${stop}'>`);
-
     this.$boutonStop.on('click', () => {
       afficheFenetreModale(
-        this.$pointInsertion,
+        $(pointInsertion),
         $,
         traduction('situation.stop'),
         this.clickSurOk.bind(this)
       );
     });
-  }
-
-  affiche () {
-    this.$pointInsertion.append(this.$boutonStop);
+    $(pointInsertion).append(this.$boutonStop);
   }
 
   clickSurOk () {

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
 
-import SituationCommune, { CHANGEMENT_ETAT, NON_DEMARRE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI } from 'commun/modeles/situation';
+import SituationCommune, { CHANGEMENT_ETAT, NON_DEMARRE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI, STOPPEE } from 'commun/modeles/situation';
 import VueCadre from 'commun/vues/cadre';
 import MockAudio from '../../commun/aides/mock_audio';
 
@@ -102,7 +102,7 @@ describe('Une vue du cadre', function () {
   it("ne demande pas une confirmation pour quitter la page lorsque la situation n'a pas démarré", function () {
     const vueCadre = new VueCadre(uneVue(), situation);
     vueCadre.affiche('#point-insertion', $);
-    [FINI, NON_DEMARRE].forEach((etat) => {
+    [FINI, NON_DEMARRE, STOPPEE].forEach((etat) => {
       situation.modifieEtat(etat);
       const event = $.Event('beforeunload');
       $(window).trigger(event);

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -1,6 +1,7 @@
 import jsdom from 'jsdom-global';
 import VueStop from 'commun/vues/stop';
 import EvenementStop from 'commun/modeles/evenement_stop';
+import Situation, { STOPPEE } from 'commun/modeles/situation';
 
 import i18next from 'i18next';
 i18next.init({
@@ -14,6 +15,7 @@ describe('vue Stop', function () {
   let $;
   let retourAccueil = false;
   let mockJournal;
+  let situation;
 
   beforeEach(function () {
     jsdom('<div id="magasin"></div>');
@@ -21,7 +23,8 @@ describe('vue Stop', function () {
     mockJournal = {
       enregistre () {}
     };
-    vue = new VueStop(mockJournal, () => {
+    situation = new Situation();
+    vue = new VueStop(situation, mockJournal, () => {
       retourAccueil = true;
     });
   });
@@ -45,6 +48,7 @@ describe('vue Stop', function () {
       return Promise.resolve();
     };
     vue.clickSurOk().then(() => {
+      expect(situation.etat()).to.eql(STOPPEE);
       expect(retourAccueil).to.equal(true);
       done();
     });

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -21,25 +21,25 @@ describe('vue Stop', function () {
     mockJournal = {
       enregistre () {}
     };
-    vue = new VueStop('#magasin', $, mockJournal, () => {
+    vue = new VueStop(mockJournal, () => {
       retourAccueil = true;
     });
   });
 
   it("sait s'insérer dans une page web", function () {
-    vue.affiche();
+    vue.affiche('#magasin', $);
     expect(document.querySelector('#magasin #stop').classList).to.not.contain('invisible');
   });
 
   it('ouvre une fenêtre de confirmation avant de stopper', function () {
-    vue.affiche();
+    vue.affiche('#magasin', $);
 
     $('#magasin #stop').click();
     expect($('#fenetre-modale').length).to.equal(1);
     expect($('label').text()).to.equal('situation.stop');
   });
 
-  it("Enregistre l'événément et redirige vers l'accueil quand on confirme la modale", function (done) {
+  it("enregistre l'événement et redirige vers l'accueil quand on confirme la modale", function (done) {
     mockJournal.enregistre = (evenement) => {
       expect(evenement).to.be.a(EvenementStop);
       return Promise.resolve();


### PR DESCRIPTION
Lors de la confirmation du stop lorsque la situation a démarré, on avait une confirmation en plus du à #163. 
La raison était que l'état de la situation était toujours `démarré`. Désormais l'état passe à `stoppée`, qui permet de ne pas afficher la confirmation du navigateur.

Fix #186 