### PR TITLE
Désactive la vérification de l'hote pour la connexion websocket.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "AGPL-3.0-only",
   "scripts": {
     "build": "webpack --mode production",
-    "dev": "webpack-dev-server --history-api-fallback --inline --progress --mode development --host 0.0.0.0",
+    "dev": "webpack-dev-server --history-api-fallback --inline --progress --mode development",
     "test": "./bin/test.sh",
     "lint": "semistandard"
   },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -113,6 +113,8 @@ module.exports = {
   ],
   devServer: {
     contentBase: './src/public',
+    host: '0.0.0.0',
+    disableHostCheck: true,
     port: 7700
   }
 };


### PR DESCRIPTION
Il y a un bug dans la version actuelle de webpack-dev-server qui casse le rechargement automatique de la page.

Le contournement officiel est de rajouter `disableHostCheck` dans la config. Voir https://github.com/webpack/webpack-dev-server/issues/1604