### PR TITLE
[NETTOYAGE] supprime le répertoire `dist` du .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /public
 bin/config.sh
-dist/
 node_modules/
 tests_build/
 .DS_Store


### PR DESCRIPTION
Ce répertoire était un vestigue de l'ancien méthode de déploiement.