### PR TITLE
Charge `jsdom` avant l'exécution du premier test

### DIFF
--- a/all-tests.js
+++ b/all-tests.js
@@ -1,3 +1,5 @@
+require('jsdom');
+
 let context = require.context('./tests', true, /\.js$/);
 context.keys().forEach(context);
 module.exports = context;


### PR DESCRIPTION
Le module node `jsdom` est notoirement long à charger, encore plus quand on est à l'intérieur
d'un conteneur Docker, encore plus depuis Docker sous Mac. Cela entraîne un timeout au niveau du
`beforeEach` qui charge en premier ce module. La solution proposée consiste à « pré-charger »
le module avant l'exécution du premier test.

Point discutable : on pré-charge `jsdom` même dans le cas où on n'exécute qu'une partie des tests.