### PR TITLE
Peut stopper sans serveur

### DIFF
--- a/src/situations/commun/infra/depot_journal.js
+++ b/src/situations/commun/infra/depot_journal.js
@@ -3,22 +3,29 @@ export default class DepotJournal {
     this.$ = $;
   }
 
-  enregistre (payload) {
-    return this.$.ajax({
-      type: 'POST',
-      url: `${process.env.URL_SERVEUR}/api/evenements`,
-      data: JSON.stringify(payload),
-      contentType: 'application/json; charset=utf-8',
-      retryTimeout: 60000,
-      appel: this.$,
-      datePremierAppel: Date.now(),
-      error: function (xhr) {
-        if (Date.now() - this.datePremierAppel < this.retryTimeout) {
-          setTimeout(() => {
-            this.appel.ajax(this);
-          }, 5000);
+  enregistre (payload, timeout = 60000) {
+    let delay = 100;
+    return new Promise((resolve, reject) => {
+      this.$.ajax({
+        type: 'POST',
+        url: `${process.env.URL_SERVEUR}/api/evenements`,
+        data: JSON.stringify(payload),
+        contentType: 'application/json; charset=utf-8',
+        retryTimeout: timeout,
+        appel: this.$,
+        datePremierAppel: Date.now(),
+        success: resolve,
+        error: function (xhr) {
+          if (Date.now() - this.datePremierAppel < this.retryTimeout) {
+            setTimeout(() => {
+              delay = delay * 2;
+              this.appel.ajax(this);
+            }, delay);
+          } else {
+            reject(xhr);
+          }
         }
-      }
+      });
     });
   }
 }

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -7,16 +7,15 @@ export default class Journal {
     this.registreUtilisateur = registre;
   }
 
-  enregistre (evenement) {
-    return this.depot.enregistre(
-      {
-        date: this.maintenant(),
-        session_id: this.sessionId,
-        situation: this.situation,
-        nom: evenement.nom(),
-        donnees: evenement.donnees(),
-        utilisateur: this.registreUtilisateur.consulte()
-      }
-    );
+  enregistre (evenement, timeout) {
+    const payLoad = {
+      date: this.maintenant(),
+      session_id: this.sessionId,
+      situation: this.situation,
+      nom: evenement.nom(),
+      donnees: evenement.donnees(),
+      utilisateur: this.registreUtilisateur.consulte()
+    };
+    return this.depot.enregistre(payLoad, timeout);
   }
 }

--- a/src/situations/commun/styles/modale.scss
+++ b/src/situations/commun/styles/modale.scss
@@ -14,7 +14,7 @@
     }
   }
 
-  &.modale-stop {
+  &.modale {
     background: rgba(0, 0, 0, 0.7);
     label {
       display: block;

--- a/src/situations/commun/styles/modale.scss
+++ b/src/situations/commun/styles/modale.scss
@@ -1,0 +1,47 @@
+@import 'commun/styles/bouton.scss';
+@import 'commun/styles/couleurs.scss';
+
+.overlay {
+  &.attendre {
+    cursor: wait;
+
+    button {
+      cursor: wait;
+    }
+
+    label {
+      cursor: wait;
+    }
+  }
+
+  &.modale-stop {
+    background: rgba(0, 0, 0, 0.7);
+    label {
+      display: block;
+      width: 100%;
+      color: $blanc;
+      line-height: 6.5rem;
+      font-size: 2.25rem;
+      font-weight: bold;
+      position: relative;
+      bottom: 7rem;
+      text-align: center;
+    }
+    .buttons {
+      display: block;
+      position: absolute;
+      width: 100%;
+      text-align: center;
+      button {
+        margin: 0 1.875rem;
+      }
+      .modal-ok {
+        @include bouton-modale($couleur-fond-bouton-vert, $blanc, $couleur-fond-bouton-vert-focus)
+      }
+
+      .modal-annuler {
+        @include bouton-modale($couleur-reponse-incorrecte, $blanc, $couleur-fond-bouton-rouge-focus)
+      }
+    }
+  }
+}

--- a/src/situations/commun/styles/stop.scss
+++ b/src/situations/commun/styles/stop.scss
@@ -8,37 +8,3 @@
     height: .875rem;
   }
 }
-
-
-.overlay {
-  &.modale-stop {
-    background: rgba(0, 0, 0, 0.7);
-    label {
-      display: block;
-      width: 100%;
-      color: $blanc;
-      line-height: 6.5rem;
-      font-size: 2.25rem;
-      font-weight: bold;
-      position: relative;
-      bottom: 7rem;
-      text-align: center;
-    }
-    .buttons {
-      display: block;
-      position: absolute;
-      width: 100%;
-      text-align: center;
-      button {
-        margin: 0 1.875rem;
-      }
-      .modal-ok {
-        @include bouton-modale($couleur-fond-bouton-vert, $blanc, $couleur-fond-bouton-vert-focus)
-      }
-
-      .modal-annuler {
-        @include bouton-modale($couleur-reponse-incorrecte, $blanc, $couleur-fond-bouton-rouge-focus)
-      }
-    }
-  }
-}

--- a/src/situations/commun/vues/modale.js
+++ b/src/situations/commun/vues/modale.js
@@ -13,8 +13,10 @@ export function afficheFenetreModale ($pointInsertion, $, message, actionOk) {
   $pointInsertion.append($modale);
 
   $('#OK-modale').on('click', () => {
-    actionOk();
-    $modale.remove();
+    $modale.addClass('attendre');
+    Promise.resolve(actionOk()).finally(() => {
+      $modale.remove();
+    });
   });
 
   $('#annuler-modale').on('click', () => {

--- a/src/situations/commun/vues/modale.js
+++ b/src/situations/commun/vues/modale.js
@@ -4,7 +4,7 @@ import 'commun/styles/overlay.scss';
 import 'commun/styles/modale.scss';
 
 export function afficheFenetreModale ($pointInsertion, $, message, actionOk) {
-  const $modale = $(`<div id="fenetre-modale" class="overlay modale-stop">
+  const $modale = $(`<div id="fenetre-modale" class="overlay modale">
     <label>${message}</label>
     <div class="buttons">
     <button id="annuler-modale" class='modal-annuler'>${traduction('situation.modale.annuler')}</button>

--- a/src/situations/commun/vues/modale.js
+++ b/src/situations/commun/vues/modale.js
@@ -1,6 +1,7 @@
 import { traduction } from 'commun/infra/internationalisation';
 
 import 'commun/styles/overlay.scss';
+import 'commun/styles/modale.scss';
 
 export function afficheFenetreModale ($pointInsertion, $, message, actionOk) {
   const $modale = $(`<div id="fenetre-modale" class="overlay modale-stop">

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -32,8 +32,8 @@ export default class VueStop {
   clickSurOk () {
     this.situation.modifieEtat(STOPPEE);
     return this.journal
-      .enregistre(new EvenementStop())
-      .then(() => {
+      .enregistre(new EvenementStop(), 1000)
+      .finally(() => {
         this.retourAccueil();
       });
   }

--- a/tests/situations/commun/infra/depot_journal.js
+++ b/tests/situations/commun/infra/depot_journal.js
@@ -2,19 +2,22 @@ import DepotJournal from 'commun/infra/depot_journal';
 import jsdom from 'jsdom-global';
 
 describe('le depot du journal', function () {
-  let depot;
-  let requetes = [];
-
   beforeEach(function () {
     jsdom('', { url: 'http://localhost' });
-    requetes = [];
-    depot = new DepotJournal({ ajax (params) { requetes.push(params); } });
   });
 
   it('fait un POST des lignes du journal vers le serveur', function () {
+    const requetes = [];
+    const depot = new DepotJournal({ ajax (params) { requetes.push(params); } });
     depot.enregistre({ autreCle: 'valeur2', description: { cle: 'valeur2' } });
 
     expect(requetes.length).to.equal(1);
     expect(requetes[0]['type']).to.equal('POST');
+  });
+
+  it('retourne une promesse standard javascript', function () {
+    const depot = new DepotJournal({ ajax (params) {} });
+
+    expect(depot.enregistre({})).to.be.a(Promise);
   });
 });

--- a/tests/situations/commun/modale.js
+++ b/tests/situations/commun/modale.js
@@ -25,10 +25,37 @@ describe('fenetre modale', function () {
     $('#OK-modale').click();
   });
 
+  it("supprime la fenêtre quand l'action Ok est finie", function () {
+    const promesseOk = Promise.resolve();
+    afficheFenetreModale($('#point-insertion'), $, 'message', () => {
+      return promesseOk;
+    });
+
+    $('#OK-modale').click();
+    return promesseOk.then(() => {
+      expect($('#fenetre-modale').length).to.equal(0);
+    });
+  });
+
+  it("supprime la fenêtre quand l'action ok est fini même si ce n'est pas une promessse", function () {
+    afficheFenetreModale($('#point-insertion'), $, 'message', () => { });
+
+    $('#OK-modale').click();
+    return Promise.resolve().then(() => {
+      expect($('#fenetre-modale').length).to.equal(0);
+    });
+  });
+
   it('supprime la fenêtre modal quand on clique sur annuler', () => {
     afficheFenetreModale($('#point-insertion'), $, 'message', () => {});
 
     $('#annuler-modale').click();
     expect($('#fenetre-modale').length).to.equal(0);
+  });
+
+  it("affiche un sablier après l'appuie sur OK", function () {
+    afficheFenetreModale($('#point-insertion'), $, 'message', () => {});
+    $('#OK-modale').click();
+    expect($('#fenetre-modale').hasClass('attendre')).to.be.ok();
   });
 });

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -18,7 +18,7 @@ describe('vue Stop', function () {
   let situation;
 
   beforeEach(function () {
-    jsdom('<div id="magasin"></div>');
+    jsdom('<div id="point-insertion"></div>');
     $ = jQuery(window);
     mockJournal = {
       enregistre () {}
@@ -30,27 +30,41 @@ describe('vue Stop', function () {
   });
 
   it("sait s'insérer dans une page web", function () {
-    vue.affiche('#magasin', $);
-    expect(document.querySelector('#magasin #stop').classList).to.not.contain('invisible');
+    vue.affiche('#point-insertion', $);
+    expect(document.querySelector('#point-insertion #stop').classList).to.not.contain('invisible');
   });
 
   it('ouvre une fenêtre de confirmation avant de stopper', function () {
-    vue.affiche('#magasin', $);
+    vue.affiche('#point-insertion', $);
 
-    $('#magasin #stop').click();
+    $('#point-insertion #stop').click();
     expect($('#fenetre-modale').length).to.equal(1);
     expect($('label').text()).to.equal('situation.stop');
   });
 
-  it("enregistre l'événement et redirige vers l'accueil quand on confirme la modale", function (done) {
+  it("enregistre l'événement et redirige vers l'accueil quand on confirme la modale", function () {
     mockJournal.enregistre = (evenement) => {
       expect(evenement).to.be.a(EvenementStop);
       return Promise.resolve();
     };
-    vue.clickSurOk().then(() => {
+    return vue.clickSurOk().then(() => {
       expect(situation.etat()).to.eql(STOPPEE);
       expect(retourAccueil).to.equal(true);
-      done();
+    });
+  });
+
+  it("Redirige vers l'accueil même si l'enregistrement échoue", function (done) {
+    retourAccueil = false;
+    mockJournal.enregistre = (evenement) => {
+      return Promise.reject(new Error('serveur non joignable'));
+    };
+    vue.clickSurOk().finally(() => {
+      try {
+        expect(retourAccueil).to.equal(true);
+        done();
+      } catch (e) {
+        done(e);
+      }
     });
   });
 });


### PR DESCRIPTION
Cette PR, améliore le comportement de la fenêtre de confirmation, dans le cas ou le serveur ne répond pas ou répond lentement.

- La modale ne disparait pas immédiatement.
- La modale affiche un curseur d'attente.
- Au bout de 1 secondes, on quitte la situation, même si le serveur n'a pas traité.