### PR TITLE
Permet à l'utilisateur de rejouer la consigne

### DIFF
--- a/src/situations/commun/styles/action_overlay.scss
+++ b/src/situations/commun/styles/action_overlay.scss
@@ -38,7 +38,7 @@
   cursor: default;
 
   img {
-    height: 4rem;
+    height: 3.5rem;
   }
 }
 

--- a/src/situations/commun/styles/actions.scss
+++ b/src/situations/commun/styles/actions.scss
@@ -7,4 +7,5 @@
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
+  justify-content: space-between;
 }

--- a/src/situations/commun/styles/rejoue_consigne.scss
+++ b/src/situations/commun/styles/rejoue_consigne.scss
@@ -1,11 +1,19 @@
 @import 'commun/styles/bouton.scss';
-@import 'commun/styles/couleurs.scss';
 
 .bouton-relecture-consigne {
   @include bouton-carre($couleur-fond-bouton-vert, $couleur-fond-bouton-vert-focus);
+  cursor: pointer;
   img {
-    position: relative;
-    margin: auto;
     height: 1.3rem;
+  }
+}
+
+
+.bouton-relecture-en-cours {
+  @include bouton-carre($couleur-fond-bouton-vert, $couleur-fond-bouton-vert, $couleur-fond-bouton-vert);
+  cursor: default;
+  box-shadow: none;
+  img {
+    height: 3.5rem;
   }
 }

