### PR TITLE
Barre d'outils de développement dans les situations

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -16,6 +16,10 @@
     "retour_stock": "Retour au stock"
   },
   "situation": {
+    "barre-dev": {
+      "muet": "Rendre muet",
+      "sonore": "Rendre sonore"
+    },
     "ecouter-consigne": "Commencez par écouter la consigne",
     "erreur_chargement": "Erreur de chargement. Veuillez rééssayer.",
     "chargement": "Chargement en cours",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -17,7 +17,9 @@
   },
   "situation": {
     "barre-dev": {
+      "confirmation": "Avoir une confirmation en quittant",
       "muet": "Rendre muet",
+      "pas-confirmation": "Désactiver la confirmation en quittant",
       "sonore": "Rendre sonore"
     },
     "ecouter-consigne": "Commencez par écouter la consigne",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -17,7 +17,7 @@
   },
   "situation": {
     "barre-dev": {
-      "confirmation": "Avoir une confirmation en quittant",
+      "confirmation": "Activer la confirmation en quittant",
       "muet": "Rendre muet",
       "pas-confirmation": "Désactiver la confirmation en quittant",
       "sonore": "Rendre sonore"

--- a/src/situations/commun/infra/preferences_dev.js
+++ b/src/situations/commun/infra/preferences_dev.js
@@ -1,4 +1,5 @@
 const PREFERENCE_ETAT_MUET = 'situation.muet';
+const PREFERENCE_ETAT_CONFIRMATION_QUITTER = 'situation.confirmation-quitter-en-cours';
 
 export default class PreferencesDev {
   enregistreEtatMuet (muet) {
@@ -7,5 +8,13 @@ export default class PreferencesDev {
 
   consulteEtatMuet () {
     return window.localStorage.getItem(PREFERENCE_ETAT_MUET);
+  }
+
+  consulteEtatConfirmationQuitterEnCours () {
+    return window.localStorage.getItem(PREFERENCE_ETAT_CONFIRMATION_QUITTER);
+  }
+
+  enregistreEtatConfirmationQuitterEnCours (confirmation) {
+    window.localStorage.setItem(PREFERENCE_ETAT_CONFIRMATION_QUITTER, confirmation);
   }
 }

--- a/src/situations/commun/infra/preferences_dev.js
+++ b/src/situations/commun/infra/preferences_dev.js
@@ -1,0 +1,11 @@
+const PREFERENCE_ETAT_MUET = 'situation.muet';
+
+export default class PreferencesDev {
+  enregistreEtatMuet (muet) {
+    window.localStorage.setItem(PREFERENCE_ETAT_MUET, muet);
+  }
+
+  consulteEtatMuet () {
+    return window.localStorage.getItem(PREFERENCE_ETAT_MUET);
+  }
+}

--- a/src/situations/commun/styles/barre_dev.scss
+++ b/src/situations/commun/styles/barre_dev.scss
@@ -10,5 +10,7 @@
 
   button {
     @include bouton-carre($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
+    width: auto;
+    min-width: 4rem;
   }
 }

--- a/src/situations/commun/styles/barre_dev.scss
+++ b/src/situations/commun/styles/barre_dev.scss
@@ -1,0 +1,18 @@
+@import './bouton.scss';
+
+.barre-dev {
+  border-top: 1px solid black;
+  background-color: gray;
+  width: 100vw;
+  display: flex;
+  justify-content: space-between;
+  padding: 5px;
+
+  .bouton-go {
+    @include bouton-carre($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
+  }
+
+  .bouton-fini {
+    @include bouton-carre($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
+  }
+}

--- a/src/situations/commun/styles/barre_dev.scss
+++ b/src/situations/commun/styles/barre_dev.scss
@@ -2,7 +2,6 @@
 
 .barre-dev {
   border-top: 1px solid black;
-  background-color: gray;
   width: 100vw;
   display: flex;
   justify-content: space-between;

--- a/src/situations/commun/styles/barre_dev.scss
+++ b/src/situations/commun/styles/barre_dev.scss
@@ -8,11 +8,7 @@
   justify-content: space-between;
   padding: 5px;
 
-  .bouton-go {
-    @include bouton-carre($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
-  }
-
-  .bouton-fini {
+  button {
     @include bouton-carre($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
   }
 }

--- a/src/situations/commun/styles/bouton.scss
+++ b/src/situations/commun/styles/bouton.scss
@@ -21,6 +21,12 @@
     box-shadow: inset 0px 0px 0px 3px $couleur-fond;
   }
 
+  &[disabled] {
+    opacity: .5;
+    background-color: $couleur-fond;
+    cursor: default;
+  }
+
   img {
     position: relative;
     margin: auto;

--- a/src/situations/commun/vues/affiche_situation.js
+++ b/src/situations/commun/vues/affiche_situation.js
@@ -2,6 +2,7 @@ import uuidv4 from 'uuid/v4';
 
 import DepotJournal from 'commun/infra/depot_journal';
 import ChargeurRessources from 'commun/infra/chargeur_ressources';
+import PreferencesDev from 'commun/infra/preferences_dev';
 import Journal from 'commun/modeles/journal';
 import VueCadre from 'commun/vues/cadre';
 import { initialise as initialiseInternationalisation, traduction } from 'commun/infra/internationalisation';
@@ -21,8 +22,8 @@ export function afficheSituation (nomSituation, modeleSituation, VueSituation, c
     const ressourcesSituation = contexte.keys().map(contexte);
     chargeurRessources.charge(ressourcesSituation);
 
-    const barreDev = process.env.NODE_ENV !== 'production';
-    const vueCadre = new VueCadre(vueSituation, modeleSituation, journal, chargeurRessources, barreDev);
+    const preferencesDev = process.env.NODE_ENV !== 'production' ? new PreferencesDev() : null;
+    const vueCadre = new VueCadre(vueSituation, modeleSituation, journal, chargeurRessources, preferencesDev);
     vueCadre.affiche(pointInsertion, $);
   }
 

--- a/src/situations/commun/vues/affiche_situation.js
+++ b/src/situations/commun/vues/affiche_situation.js
@@ -21,7 +21,8 @@ export function afficheSituation (nomSituation, modeleSituation, VueSituation, c
     const ressourcesSituation = contexte.keys().map(contexte);
     chargeurRessources.charge(ressourcesSituation);
 
-    const vueCadre = new VueCadre(vueSituation, modeleSituation, journal, chargeurRessources);
+    const barreDev = process.env.NODE_ENV !== 'production';
+    const vueCadre = new VueCadre(vueSituation, modeleSituation, journal, chargeurRessources, barreDev);
     vueCadre.affiche(pointInsertion, $);
   }
 

--- a/src/situations/commun/vues/barre_dev.js
+++ b/src/situations/commun/vues/barre_dev.js
@@ -21,14 +21,18 @@ export default class VueBareDev {
     const $muet = $(`<button class="bouton-muet"></button>`);
     $muet.on('click', () => { this.basculeEtatMuet(pointInsertion, $); });
 
+    const $confirmation = $(`<button class="bouton-confirmation"></button>`);
+    $confirmation.on('click', () => { this.basculeEtatConfirmationQuitterEnCours(pointInsertion, $); });
+
     const $fini = $('<button class="bouton-fini">FIN</button>');
     $fini.on('click', () => {
       this.situation.modifieEtat(FINI);
     });
-    $div.append($go, $muet, $fini);
+    $div.append($go, $muet, $confirmation, $fini);
     $(pointInsertion).append($div);
 
     this.metAJourEtatMuet(pointInsertion, $, this.etatMuet());
+    this.metAjourConfirmationQuitterEnCours(pointInsertion, $, this.confirmationQuitterEnCours());
     this.situation.on(CHANGEMENT_ETAT, () => {
       this.metAJourEtat(pointInsertion, $);
     });
@@ -51,9 +55,8 @@ export default class VueBareDev {
     const muet = this.preferencesDev.consulteEtatMuet();
     if (muet === null) {
       return false;
-    } else {
-      return muet === 'true';
     }
+    return muet === 'true';
   }
 
   metAJourEtatMuet (pointInsertion, $, muet) {
@@ -63,5 +66,24 @@ export default class VueBareDev {
     });
     const chaine = muet ? 'situation.barre-dev.sonore' : 'situation.barre-dev.muet';
     $('.bouton-muet', pointInsertion).text(traduction(chaine));
+  }
+
+  basculeEtatConfirmationQuitterEnCours (pointInsertion, $) {
+    const confirmation = !this.confirmationQuitterEnCours();
+    this.preferencesDev.enregistreEtatConfirmationQuitterEnCours(confirmation);
+    this.metAjourConfirmationQuitterEnCours(pointInsertion, $, confirmation);
+  }
+
+  confirmationQuitterEnCours () {
+    const confirmation = this.preferencesDev.consulteEtatConfirmationQuitterEnCours();
+    if (confirmation === null) {
+      return true;
+    }
+    return confirmation === 'true';
+  }
+
+  metAjourConfirmationQuitterEnCours (pointInsertion, $) {
+    const chaine = this.confirmationQuitterEnCours() ? 'situation.barre-dev.pas-confirmation' : 'situation.barre-dev.confirmation';
+    $('.bouton-confirmation', pointInsertion).text(traduction(chaine));
   }
 }

--- a/src/situations/commun/vues/barre_dev.js
+++ b/src/situations/commun/vues/barre_dev.js
@@ -1,0 +1,25 @@
+import 'commun/styles/barre_dev.scss';
+
+import go from '../assets/play.svg';
+
+import { DEMARRE, FINI } from '../modeles/situation';
+
+export default class VueBareDev {
+  constructor (situation) {
+    this.situation = situation;
+  }
+
+  affiche (pointInsertion, $) {
+    const $div = $('<div class="barre-dev"></div>');
+    const $go = $(`<button class="bouton-go"><img src="${go}"></button>`);
+    $go.on('click', () => {
+      this.situation.modifieEtat(DEMARRE);
+    });
+    const $fini = $('<button class="bouton-fini">FIN</button>');
+    $fini.on('click', () => {
+      this.situation.modifieEtat(FINI);
+    });
+    $div.append($go, $fini);
+    $(pointInsertion).append($div);
+  }
+}

--- a/src/situations/commun/vues/barre_dev.js
+++ b/src/situations/commun/vues/barre_dev.js
@@ -3,6 +3,7 @@ import 'commun/styles/barre_dev.scss';
 import go from '../assets/play.svg';
 
 import { CHANGEMENT_ETAT, ATTENTE_DEMARRAGE, DEMARRE, FINI } from '../modeles/situation';
+import { traduction } from '../infra/internationalisation';
 
 export default class VueBareDev {
   constructor (situation) {
@@ -15,11 +16,15 @@ export default class VueBareDev {
     $go.on('click', () => {
       this.situation.modifieEtat(DEMARRE);
     });
+
+    const $muet = $(`<button class="bouton-muet">${traduction('situation.barre-dev.muet')}</button>`);
+    $muet.on('click', () => { this.basculeEtatMuet(pointInsertion, $); });
+
     const $fini = $('<button class="bouton-fini">FIN</button>');
     $fini.on('click', () => {
       this.situation.modifieEtat(FINI);
     });
-    $div.append($go, $fini);
+    $div.append($go, $muet, $fini);
     $(pointInsertion).append($div);
     this.situation.on(CHANGEMENT_ETAT, () => {
       this.metAJourEtat(pointInsertion, $);
@@ -31,5 +36,15 @@ export default class VueBareDev {
 
     $('.bouton-go', pointInsertion).prop('disabled', etat !== ATTENTE_DEMARRAGE);
     $('.bouton-fini', pointInsertion).prop('disabled', etat === FINI);
+  }
+
+  basculeEtatMuet (pointInsertion, $) {
+    const audios = this.situation.audios;
+    let muet;
+    Object.keys(audios).forEach((audio) => {
+      audios[audio].muted = !audios[audio].muted;
+      muet = audios[audio].muted;
+    });
+    $('.bouton-muet', pointInsertion).text(traduction(muet ? 'situation.barre-dev.sonore' : 'situation.barre-dev.muet'));
   }
 }

--- a/src/situations/commun/vues/barre_dev.js
+++ b/src/situations/commun/vues/barre_dev.js
@@ -2,7 +2,7 @@ import 'commun/styles/barre_dev.scss';
 
 import go from '../assets/play.svg';
 
-import { DEMARRE, FINI } from '../modeles/situation';
+import { CHANGEMENT_ETAT, ATTENTE_DEMARRAGE, DEMARRE, FINI } from '../modeles/situation';
 
 export default class VueBareDev {
   constructor (situation) {
@@ -21,5 +21,15 @@ export default class VueBareDev {
     });
     $div.append($go, $fini);
     $(pointInsertion).append($div);
+    this.situation.on(CHANGEMENT_ETAT, () => {
+      this.metAJourEtat(pointInsertion, $);
+    });
+  }
+
+  metAJourEtat (pointInsertion, $) {
+    const etat = this.situation.etat();
+
+    $('.bouton-go', pointInsertion).prop('disabled', etat !== ATTENTE_DEMARRAGE);
+    $('.bouton-fini', pointInsertion).prop('disabled', etat === FINI);
   }
 }

--- a/src/situations/commun/vues/barre_dev.js
+++ b/src/situations/commun/vues/barre_dev.js
@@ -6,8 +6,9 @@ import { CHANGEMENT_ETAT, ATTENTE_DEMARRAGE, DEMARRE, FINI } from '../modeles/si
 import { traduction } from '../infra/internationalisation';
 
 export default class VueBareDev {
-  constructor (situation) {
+  constructor (situation, preferencesDev) {
     this.situation = situation;
+    this.preferencesDev = preferencesDev;
   }
 
   affiche (pointInsertion, $) {
@@ -17,7 +18,7 @@ export default class VueBareDev {
       this.situation.modifieEtat(DEMARRE);
     });
 
-    const $muet = $(`<button class="bouton-muet">${traduction('situation.barre-dev.muet')}</button>`);
+    const $muet = $(`<button class="bouton-muet"></button>`);
     $muet.on('click', () => { this.basculeEtatMuet(pointInsertion, $); });
 
     const $fini = $('<button class="bouton-fini">FIN</button>');
@@ -26,6 +27,8 @@ export default class VueBareDev {
     });
     $div.append($go, $muet, $fini);
     $(pointInsertion).append($div);
+
+    this.metAJourEtatMuet(pointInsertion, $, this.etatMuet());
     this.situation.on(CHANGEMENT_ETAT, () => {
       this.metAJourEtat(pointInsertion, $);
     });
@@ -39,12 +42,26 @@ export default class VueBareDev {
   }
 
   basculeEtatMuet (pointInsertion, $) {
+    const muet = !this.etatMuet();
+    this.preferencesDev.enregistreEtatMuet(muet);
+    this.metAJourEtatMuet(pointInsertion, $, muet);
+  }
+
+  etatMuet () {
+    const muet = this.preferencesDev.consulteEtatMuet();
+    if (muet === null) {
+      return false;
+    } else {
+      return muet === 'true';
+    }
+  }
+
+  metAJourEtatMuet (pointInsertion, $, muet) {
     const audios = this.situation.audios;
-    let muet;
     Object.keys(audios).forEach((audio) => {
-      audios[audio].muted = !audios[audio].muted;
-      muet = audios[audio].muted;
+      audios[audio].muted = muet;
     });
-    $('.bouton-muet', pointInsertion).text(traduction(muet ? 'situation.barre-dev.sonore' : 'situation.barre-dev.muet'));
+    const chaine = muet ? 'situation.barre-dev.sonore' : 'situation.barre-dev.muet';
+    $('.bouton-muet', pointInsertion).text(traduction(chaine));
   }
 }

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -8,14 +8,13 @@ import VueConsigne from 'commun/vues/consigne';
 import VueGo from 'commun/vues/go';
 import VueTerminer from 'commun/vues/terminer';
 import VueBarreDev from 'commun/vues/barre_dev';
-import PreferencesDev from '../infra/preferences_dev';
 
 export default class VueCadre {
-  constructor (vueSituation, situation, journal, chargeurRessources, barreDev) {
+  constructor (vueSituation, situation, journal, chargeurRessources, preferencesDev) {
     this.vueSituation = vueSituation;
     this.situation = situation;
     this.chargeurRessources = chargeurRessources;
-    this.barreDev = barreDev;
+    this.preferencesDev = preferencesDev;
     this.vueActions = new VueActions(situation, journal);
     this.vuesEtats = new Map();
     this.vuesEtats.set(CHARGEMENT, VueChargement);
@@ -41,9 +40,9 @@ export default class VueCadre {
     this.situation.on(CHANGEMENT_ETAT, this.afficheEtat.bind(this));
     this.previensLaFermetureDeLaSituation($);
 
-    if (this.barreDev) {
-      const barreDev = new VueBarreDev(this.situation, new PreferencesDev());
-      barreDev.affiche(pointInsertion, $);
+    if (this.preferencesDev) {
+      this.barreDev = new VueBarreDev(this.situation, this.preferencesDev);
+      this.barreDev.affiche(pointInsertion, $);
     }
   }
 
@@ -64,6 +63,9 @@ export default class VueCadre {
 
   previensLaFermetureDeLaSituation ($) {
     $(window).on('beforeunload', (e) => {
+      if (this.barreDev && !this.barreDev.confirmationQuitterEnCours()) {
+        return;
+      }
       if (![CHARGEMENT, ERREUR_CHARGEMENT, ATTENTE_DEMARRAGE, FINI, STOPPEE].includes(this.situation.etat())) {
         e.preventDefault();
         return '';

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -7,12 +7,14 @@ import VueJoue from 'commun/vues/joue';
 import VueConsigne from 'commun/vues/consigne';
 import VueGo from 'commun/vues/go';
 import VueTerminer from 'commun/vues/terminer';
+import VueBarreDev from 'commun/vues/barre_dev';
 
 export default class VueCadre {
-  constructor (vueSituation, situation, journal, chargeurRessources) {
+  constructor (vueSituation, situation, journal, chargeurRessources, barreDev) {
     this.vueSituation = vueSituation;
     this.situation = situation;
     this.chargeurRessources = chargeurRessources;
+    this.barreDev = barreDev;
     this.vueActions = new VueActions(situation, journal);
     this.vuesEtats = new Map();
     this.vuesEtats.set(CHARGEMENT, VueChargement);
@@ -37,6 +39,11 @@ export default class VueCadre {
     this.afficheEtat(this.situation.etat());
     this.situation.on(CHANGEMENT_ETAT, this.afficheEtat.bind(this));
     this.previensLaFermetureDeLaSituation($);
+
+    if (this.barreDev) {
+      const barreDev = new VueBarreDev(this.situation);
+      barreDev.affiche(pointInsertion, $);
+    }
   }
 
   afficheEtat (etat) {

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -8,6 +8,7 @@ import VueConsigne from 'commun/vues/consigne';
 import VueGo from 'commun/vues/go';
 import VueTerminer from 'commun/vues/terminer';
 import VueBarreDev from 'commun/vues/barre_dev';
+import PreferencesDev from '../infra/preferences_dev';
 
 export default class VueCadre {
   constructor (vueSituation, situation, journal, chargeurRessources, barreDev) {
@@ -41,7 +42,7 @@ export default class VueCadre {
     this.previensLaFermetureDeLaSituation($);
 
     if (this.barreDev) {
-      const barreDev = new VueBarreDev(this.situation);
+      const barreDev = new VueBarreDev(this.situation, new PreferencesDev());
       barreDev.affiche(pointInsertion, $);
     }
   }

--- a/tests/situations/commun/vues/barre_dev.js
+++ b/tests/situations/commun/vues/barre_dev.js
@@ -16,7 +16,7 @@ describe('la barre de developpement', () => {
     situation.audios = {
       test: new window.Audio()
     };
-    preferencesDev = { enregistreEtatMuet () {}, consulteEtatMuet () {} };
+    preferencesDev = { enregistreEtatMuet () {}, consulteEtatMuet () {}, consulteEtatConfirmationQuitterEnCours () {} };
     vue = new BarreDev(situation, preferencesDev);
   });
 
@@ -95,5 +95,23 @@ describe('la barre de developpement', () => {
     expect($('#pointInsertion .bouton-fini').prop('disabled')).to.not.be.ok();
     situation.modifieEtat(FINI);
     expect($('#pointInsertion .bouton-fini').attr('disabled')).to.be.ok();
+  });
+
+  it('affiche un bouton pour ne pas avoir la confirmation de quitter la situation', () => {
+    vue.affiche('#pointInsertion', $);
+    expect($('#pointInsertion .barre-dev .bouton-confirmation').length).to.eql(1);
+  });
+
+  it("l'appui sur le bouton confirmation enregistre l'état dans les préférences", () => {
+    let enregistrement = 0;
+    preferencesDev.consulteEtatConfirmationQuitterEnCours = () => enregistrement === 1 ? false : null;
+    preferencesDev.enregistreEtatConfirmationQuitterEnCours = () => enregistrement++;
+    vue.affiche('#pointInsertion', $);
+    expect($('#pointInsertion .bouton-confirmation').text()).to.equal('situation.barre-dev.pas-confirmation');
+    expect(vue.confirmationQuitterEnCours()).to.be(true);
+    $('#pointInsertion .bouton-confirmation').click();
+    expect(vue.confirmationQuitterEnCours()).to.be(false);
+    expect($('#pointInsertion .bouton-confirmation').text()).to.equal('situation.barre-dev.confirmation');
+    expect(enregistrement).to.equal(1);
   });
 });

--- a/tests/situations/commun/vues/barre_dev.js
+++ b/tests/situations/commun/vues/barre_dev.js
@@ -12,6 +12,9 @@ describe('la barre de developpement', () => {
     jsdom('<div id="pointInsertion"></div>');
     $ = jQuery(window);
     situation = new Situation();
+    situation.audios = {
+      test: new window.Audio()
+    };
     vue = new BarreDev(situation);
     vue.affiche('#pointInsertion', $);
   });
@@ -33,6 +36,24 @@ describe('la barre de developpement', () => {
     expect($('#pointInsertion .bouton-go').prop('disabled')).to.not.be.ok();
     situation.modifieEtat(DEMARRE);
     expect($('#pointInsertion .bouton-go').attr('disabled')).to.be.ok();
+  });
+
+  it('affiche un bouton muet', () => {
+    expect($('#pointInsertion .barre-dev .bouton-muet').length).to.eql(1);
+  });
+
+  it("l'appui sur le bouton muet, rend muet tout les sons de la situation", () => {
+    expect($('#pointInsertion .bouton-muet').text()).to.equal('situation.barre-dev.muet');
+    $('#pointInsertion .bouton-muet').click();
+    expect(situation.audios.test.muted).to.be(true);
+    expect($('#pointInsertion .bouton-muet').text()).to.equal('situation.barre-dev.sonore');
+  });
+
+  it('au ré-appui sur le bouton muet, rend non muet tout les sons de la situation', () => {
+    $('#pointInsertion .bouton-muet').click();
+    expect(situation.audios.test.muted).to.be(true);
+    $('#pointInsertion .bouton-muet').click();
+    expect(situation.audios.test.muted).to.be(false);
   });
 
   it('affiche un bouton fini', () => {

--- a/tests/situations/commun/vues/barre_dev.js
+++ b/tests/situations/commun/vues/barre_dev.js
@@ -1,0 +1,40 @@
+import jsdom from 'jsdom-global';
+
+import BarreDev from 'commun/vues/barre_dev';
+import Situation, { DEMARRE, FINI } from 'commun/modeles/situation';
+
+describe('la barre de developpement', () => {
+  let $;
+  let situation;
+  let vue;
+
+  beforeEach(() => {
+    jsdom('<div id="pointInsertion"></div>');
+    $ = jQuery(window);
+    situation = new Situation();
+    vue = new BarreDev(situation);
+    vue.affiche('#pointInsertion', $);
+  });
+
+  it('crée un conteneur', () => {
+    expect($('#pointInsertion .barre-dev').length).to.eql(1);
+  });
+
+  it('affiche un bouton go', () => {
+    expect($('#pointInsertion .barre-dev .bouton-go').length).to.eql(1);
+  });
+
+  it("l'appui sur le bouton passe la situation en DEMARRE", () => {
+    $('#pointInsertion .bouton-go').click();
+    expect(situation.etat()).to.eql(DEMARRE);
+  });
+
+  it('affiche un bouton fini', () => {
+    expect($('#pointInsertion .barre-dev .bouton-fini').length).to.eql(1);
+  });
+
+  it("l'appui sur le bouton fini passe la situation en FINI", () => {
+    $('#pointInsertion .bouton-fini').click();
+    expect(situation.etat()).to.eql(FINI);
+  });
+});

--- a/tests/situations/commun/vues/barre_dev.js
+++ b/tests/situations/commun/vues/barre_dev.js
@@ -7,6 +7,7 @@ describe('la barre de developpement', () => {
   let $;
   let situation;
   let vue;
+  let preferencesDev;
 
   beforeEach(() => {
     jsdom('<div id="pointInsertion"></div>');
@@ -15,57 +16,82 @@ describe('la barre de developpement', () => {
     situation.audios = {
       test: new window.Audio()
     };
-    vue = new BarreDev(situation);
-    vue.affiche('#pointInsertion', $);
+    preferencesDev = { enregistreEtatMuet () {}, consulteEtatMuet () {} };
+    vue = new BarreDev(situation, preferencesDev);
   });
 
   it('crée un conteneur', () => {
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .barre-dev').length).to.eql(1);
   });
 
   it('affiche un bouton go', () => {
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .barre-dev .bouton-go').length).to.eql(1);
   });
 
   it("l'appui sur le bouton passe la situation en DEMARRE", () => {
+    vue.affiche('#pointInsertion', $);
     $('#pointInsertion .bouton-go').click();
     expect(situation.etat()).to.eql(DEMARRE);
   });
 
   it("le bouton go n'est actif que dans l'état ATTENTE_DEMARRAGE", () => {
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .bouton-go').prop('disabled')).to.not.be.ok();
     situation.modifieEtat(DEMARRE);
     expect($('#pointInsertion .bouton-go').attr('disabled')).to.be.ok();
   });
 
   it('affiche un bouton muet', () => {
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .barre-dev .bouton-muet').length).to.eql(1);
   });
 
   it("l'appui sur le bouton muet, rend muet tout les sons de la situation", () => {
+    preferencesDev.consulteEtatMuet = () => null;
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .bouton-muet').text()).to.equal('situation.barre-dev.muet');
     $('#pointInsertion .bouton-muet').click();
     expect(situation.audios.test.muted).to.be(true);
     expect($('#pointInsertion .bouton-muet').text()).to.equal('situation.barre-dev.sonore');
   });
 
-  it('au ré-appui sur le bouton muet, rend non muet tout les sons de la situation', () => {
+  it("sauvegarde l'état muet dans les préférences", (done) => {
+    vue.affiche('#pointInsertion', $);
+    preferencesDev.enregistreEtatMuet = (valeur) => {
+      expect(valeur).to.equal(true);
+      done();
+    };
+    preferencesDev.consulteEtatMuet = (clef) => {
+      return 'false';
+    };
     $('#pointInsertion .bouton-muet').click();
+  });
+
+  it('au ré-appui sur le bouton muet, rend non muet tout les sons de la situation', () => {
+    preferencesDev.consulteEtatMuet = () => {
+      return 'true';
+    };
+    vue.affiche('#pointInsertion', $);
     expect(situation.audios.test.muted).to.be(true);
     $('#pointInsertion .bouton-muet').click();
     expect(situation.audios.test.muted).to.be(false);
   });
 
   it('affiche un bouton fini', () => {
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .barre-dev .bouton-fini').length).to.eql(1);
   });
 
   it("l'appui sur le bouton fini passe la situation en FINI", () => {
+    vue.affiche('#pointInsertion', $);
     $('#pointInsertion .bouton-fini').click();
     expect(situation.etat()).to.eql(FINI);
   });
 
   it("le bouton fini n'est pas actif dans l'état FINI", () => {
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .bouton-fini').prop('disabled')).to.not.be.ok();
     situation.modifieEtat(FINI);
     expect($('#pointInsertion .bouton-fini').attr('disabled')).to.be.ok();

--- a/tests/situations/commun/vues/barre_dev.js
+++ b/tests/situations/commun/vues/barre_dev.js
@@ -29,6 +29,12 @@ describe('la barre de developpement', () => {
     expect(situation.etat()).to.eql(DEMARRE);
   });
 
+  it("le bouton go n'est actif que dans l'état ATTENTE_DEMARRAGE", () => {
+    expect($('#pointInsertion .bouton-go').prop('disabled')).to.not.be.ok();
+    situation.modifieEtat(DEMARRE);
+    expect($('#pointInsertion .bouton-go').attr('disabled')).to.be.ok();
+  });
+
   it('affiche un bouton fini', () => {
     expect($('#pointInsertion .barre-dev .bouton-fini').length).to.eql(1);
   });
@@ -36,5 +42,11 @@ describe('la barre de developpement', () => {
   it("l'appui sur le bouton fini passe la situation en FINI", () => {
     $('#pointInsertion .bouton-fini').click();
     expect(situation.etat()).to.eql(FINI);
+  });
+
+  it("le bouton fini n'est pas actif dans l'état FINI", () => {
+    expect($('#pointInsertion .bouton-fini').prop('disabled')).to.not.be.ok();
+    situation.modifieEtat(FINI);
+    expect($('#pointInsertion .bouton-fini').attr('disabled')).to.be.ok();
   });
 });

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -2,6 +2,7 @@ import jsdom from 'jsdom-global';
 
 import SituationCommune, { CHANGEMENT_ETAT, CHARGEMENT, ERREUR_CHARGEMENT, ATTENTE_DEMARRAGE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI, STOPPEE } from 'commun/modeles/situation';
 import VueCadre from 'commun/vues/cadre';
+import PreferencesDev from 'commun/infra/preferences_dev';
 import MockAudio from '../../commun/aides/mock_audio';
 
 function uneVue (callbackAffichage = () => {}) {
@@ -123,15 +124,26 @@ describe('Une vue du cadre', function () {
     });
   });
 
+  it("ne demande pas une confirmation pour quitter la page lorsque la situation a une barre de dev qui l'interdit", function () {
+    const preferencesDev = new PreferencesDev();
+    preferencesDev.consulteEtatConfirmationQuitterEnCours = () => false;
+    const vueCadre = new VueCadre(uneVue(), situation, {}, chargeurRessources, preferencesDev);
+    vueCadre.affiche('#point-insertion', $);
+    situation.modifieEtat(DEMARRE);
+    const event = $.Event('beforeunload');
+    $(window).trigger(event);
+    expect(event.isDefaultPrevented()).to.not.be.ok();
+  });
+
   it("crée la barre d'outils de dev", function () {
-    const vueCadre = new VueCadre(uneVue(), situation, {}, chargeurRessources, true);
+    const vueCadre = new VueCadre(uneVue(), situation, {}, chargeurRessources, new PreferencesDev());
     vueCadre.affiche('#point-insertion', $);
 
     expect($('.barre-dev').length).to.equal(1);
   });
 
   it("ne crée pas la barre d'outils de dev", function () {
-    const vueCadre = new VueCadre(uneVue(), situation, {}, chargeurRessources, false);
+    const vueCadre = new VueCadre(uneVue(), situation, {}, chargeurRessources, null);
     vueCadre.affiche('#point-insertion', $);
 
     expect($('.barre-dev').length).to.equal(0);

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -14,7 +14,9 @@ describe('Une vue du cadre', function () {
   let chargeurRessources;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
+    jsdom('<div id="point-insertion"></div>', {
+      url: 'https://example.org/'
+    });
     $ = jQuery(window);
     chargeurRessources = { chargement: () => Promise.resolve() };
     situation = new class extends SituationCommune {

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -120,4 +120,18 @@ describe('Une vue du cadre', function () {
       expect(event.isDefaultPrevented()).to.not.be.ok();
     });
   });
+
+  it("crée la barre d'outils de dev", function () {
+    const vueCadre = new VueCadre(uneVue(), situation, {}, chargeurRessources, true);
+    vueCadre.affiche('#point-insertion', $);
+
+    expect($('.barre-dev').length).to.equal(1);
+  });
+
+  it("ne crée pas la barre d'outils de dev", function () {
+    const vueCadre = new VueCadre(uneVue(), situation, {}, chargeurRessources, false);
+    vueCadre.affiche('#point-insertion', $);
+
+    expect($('.barre-dev').length).to.equal(0);
+  });
 });


### PR DESCRIPTION
Pour faciliter le test des situations, voici une barre d'outils, pour l'instant générique, qui permet de changer l'état de la situation rapidement (passe en démarrer, passe en fin), muter de façon globale les sons (et le sauvegarde), ainsi que le fait de désactiver la confirmation lorsqu'on quitter une situation en cours (et le sauvegarde).

C'est une première version que j'espère améliorer avec des contrôles spécifique à chaque situation.

![barre-dev](https://user-images.githubusercontent.com/86659/56569308-03494780-65b9-11e9-87e6-0048a74b9e33.gif)
