### PR TITLE
Controle: change la gestion du déplacement des pièces

### DIFF
--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -91,6 +91,10 @@ export class Situation extends SituationCommune {
     this._piecesAffichees.splice(this._piecesAffichees.indexOf(piece), 1);
     piece.emit(DISPARITION_PIECE);
 
+    if (piece.estSelectionnee()) {
+      this.bacs().forEach((bac) => bac.reinitialiseEtatSurvole());
+    }
+
     const bac = this.bacs().find((bac) => bac.contient(piece));
     if (bac) {
       const evenement = bac.correspondALaCategorie(piece) ? PIECE_BIEN_PLACEE : PIECE_MAL_PLACEE;

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -59,13 +59,6 @@ export class VuePiece extends EventEmitter {
     $piece.on('dragstart', function (event) { event.preventDefault(); });
     $piece.mouseup(e => { this.piece.deselectionne(); });
 
-    $elementParent.mousemove(e => {
-      this.piece.deplaceSiSelectionnee({
-        x: 100 * e.clientX / $elementParent.width(),
-        y: 100 * e.clientY / $elementParent.height()
-      });
-    });
-
     this.piece.on(CHANGEMENT_POSITION, (nouvellePosition) => {
       metsAJourPosition($piece, nouvellePosition, dimensionsElementParent);
     });

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -39,7 +39,8 @@ export class VueSituation {
       vueBac.affiche(pointInsertion, $);
     }
 
-    $(pointInsertion).addClass('controle');
+    const $situation = $(pointInsertion);
+    $situation.addClass('controle');
 
     this.situation.bacs().forEach(afficheBac);
     this.tapis.affiche(pointInsertion, $);
@@ -50,6 +51,16 @@ export class VueSituation {
         this.journal.enregistre(new EvenementDemarrage());
         this.demarre(pointInsertion, $);
       }
+    });
+
+    $situation.mousemove(e => {
+      const piecesAffichees = this.situation.piecesAffichees();
+      piecesAffichees.forEach(p => {
+        p.deplaceSiSelectionnee({
+          x: 100 * e.clientX / $situation.width(),
+          y: 100 * e.clientY / $situation.height()
+        });
+      });
     });
   }
 

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -162,5 +162,20 @@ describe('La situation « Contrôle »', function () {
 
       piece.deselectionne();
     });
+
+    it("réinitialise l'état survolé des bacs lors de la disparition de la pièce", function (done) {
+      bac.reinitialiseEtatSurvole = done;
+
+      situation.faisDisparaitrePiece(piece);
+    });
+
+    it("ne réinitialise pas l'état survolé des bacs lorsque la pièce n'est pas sélectionné", function () {
+      let nbReinitialiseEtatSurvole = 0;
+      piece.deselectionne();
+      bac.reinitialiseEtatSurvole = () => nbReinitialiseEtatSurvole++;
+
+      situation.faisDisparaitrePiece(piece);
+      expect(nbReinitialiseEtatSurvole).to.equal(0);
+    });
   });
 });

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -42,21 +42,39 @@ describe('Une pièce', function () {
     expect($('.piece').css('top')).to.eql('20px');
   });
 
-  it('peut être déplacée', function () {
+  it('peut être sélectionnée', function () {
     const piece = new Piece({ x: 90, y: 40 });
     const vuePiece = creeVueMinimale(piece);
     vuePiece.affiche('#controle', $);
+
+    expect(piece.estSelectionnee()).to.be(false);
+    $('.piece').trigger($.Event('mousedown', { clientX: 95, clientY: 55 }));
+    expect(piece.estSelectionnee()).to.be(true);
+  });
+
+  it('peut être désélectionnée', function () {
+    const piece = new Piece({ x: 90, y: 40 });
+    piece.selectionne({ x: 95, y: 55 });
+
+    const vuePiece = creeVueMinimale(piece);
+    vuePiece.affiche('#controle', $);
+
+    expect(piece.estSelectionnee()).to.be(true);
+    $('.piece').trigger($.Event('mouseup'));
+    expect(piece.estSelectionnee()).to.be(false);
+  });
+
+  it('peut être bougée', function () {
+    const piece = new Piece({ x: 90, y: 40 });
+    const vuePiece = creeVueMinimale(piece);
+
+    $('#controle').width(100).height(100);
+    vuePiece.affiche('#controle', $);
+
     expect($('.piece').css('left')).to.eql('90px');
     expect($('.piece').css('top')).to.eql('40px');
 
-    const $piece = $('.piece');
-    const $elementParent = $('#controle');
-    const evenementSelectionner = $.Event('mousedown', { clientX: 95, clientY: 55 });
-    const evenementGlisser = $.Event('mousemove', { clientX: 30, clientY: 20 });
-    const evenementDeposer = $.Event('mouseup');
-    $piece.trigger(evenementSelectionner);
-    $elementParent.trigger(evenementGlisser);
-    $piece.trigger(evenementDeposer);
+    piece.changePosition({ x: 25, y: 5 });
 
     expect($('.piece').css('left')).to.eql('25px');
     expect($('.piece').css('top')).to.eql('5px');

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -74,6 +74,21 @@ describe('La situation « Contrôle »', function () {
     vueSituation.situation.emit(CHANGEMENT_ETAT, DEMARRE);
   });
 
+  it('déplace les pièces sélectionnées', function () {
+    const piece = new Piece({ x: 95, y: 55 });
+    const vueSituation = vueSituationMinimaliste();
+    const $pointInsertion = $('#point-insertion');
+
+    piece.selectionne({ x: 95, y: 55 });
+    $pointInsertion.width(50).height(200);
+    vueSituation.affiche('#point-insertion', $);
+    vueSituation.situation.ajoutePiece(piece);
+
+    $pointInsertion.trigger($.Event('mousemove', { clientX: 30, clientY: 20 }));
+
+    expect(piece.position()).to.eql({ x: 60, y: 10 });
+  });
+
   describe('avec une situation démarrée, une pièce et un journal', function () {
     let journal;
     let piece;


### PR DESCRIPTION
La gestion du déplacement des pièces qui était géré par la vue pièce est désormais géré au niveau de la vue situation. Cela a pour effet de corriger un bug une fois que la pièce a disparu alors qu'elle était en cours de déplacement. Fix #187.

De plus au moment de la disparition, si la pièce était au dessus d'un bac, l'état survolé était toujours actif sur le bac.