### PR TITLE
Controle: affichage du résultat à la fin

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -6,7 +6,12 @@
     "titre": "Compétences pro"
   },
   "controle": {
-    "titre": "Chaîne de fabrication"
+    "titre": "Chaîne de fabrication",
+    "resultat": {
+      "bien_placees": "Réussis : {{nombre}}",
+      "mal_placees": "Erreurs : {{nombre}}",
+      "ratees": "Non triés : {{nombre}}"
+    }
   },
   "inventaire": {
     "placeholder": "Qté",

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -19,6 +19,11 @@ export default class Situation extends SituationCommune {
     this.audios = {
       fondSonore: new window.Audio(sonFondSonore)
     };
+    this.resultat = {
+      bien_placees: 0,
+      mal_placees: 0,
+      ratees: 0
+    };
     this._piecesAffichees = [];
     this._bacs = [];
   }
@@ -98,10 +103,15 @@ export default class Situation extends SituationCommune {
 
     const bac = this.bacs().find((bac) => bac.contient(piece));
     if (bac) {
-      const evenement = bac.correspondALaCategorie(piece) ? PIECE_BIEN_PLACEE : PIECE_MAL_PLACEE;
-
-      this.emit(evenement, piece);
+      if (bac.correspondALaCategorie(piece)) {
+        this.resultat.bien_placees++;
+        this.emit(PIECE_BIEN_PLACEE, piece);
+      } else {
+        this.resultat.mal_placees++;
+        this.emit(PIECE_MAL_PLACEE, piece);
+      }
     } else {
+      this.resultat.ratees++;
       this.emit(PIECE_RATEE, piece);
     }
 

--- a/src/situations/controle/styles/fin.scss
+++ b/src/situations/controle/styles/fin.scss
@@ -1,0 +1,15 @@
+@import 'commun/styles/couleurs.scss';
+
+.message-fin {
+  position:absolute;
+  bottom: 2rem;
+  color: $blanc;
+  text-align: center;
+  width: 100%;
+  font-size: 2.25rem;
+  font-weight: bold;
+
+  p {
+    margin: 0;
+  }
+}

--- a/src/situations/controle/vues/fin.js
+++ b/src/situations/controle/vues/fin.js
@@ -1,0 +1,32 @@
+import 'controle/styles/fin.scss';
+
+import { traduction } from 'commun/infra/internationalisation';
+import { CHANGEMENT_ETAT, FINI } from 'commun/modeles/situation';
+
+export default class VueFin {
+  constructor (situation) {
+    this.situation = situation;
+    this.situation.on(CHANGEMENT_ETAT, (etat) => {
+      if (etat === FINI) {
+        this.passeEnEtatFini();
+      }
+    });
+  }
+
+  affiche (pointInsertion, $) {
+    this.$ = $;
+    this.$overlay = $('<div class="overlay invisible"></div>');
+
+    $(pointInsertion).append(this.$overlay);
+  }
+
+  passeEnEtatFini () {
+    const $message = this.$('<div class="message-fin"></div>');
+    for (let resultat in this.situation.resultat) {
+      const message = traduction(`controle.resultat.${resultat}`, { nombre: this.situation.resultat[resultat] });
+      $message.append(this.$(`<p>${message}</p>`));
+    }
+    this.$overlay.append($message);
+    this.$overlay.removeClass('invisible');
+  }
+}

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -11,6 +11,7 @@ import VueBac from 'controle/vues/bac';
 import VuePiece from 'controle/vues/piece';
 import VueTapis from 'controle/vues/tapis';
 import VueFondSonore from 'controle/vues/fond_sonore';
+import VueFin from 'controle/vues/fin';
 
 export default class VueSituation {
   constructor (situation, journal) {
@@ -28,6 +29,7 @@ export default class VueSituation {
     this.journal = journal;
     this.tapis = new VueTapis(situation);
     this.fondSonore = new VueFondSonore(situation);
+    this.fin = new VueFin(situation);
   }
 
   creeVuePiece (piece) {
@@ -46,6 +48,7 @@ export default class VueSituation {
     this.situation.bacs().forEach(afficheBac);
     this.tapis.affiche(pointInsertion, $);
     this.fondSonore.affiche(pointInsertion, $);
+    this.fin.affiche(pointInsertion, $);
 
     this.situation.on(CHANGEMENT_ETAT, (etat) => {
       if (etat === DEMARRE) {

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -28,6 +28,13 @@ describe('La situation « Contrôle »', function () {
     expect(situation.sequenceTerminee()).to.be(true);
   });
 
+  it('initialise le résultat', function () {
+    const situation = new Situation({ scenario: [] });
+    expect(situation.resultat.bien_placees).to.eql(0);
+    expect(situation.resultat.mal_placees).to.eql(0);
+    expect(situation.resultat.ratees).to.eql(0);
+  });
+
   it('sait donner la piece suivante quand il y en encore à venir', function () {
     let situation = new Situation({ scenario: [{ conforme: false }], positionApparitionPieces: { x: 25, y: 50 } });
     expect(situation.sequenceTerminee()).to.be(false);
@@ -102,6 +109,7 @@ describe('La situation « Contrôle »', function () {
       bac.correspondALaCategorie = () => true;
 
       situation.on(PIECE_BIEN_PLACEE, (piece) => {
+        expect(situation.resultat.bien_placees).to.equal(1);
         done();
       });
       situation.faisDisparaitrePiece(piece);
@@ -112,6 +120,7 @@ describe('La situation « Contrôle »', function () {
       bac.correspondALaCategorie = () => false;
 
       situation.on(PIECE_MAL_PLACEE, (piece) => {
+        expect(situation.resultat.mal_placees).to.equal(1);
         done();
       });
       situation.faisDisparaitrePiece(piece);
@@ -121,6 +130,7 @@ describe('La situation « Contrôle »', function () {
       bac.contient = () => false;
 
       situation.on(PIECE_RATEE, (piece) => {
+        expect(situation.resultat.ratees).to.equal(1);
         done();
       });
       situation.faisDisparaitrePiece(piece);

--- a/tests/situations/controle/vues/fin.js
+++ b/tests/situations/controle/vues/fin.js
@@ -1,0 +1,38 @@
+import jsdom from 'jsdom-global';
+
+import Situation, { FINI } from 'commun/modeles/situation';
+import VueFin from 'controle/vues/fin';
+
+describe('La vue de fin', function () {
+  let $;
+  let situation;
+
+  beforeEach(function () {
+    jsdom('<div id="pointInsertion"></div>');
+    $ = jQuery(window);
+    situation = new Situation();
+  });
+
+  it("s'ajoute dans le DOM à partir d'un point d'insertion", function () {
+    const vue = new VueFin(situation);
+    expect($('.overlay.invisible').length).to.equal(0);
+
+    vue.affiche('#pointInsertion', $);
+
+    expect($('.overlay.invisible').length).to.equal(1);
+  });
+
+  it("s'affiche lorsque la situation passe en vue terminé", function () {
+    const vue = new VueFin(situation);
+    vue.affiche('#pointInsertion', $);
+    situation.resultat = {
+      bien_placees: 3,
+      mal_placees: 2,
+      ratees: 1
+    };
+    situation.modifieEtat(FINI);
+    expect($('.overlay').hasClass('invisible')).to.be(false);
+    expect($('.overlay .message-fin').length).to.equal(1);
+    expect($('.overlay .message-fin p').length).to.equal(3);
+  });
+});


### PR DESCRIPTION
A la fin de la situation contrôle, le nombre de pièces réussis, en erreurs et non triées sont affiché comme sur la maquette.

C'est le modèle qui maintient et stocke les chiffres.

![Screenshot_2019-05-14 Chaîne de fabrication(1)](https://user-images.githubusercontent.com/86659/57718499-b0295880-767d-11e9-82b9-7b87c2b3ae68.png)

Fix #170 
