### PR TITLE
Désactive la sélection des choses par le navigateur.

### DIFF
--- a/src/situations/commun/styles/conteneur.scss
+++ b/src/situations/commun/styles/conteneur.scss
@@ -3,4 +3,9 @@
   height: 41.875rem;
   margin: auto;
   position: relative;
+
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 }


### PR DESCRIPTION
Cela prévient la sélection des choses dans les situations comme dans la capture d'écran suivante:

![Screenshot_2019-04-17 Chaîne de fabrication](https://user-images.githubusercontent.com/86659/56282746-2931a080-6110-11e9-86ee-de83e0950a40.png)

