### PR TITLE
Contrôle: Déselectionne toutes les pièces si le clic gauche n'est pas maintenu.

### DIFF
--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -39,8 +39,8 @@ export class VueSituation {
       vueBac.affiche(pointInsertion, $);
     }
 
-    const $situation = $(pointInsertion);
-    $situation.addClass('controle');
+    this.$situation = $(pointInsertion);
+    this.$situation.addClass('controle');
 
     this.situation.bacs().forEach(afficheBac);
     this.tapis.affiche(pointInsertion, $);
@@ -53,14 +53,12 @@ export class VueSituation {
       }
     });
 
-    $situation.mousemove(e => {
-      const piecesAffichees = this.situation.piecesAffichees();
-      piecesAffichees.forEach(p => {
-        p.deplaceSiSelectionnee({
-          x: 100 * e.clientX / $situation.width(),
-          y: 100 * e.clientY / $situation.height()
-        });
-      });
+    this.$situation.mousemove(e => {
+      if (e.buttons === 1) {
+        this.deplacePiecesSelectionnees(e);
+      } else {
+        this.deselectionneToutesLesPieces();
+      }
     });
   }
 
@@ -78,5 +76,22 @@ export class VueSituation {
     this.situation.on(PIECE_MAL_PLACEE, envoiEvenementPiece(EvenementPieceMalPlacee));
     this.situation.on(PIECE_RATEE, envoiEvenementPiece(EvenementPieceRatee));
     this.situation.demarre();
+  }
+
+  deplacePiecesSelectionnees (e) {
+    const piecesAffichees = this.situation.piecesAffichees();
+    piecesAffichees.forEach(p => {
+      p.deplaceSiSelectionnee({
+        x: 100 * e.clientX / this.$situation.width(),
+        y: 100 * e.clientY / this.$situation.height()
+      });
+    });
+  }
+
+  deselectionneToutesLesPieces () {
+    const piecesAffichees = this.situation.piecesAffichees();
+    piecesAffichees.forEach(p => {
+      p.deselectionne();
+    });
   }
 }

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -84,9 +84,23 @@ describe('La situation « Contrôle »', function () {
     vueSituation.affiche('#point-insertion', $);
     vueSituation.situation.ajoutePiece(piece);
 
-    $pointInsertion.trigger($.Event('mousemove', { clientX: 30, clientY: 20 }));
+    $pointInsertion.trigger($.Event('mousemove', { buttons: 1, clientX: 30, clientY: 20 }));
 
     expect(piece.position()).to.eql({ x: 60, y: 10 });
+  });
+
+  it('déselectionne les pièces si il y a un mousemove sans maintien du clic', function () {
+    const piece = new Piece({});
+    const vueSituation = vueSituationMinimaliste();
+    const $pointInsertion = $('#point-insertion');
+
+    piece.selectionne({ x: 95, y: 55 });
+    vueSituation.affiche('#point-insertion', $);
+    vueSituation.situation.ajoutePiece(piece);
+
+    $pointInsertion.trigger($.Event('mousemove', { buttons: 0, clientX: 30, clientY: 20 }));
+
+    expect(piece.estSelectionnee()).to.be(false);
   });
 
   describe('avec une situation démarrée, une pièce et un journal', function () {


### PR DESCRIPTION
1. Sélectionner une pièce
2. Déplacer la souris en maintenant le clic au dehors de la zone de la situation
3. Relâcher le clic
4. Revenir dans la zone de situation
5. La pièce se déplace sans maintenir le clic

Fix #197