### PR TITLE
Met à jour JQuery pour corriger l'alerte CVE-2019-11358

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6481,9 +6481,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.0.tgz",
+      "integrity": "sha512-ggRCXln9zEqv6OqAGXFEcshF5dSBvCkzj6Gm2gzuR5fWawaX8t7cxKVkkygKODrDAzKdoYw3l/e3pm3vlT4IbQ=="
     },
     "js-base64": {
       "version": "2.4.9",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.8.1",
     "i18next": "^15.0.6",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.0",
     "uuid": "^3.3.2"
   },
   "semistandard": {


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-11358