### PR TITLE
[NETTOYAGE] supprime le traitement en cas d'erreur de lecture de la consigne

### DIFF
--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -11,7 +11,7 @@ export default class VueConsigne extends VueActionOverlay {
 
   affiche (pointInsertion, $) {
     super.affiche(pointInsertion, $);
-    return this.joueConsigne($);
+    this.joueConsigne($);
   }
 
   lectureTermine () {
@@ -20,9 +20,6 @@ export default class VueConsigne extends VueActionOverlay {
 
   joueConsigne ($) {
     $(this.consigne).on('ended', this.lectureTermine.bind(this));
-    return Promise.resolve(this.consigne.play())
-      .catch(e => {
-        this.lectureTermine();
-      });
+    this.consigne.play();
   }
 }

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -28,10 +28,7 @@ export default class VueRejoueConsigne {
 
   joueConsigne ($) {
     $(this.consigne).on('ended', this.lectureTermine.bind(this));
-    return Promise.resolve(this.consigne.play())
-      .catch(e => {
-        this.lectureTermine();
-      });
+    this.consigne.play();
   }
 
   lectureTermine () {

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -23,14 +23,4 @@ describe('vue consigne', function () {
     $(vue.consigne).trigger('ended');
     expect(situation.etat()).to.eql(CONSIGNE_ECOUTEE);
   });
-
-  it("passe  directement a l'état CONSIGNE_ECOUTEE si la consigne ne peut pas être jouée", (done) => {
-    vue.consigne.play = () => {
-      return Promise.reject(new Error('Le fichier audio ne peut pas être joué'));
-    };
-    vue.affiche('#pointInsertion', $).then(() => {
-      expect(situation.etat()).to.eql(CONSIGNE_ECOUTEE);
-      done();
-    });
-  });
 });


### PR DESCRIPTION
Le comportement à adopter en cas d'impossibilité de la lecture de la
consigne n'est pas déterminé mais en tout cas, passer dans l'état
suivant n'est probablement pas ce que l'on veut.
