### PR TITLE
[Contrôle] empêcher le déplacement de deux pièces simultanées

### DIFF
--- a/src/situations/controle/styles/piece.scss
+++ b/src/situations/controle/styles/piece.scss
@@ -2,4 +2,8 @@
   display: block;
   position: absolute;
   width: 10%;
+
+  &.selectionnee {
+    z-index: 100;
+  }
 }

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -70,6 +70,7 @@ export class VuePiece extends EventEmitter {
       metsAJourPosition($piece, nouvellePosition, dimensionsElementParent);
     });
     this.piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
+      $elementParent.append($piece);
       $piece.toggleClass('selectionnee', selectionnee);
     });
     $elementParent.append($piece);

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 
 import 'controle/styles/piece.scss';
 
-import { CHANGEMENT_POSITION } from 'controle/modeles/piece';
+import { CHANGEMENT_POSITION, CHANGEMENT_SELECTION } from 'controle/modeles/piece';
 import { DISPARITION_PIECE } from 'controle/modeles/situation';
 
 export function animationInitiale ($element) {
@@ -68,6 +68,9 @@ export class VuePiece extends EventEmitter {
 
     this.piece.on(CHANGEMENT_POSITION, (nouvellePosition) => {
       metsAJourPosition($piece, nouvellePosition, dimensionsElementParent);
+    });
+    this.piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
+      $piece.toggleClass('selectionnee', selectionnee);
     });
     $elementParent.append($piece);
     $piece.show(() => { this.callbackApresApparition($piece); });

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -115,4 +115,14 @@ describe('Une pièce', function () {
     piece.selectionne({ x: 0, y: 0 });
     expect($('.piece.selectionnee').length).to.equal(1);
   });
+
+  it("réordonne la pièce sélectionnée pour la placer en dernier dans l'élément parent", function () {
+    const piece = new Piece({});
+    const vuePiece = creeVueMinimale(piece);
+    vuePiece.affiche('#controle', $);
+    $('#controle').append(`<div class="element"></div>`);
+    expect($('.piece').index()).to.equal(0);
+    piece.selectionne({ x: 0, y: 0 });
+    expect($('.piece').index()).to.equal(1);
+  });
 });

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -106,4 +106,13 @@ describe('Une pièce', function () {
     expect($('.piece').length).to.equal(1);
     piece.emit(DISPARITION_PIECE);
   });
+
+  it("rajoute la classe selectionne lorsqu'elle est sélectionné", function () {
+    const piece = new Piece({});
+    const vuePiece = creeVueMinimale(piece);
+    vuePiece.affiche('#controle', $);
+    expect($('.piece.selectionnee').length).to.equal(0);
+    piece.selectionne({ x: 0, y: 0 });
+    expect($('.piece.selectionnee').length).to.equal(1);
+  });
 });


### PR DESCRIPTION
Auparavant, en suivant le scénario décrit dans #196, il était possible de déplacer deux pièces simultanément.

![selection-simultanees2](https://user-images.githubusercontent.com/86659/56291731-1de96f80-6126-11e9-8f62-f5e47f9584be.gif)

Désormais, la pièce sélectionnée a un z-index plus grand qui lui permet d'éviter ce genre de problèmes.

De plus les pièces qui sont sélectionnée sont réordonnées dans le DOM (en dernier pour préserver l'ordre naturel.

![selection-simultanees-apres](https://user-images.githubusercontent.com/86659/56291979-8d5f5f00-6126-11e9-851a-dcbb0c6c4355.gif)

Fix #196 
