### PR TITLE
Corrige un avertissement d'exception non attrapée dans les tests.

### DIFF
--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -58,7 +58,7 @@ describe('vue Stop', function () {
     mockJournal.enregistre = (evenement) => {
       return Promise.reject(new Error('serveur non joignable'));
     };
-    vue.clickSurOk().finally(() => {
+    vue.clickSurOk().catch(() => {
       try {
         expect(retourAccueil).to.equal(true);
         done();


### PR DESCRIPTION
Je ne suis pas sur pourquoi il y a un avertissement alors que finally
est censé permettre ne pas avoir de then ni de catch. Bref, c'est corrigé.