### PR TITLE
Désactive le clic droit sur le cadre.

### DIFF
--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -47,6 +47,7 @@ export default class VueCadre {
     afficheEtat(this.situation.etat());
     this.situation.on(CHANGEMENT_ETAT, afficheEtat);
     this.previensLaFermetureDeLaSituation($);
+    this.previensLeClickDroit($);
 
     return this.depotRessources.chargement().then(() => {
       this.vueSituation.affiche('.scene', $);
@@ -61,6 +62,12 @@ export default class VueCadre {
         e.preventDefault();
         return '';
       }
+    });
+  }
+
+  previensLeClickDroit ($) {
+    $('#cadre').on('contextmenu', (e) => {
+      e.preventDefault();
     });
   }
 }

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -117,4 +117,12 @@ describe('Une vue du cadre', function () {
       });
     });
   });
+
+  it('désactive le click droit', function () {
+    const vueCadre = new VueCadre(uneVue(), situation, {}, depotRessources);
+    vueCadre.affiche('#point-insertion', $);
+    const contextmenu = $.Event('contextmenu');
+    $('#cadre').trigger(contextmenu);
+    expect(contextmenu.isDefaultPrevented()).to.be(true);
+  });
 });


### PR DESCRIPTION
Pour éviter les fausses manipulations des utilisateurs pas très au taquet sur l'informatique.

Fix #271 