--- a/src/situations/commun/styles/rejoue_consigne.scss
+++ b/src/situations/commun/styles/rejoue_consigne.scss
@@ -1,0 +1,11 @@
+@import 'commun/styles/bouton.scss';
+@import 'commun/styles/couleurs.scss';
+
+.bouton-relecture-consigne {
+  @include bouton-carre($couleur-fond-bouton-vert, $couleur-fond-bouton-vert-focus);
+  img {
+    position: relative;
+    margin: auto;
+    height: 1.3rem;
+  }
+}

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -6,8 +6,8 @@ import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
 
 export default class VueActions {
   constructor (situation, journal) {
-    this.situation = situation;
     this.journal = journal;
+    this.situation = situation;
     this.consigne = situation.audios.consigne;
   }
 

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -13,7 +13,7 @@ export default class VueActions {
 
   affiche (pointInsertion, $) {
     this.$actions = $('<div class="actions"></div>');
-    const stop = new VueStop(this.journal);
+    const stop = new VueStop(this.situation, this.journal);
     const rejoueConsigne = new VueRejoueConsigne(this.consigne);
 
     stop.affiche(this.$actions, $);

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -2,19 +2,23 @@ import 'commun/styles/actions.scss';
 import 'commun/styles/stop.scss';
 
 import VueStop from 'commun/vues/stop';
+import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
 
 export default class VueActions {
   constructor (situation, journal) {
     this.situation = situation;
     this.journal = journal;
+    this.consigne = situation.audios.consigne;
   }
 
   affiche (pointInsertion, $) {
     this.$actions = $('<div class="actions"></div>');
-    $(pointInsertion).append(this.$actions);
+    const stop = new VueStop(this.journal);
+    const rejoueConsigne = new VueRejoueConsigne(this.consigne);
 
-    const stop = new VueStop(this.situation, this.journal);
-    stop.affiche('.actions', $);
+    stop.affiche(this.$actions, $);
+    rejoueConsigne.affiche(this.$actions, $);
+    $(pointInsertion).append(this.$actions);
   }
 
   cache () {

--- a/src/situations/commun/vues/modale.js
+++ b/src/situations/commun/vues/modale.js
@@ -3,7 +3,7 @@ import { traduction } from 'commun/infra/internationalisation';
 import 'commun/styles/overlay.scss';
 import 'commun/styles/modale.scss';
 
-export function afficheFenetreModale ($pointInsertion, $, message, actionOk) {
+export function afficheFenetreModale (pointInsertion, $, message, actionOk) {
   const $modale = $(`<div id="fenetre-modale" class="overlay modale">
     <label>${message}</label>
     <div class="buttons">
@@ -11,7 +11,7 @@ export function afficheFenetreModale ($pointInsertion, $, message, actionOk) {
     <button id="OK-modale" class='modal-ok'>${traduction('situation.modale.ok')}</button>
     </div>
     </div>`);
-  $pointInsertion.append($modale);
+  $(pointInsertion).append($modale);
 
   $('#OK-modale').on('click', () => {
     $modale.addClass('attendre');

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -1,13 +1,33 @@
 import 'commun/styles/rejoue_consigne.scss';
 import play from 'commun/assets/play.svg';
+import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 
 export default class VueRejoueConsigne {
-  constructor (pointInsertion, $) {
-    this.$pointInsertion = $(pointInsertion);
-    this.$boutonRejoueConsigne = $(`<a id="rejoue-consigne" class="bouton-relecture-consigne"><img src="${play}"></a>`);
+  constructor (consigne) {
+    this.consigne = consigne;
   }
 
-  affiche () {
-    this.$pointInsertion.append(this.$boutonRejoueConsigne);
+  affiche (pointInsertion, $) {
+    this.$boutonRejoueConsigne = $(`<a id="rejoue-consigne" class="bouton-relecture-consigne"><img src="${play}"></a>`);
+    this.$boutonRejoueConsigne.on('click', () => this.click($));
+
+    $(pointInsertion).append(this.$boutonRejoueConsigne);
+  }
+
+  click ($) {
+    this.joueConsigne($);
+    this.$boutonRejoueConsigne.children().attr('src', lectureEnCours);
+  }
+
+  joueConsigne ($) {
+    $(this.consigne).on('ended', this.lectureTermine.bind(this));
+    return Promise.resolve(this.consigne.play())
+      .catch(e => {
+        this.lectureTermine();
+      });
+  }
+
+  lectureTermine () {
+    this.$boutonRejoueConsigne.children().attr('src', play);
   }
 }

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -1,0 +1,13 @@
+import 'commun/styles/rejoue_consigne.scss';
+import play from 'commun/assets/play.svg';
+
+export default class VueRejoueConsigne {
+  constructor (pointInsertion, $) {
+    this.$pointInsertion = $(pointInsertion);
+    this.$boutonRejoueConsigne = $(`<a id="rejoue-consigne" class="bouton-relecture-consigne"><img src="${play}"></a>`);
+  }
+
+  affiche () {
+    this.$pointInsertion.append(this.$boutonRejoueConsigne);
+  }
+}

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -1,6 +1,6 @@
-import 'commun/styles/rejoue_consigne.scss';
 import play from 'commun/assets/play.svg';
 import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
+import 'commun/styles/rejoue_consigne.scss';
 
 export default class VueRejoueConsigne {
   constructor (consigne) {
@@ -16,6 +16,7 @@ export default class VueRejoueConsigne {
 
   click ($) {
     this.joueConsigne($);
+    this.$boutonRejoueConsigne.addClass('bouton-relecture-en-cours');
     this.$boutonRejoueConsigne.children().attr('src', lectureEnCours);
   }
 
@@ -28,6 +29,7 @@ export default class VueRejoueConsigne {
   }
 
   lectureTermine () {
+    this.$boutonRejoueConsigne.removeClass('bouton-relecture-en-cours');
     this.$boutonRejoueConsigne.children().attr('src', play);
   }
 }

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -16,17 +16,18 @@ export default class VueStop {
   }
 
   affiche (pointInsertion, $) {
-    this.$boutonStop = $('<a id="stop" class="bouton-stop"></a>');
-    this.$boutonStop.append(`<img src='${stop}'>`);
-    this.$boutonStop.on('click', () => {
+    const $boutonStop = $('<a id="stop" class="bouton-stop"></a>');
+    $boutonStop.append(`<img src='${stop}'>`);
+
+    $boutonStop.on('click', () => {
       afficheFenetreModale(
-        $(pointInsertion),
+        pointInsertion,
         $,
         traduction('situation.stop'),
         this.clickSurOk.bind(this)
       );
     });
-    $(pointInsertion).append(this.$boutonStop);
+    $(pointInsertion).append($boutonStop);
   }
 
   clickSurOk () {

--- a/tests/situations/commun/modale.js
+++ b/tests/situations/commun/modale.js
@@ -10,7 +10,7 @@ describe('fenetre modale', function () {
   });
 
   it("sait s'ajouter dans une page web", function () {
-    afficheFenetreModale($('#point-insertion'), $, 'message', () => {});
+    afficheFenetreModale('#point-insertion', $, 'message', () => {});
 
     const $fenetre = $('#fenetre-modale');
     expect($fenetre.length).to.equal(1);
@@ -18,7 +18,7 @@ describe('fenetre modale', function () {
   });
 
   it("execute l'action quand on clique le bouton Ok", function (done) {
-    afficheFenetreModale($('#point-insertion'), $, 'message', () => {
+    afficheFenetreModale('#point-insertion', $, 'message', () => {
       done();
     });
 
@@ -47,7 +47,7 @@ describe('fenetre modale', function () {
   });
 
   it('supprime la fenêtre modal quand on clique sur annuler', () => {
-    afficheFenetreModale($('#point-insertion'), $, 'message', () => {});
+    afficheFenetreModale('#point-insertion', $, 'message', () => {});
 
     $('#annuler-modale').click();
     expect($('#fenetre-modale').length).to.equal(0);

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -16,9 +16,10 @@ describe('Affiche les éléments communs aux situations', function () {
     expect($('.actions').length).to.equal(1);
   });
 
-  it('Affiche les éléments en commun des situations (bouton stop)', function () {
+  it('Affiche les éléments en commun des situations (bouton stop, bouton rejoue consigne)', function () {
     vueActions.affiche('#magasin', $);
     expect($('#stop', '.actions').length).to.equal(1);
+    expect($('#rejoue-consigne', '.actions').length).to.equal(1);
   });
 
   it('cache le conteneur', function () {

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -1,14 +1,26 @@
 import jsdom from 'jsdom-global';
 import VueActions from 'commun/vues/actions';
+import SituationCommune from 'commun/modeles/situation';
+import MockAudio from '../../commun/aides/mock_audio';
 
 describe('Affiche les éléments communs aux situations', function () {
   let vueActions;
+  let situation;
   let $;
 
   beforeEach(function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
-    vueActions = new VueActions();
+    situation = new class extends SituationCommune {
+      constructor () {
+        super();
+        this.audios = {
+          consigne: new MockAudio()
+        };
+      }
+    }();
+
+    vueActions = new VueActions(situation);
   });
 
   it('regroupe les éléments dans un conteneur', function () {

--- a/tests/situations/commun/vues/rejoue_consigne.js
+++ b/tests/situations/commun/vues/rejoue_consigne.js
@@ -1,0 +1,25 @@
+import jsdom from 'jsdom-global';
+import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
+
+import i18next from 'i18next';
+i18next.init({
+  lng: 'fr',
+  resources: {
+  }
+});
+
+describe('vue Rejoue Consigne', function () {
+  let vue;
+  let $;
+
+  beforeEach(function () {
+    jsdom('<div id="magasin"></div>');
+    $ = jQuery(window);
+    vue = new VueRejoueConsigne('#magasin', $);
+  });
+
+  it("sait s'insérer dans une page web", function () {
+    vue.affiche();
+    expect($('#magasin #rejoue-consigne').length).to.eql(1);
+  });
+});

--- a/tests/situations/commun/vues/rejoue_consigne.js
+++ b/tests/situations/commun/vues/rejoue_consigne.js
@@ -1,25 +1,29 @@
 import jsdom from 'jsdom-global';
 import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
-
-import i18next from 'i18next';
-i18next.init({
-  lng: 'fr',
-  resources: {
-  }
-});
+import Situation from 'commun/modeles/situation';
 
 describe('vue Rejoue Consigne', function () {
+  let situation;
   let vue;
   let $;
 
   beforeEach(function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
-    vue = new VueRejoueConsigne('#magasin', $);
+    situation = new class extends Situation {
+      constructor () {
+        super();
+        this.audios = {
+          consigne: { play: () => Promise.resolve() }
+        };
+      }
+    }();
+
+    vue = new VueRejoueConsigne('#magasin', $, situation, situation.audios.consigne);
   });
 
   it("sait s'insérer dans une page web", function () {
-    vue.affiche();
+    vue.affiche('#magasin', $);
     expect($('#magasin #rejoue-consigne').length).to.eql(1);
   });
 });


### PR DESCRIPTION
Contribue à l'issue #68 

Cette PR couvre la priorité qui avait été donné mercredi 24/04, à savoir permettre à l'utilisateur de pouvoir rejouer la consigne.

<img width="1141" alt="Capture d’écran 2019-04-26 à 16 11 48" src="https://user-images.githubusercontent.com/20596535/56813823-1c165f00-683e-11e9-8c2f-57801d0ae2fc.png">

<img width="1166" alt="Capture d’écran 2019-04-26 à 16 12 00" src="https://user-images.githubusercontent.com/20596535/56813839-259fc700-683e-11e9-80b1-8c80e19246b6.png">


Plusieurs autres points ont été invoqués ce même jour:

- Journaliser l'événement
- Mettre un player
- Rejouer la consigne accessible avant de cliquer sur GO
- La lecture de la consigne et la relecture de la consigne sont très proche, il faudrait refactorer ça pour éviter la duplication.
- La consigne est inaudible sur la situation Contrôle

Par simplicité et pour éviter un trop gros pas, j'ai pris le parti de simplement rejouer la consigne.

Si c'est OK pour vous on pourrait gérer les autres éléments dans des issues à part.