### PR TITLE
Les pièces du tri et contrôle utilisent le dépôt ressources

### DIFF
--- a/src/situations/commun/modeles/piece.js
+++ b/src/situations/commun/modeles/piece.js
@@ -4,11 +4,11 @@ export const CHANGEMENT_POSITION = 'changementPosition';
 export const CHANGEMENT_SELECTION = 'changementSelection';
 
 export default class Piece extends EventEmitter {
-  constructor ({ x, y, image }) {
+  constructor ({ x, y, type }) {
     super();
     this.x = x;
     this.y = y;
-    this.image = image;
+    this.type = type;
     this.selectionnee = false;
   }
 

--- a/src/situations/commun/vues/piece.js
+++ b/src/situations/commun/vues/piece.js
@@ -5,14 +5,16 @@ import 'commun/styles/piece.scss';
 import { CHANGEMENT_POSITION } from 'commun/modeles/piece';
 
 export default class VuePiece extends EventEmitter {
-  constructor (piece) {
+  constructor (piece, depotRessources) {
     super();
     this.piece = piece;
+    this.depotRessources = depotRessources;
   }
 
   affiche (pointInsertion, $) {
-    function creeElementPiece (piece, dimensionsElementParent) {
-      let $piece = $(`<img class="piece" src="${piece.image}">`);
+    function creeElementPiece (depotRessources, piece, dimensionsElementParent) {
+      const image = depotRessources.piece(piece.type);
+      const $piece = $(`<img class="piece" src="${image}">`);
       metsAJourPosition($piece, piece.position(), dimensionsElementParent);
       return $piece;
     }
@@ -27,7 +29,7 @@ export default class VuePiece extends EventEmitter {
       largeurParent: this.$elementParent.width(),
       hauteurParent: this.$elementParent.height()
     };
-    this.$piece = creeElementPiece(this.piece, dimensionsElementParent);
+    this.$piece = creeElementPiece(this.depotRessources, this.piece, dimensionsElementParent);
     this.$elementParent.append(this.$piece);
 
     this.piece.on(CHANGEMENT_POSITION, (nouvellePosition) => {

--- a/src/situations/controle/data/pieces.js
+++ b/src/situations/controle/data/pieces.js
@@ -1,8 +1,7 @@
-const pieceConforme = { conforme: true, image: require('controle/assets/biscuit-normal.png') };
+const pieceConforme = { type: 'biscuit-normal', conforme: true };
 
 const piecesNonConformes = Array(19).fill().map((_, i) => {
-  const image = require(`controle/assets/def${i + 1}.png`);
-  return { conforme: false, image: image };
+  return { type: `def${i + 1}`, conforme: false };
 });
 
 const scenario = [

--- a/src/situations/controle/infra/depot_ressources_controle.js
+++ b/src/situations/controle/infra/depot_ressources_controle.js
@@ -2,9 +2,20 @@ import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
 
 import sonConsigne from 'controle/assets/consigne_demarrage.mp3';
 
+const biscuits = require.context('controle/assets', false, /(def[0-9]+|biscuit-normal)\.png$/);
+
 export default class DepotRessourcesControle extends DepotRessourcesCommunes {
   constructor (chargeurs) {
     super(sonConsigne, chargeurs);
     this.chargeContexte(require.context('controle/assets'));
+
+    this.biscuits = biscuits.keys().reduce((memo, fichier) => {
+      memo[fichier.match(/(def[0-9]+|biscuit-normal).png/)[1]] = biscuits(fichier);
+      return memo;
+    }, {});
+  }
+
+  piece (type) {
+    return this.biscuits[type];
   }
 }

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -57,7 +57,7 @@ export default class Situation extends SituationCommune {
     return new Piece({ x: this.positionApparition.x,
       y: this.positionApparition.y,
       conforme: donneesPiece.conforme,
-      image: donneesPiece.image });
+      type: donneesPiece.type });
   }
 
   piecesAffichees () {

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -14,9 +14,10 @@ export function animationFinale ($element, done) {
 
 export default class VuePiece extends VuePieceCommune {
   constructor (piece,
+    depotRessources,
     callbackApresApparition = animationInitiale,
     callbackAvantSuppression = animationFinale) {
-    super(piece);
+    super(piece, depotRessources);
 
     this.callbackApresApparition = callbackApresApparition;
     this.callbackAvantSuppression = callbackAvantSuppression;

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -14,7 +14,7 @@ import VueFondSonore from 'controle/vues/fond_sonore';
 import VueFin from 'controle/vues/fin';
 
 export default class VueSituation {
-  constructor (situation, journal) {
+  constructor (situation, journal, depotRessources) {
     function nouveauBac (categorie, { x, y }) {
       return new Bac({ categorie, x, y, largeur: 22.6, hauteur: 41.3 });
     }
@@ -27,13 +27,14 @@ export default class VueSituation {
 
     this.situation = situation;
     this.journal = journal;
+    this.depotRessources = depotRessources;
     this.tapis = new VueTapis(situation);
     this.fondSonore = new VueFondSonore(situation);
     this.fin = new VueFin(situation);
   }
 
   creeVuePiece (piece) {
-    return new VuePiece(piece);
+    return new VuePiece(piece, this.depotRessources);
   }
 
   affiche (pointInsertion, $) {

--- a/src/situations/tri/data/pieces.js
+++ b/src/situations/tri/data/pieces.js
@@ -4,71 +4,71 @@ const scene = {
 };
 
 const pieces = [
-  { image: require('tri/assets/bonbon3.png'), y: 430 / scene.hauteur * 100, x: 855 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon6.png'), y: 430 / scene.hauteur * 100, x: 301 / scene.largeur * 100 },
+  { type: 'bonbon3', y: 430 / scene.hauteur * 100, x: 855 / scene.largeur * 100 },
+  { type: 'bonbon6', y: 430 / scene.hauteur * 100, x: 301 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon2.png'), y: 433 / scene.hauteur * 100, x: 723 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon6.png'), y: 433 / scene.hauteur * 100, x: 335 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon1.png'), y: 433 / scene.hauteur * 100, x: 196 / scene.largeur * 100 },
+  { type: 'bonbon2', y: 433 / scene.hauteur * 100, x: 723 / scene.largeur * 100 },
+  { type: 'bonbon6', y: 433 / scene.hauteur * 100, x: 335 / scene.largeur * 100 },
+  { type: 'bonbon1', y: 433 / scene.hauteur * 100, x: 196 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon8.png'), y: 434 / scene.hauteur * 100, x: 688 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon7.png'), y: 435 / scene.hauteur * 100, x: 450 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon7.png'), y: 437 / scene.hauteur * 100, x: 474 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon2.png'), y: 439 / scene.hauteur * 100, x: 289 / scene.largeur * 100 },
+  { type: 'bonbon8', y: 434 / scene.hauteur * 100, x: 688 / scene.largeur * 100 },
+  { type: 'bonbon7', y: 435 / scene.hauteur * 100, x: 450 / scene.largeur * 100 },
+  { type: 'bonbon7', y: 437 / scene.hauteur * 100, x: 474 / scene.largeur * 100 },
+  { type: 'bonbon2', y: 439 / scene.hauteur * 100, x: 289 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon2.png'), y: 443 / scene.hauteur * 100, x: 706 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon8.png'), y: 443 / scene.hauteur * 100, x: 403 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon11.png'), y: 443 / scene.hauteur * 100, x: 243 / scene.largeur * 100 },
+  { type: 'bonbon2', y: 443 / scene.hauteur * 100, x: 706 / scene.largeur * 100 },
+  { type: 'bonbon8', y: 443 / scene.hauteur * 100, x: 403 / scene.largeur * 100 },
+  { type: 'bonbon11', y: 443 / scene.hauteur * 100, x: 243 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon6.png'), y: 445 / scene.hauteur * 100, x: 387 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon9.png'), y: 445 / scene.hauteur * 100, x: 231 / scene.largeur * 100 },
+  { type: 'bonbon6', y: 445 / scene.hauteur * 100, x: 387 / scene.largeur * 100 },
+  { type: 'bonbon9', y: 445 / scene.hauteur * 100, x: 231 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon3.png'), y: 447 / scene.hauteur * 100, x: 91 / scene.largeur * 100 },
+  { type: 'bonbon3', y: 447 / scene.hauteur * 100, x: 91 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon12.png'), y: 448 / scene.hauteur * 100, x: 501 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon12.png'), y: 448 / scene.hauteur * 100, x: 174 / scene.largeur * 100 },
+  { type: 'bonbon12', y: 448 / scene.hauteur * 100, x: 501 / scene.largeur * 100 },
+  { type: 'bonbon12', y: 448 / scene.hauteur * 100, x: 174 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon10.png'), y: 450 / scene.hauteur * 100, x: 638 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon5.png'), y: 450 / scene.hauteur * 100, x: 281 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon10.png'), y: 450 / scene.hauteur * 100, x: 255 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon12.png'), y: 450 / scene.hauteur * 100, x: 51 / scene.largeur * 100 },
+  { type: 'bonbon10', y: 450 / scene.hauteur * 100, x: 638 / scene.largeur * 100 },
+  { type: 'bonbon5', y: 450 / scene.hauteur * 100, x: 281 / scene.largeur * 100 },
+  { type: 'bonbon10', y: 450 / scene.hauteur * 100, x: 255 / scene.largeur * 100 },
+  { type: 'bonbon12', y: 450 / scene.hauteur * 100, x: 51 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon9.png'), y: 451 / scene.hauteur * 100, x: 832 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon11.png'), y: 451 / scene.hauteur * 100, x: 299 / scene.largeur * 100 },
+  { type: 'bonbon9', y: 451 / scene.hauteur * 100, x: 832 / scene.largeur * 100 },
+  { type: 'bonbon11', y: 451 / scene.hauteur * 100, x: 299 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon5.png'), y: 452 / scene.hauteur * 100, x: 457 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon9.png'), y: 453 / scene.hauteur * 100, x: 619 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon10.png'), y: 455 / scene.hauteur * 100, x: 140 / scene.largeur * 100 },
+  { type: 'bonbon5', y: 452 / scene.hauteur * 100, x: 457 / scene.largeur * 100 },
+  { type: 'bonbon9', y: 453 / scene.hauteur * 100, x: 619 / scene.largeur * 100 },
+  { type: 'bonbon10', y: 455 / scene.hauteur * 100, x: 140 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon12.png'), y: 456 / scene.hauteur * 100, x: 671 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon3.png'), y: 456 / scene.hauteur * 100, x: 346 / scene.largeur * 100 },
+  { type: 'bonbon12', y: 456 / scene.hauteur * 100, x: 671 / scene.largeur * 100 },
+  { type: 'bonbon3', y: 456 / scene.hauteur * 100, x: 346 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon3.png'), y: 458 / scene.hauteur * 100, x: 308 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon10.png'), y: 462 / scene.hauteur * 100, x: 303 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon4.png'), y: 463 / scene.hauteur * 100, x: 230 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon2.png'), y: 464 / scene.hauteur * 100, x: 453 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon11.png'), y: 466 / scene.hauteur * 100, x: 750 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon4.png'), y: 468 / scene.hauteur * 100, x: 404 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon5.png'), y: 469 / scene.hauteur * 100, x: 328 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon7.png'), y: 470 / scene.hauteur * 100, x: 751 / scene.largeur * 100 },
+  { type: 'bonbon3', y: 458 / scene.hauteur * 100, x: 308 / scene.largeur * 100 },
+  { type: 'bonbon10', y: 462 / scene.hauteur * 100, x: 303 / scene.largeur * 100 },
+  { type: 'bonbon4', y: 463 / scene.hauteur * 100, x: 230 / scene.largeur * 100 },
+  { type: 'bonbon2', y: 464 / scene.hauteur * 100, x: 453 / scene.largeur * 100 },
+  { type: 'bonbon11', y: 466 / scene.hauteur * 100, x: 750 / scene.largeur * 100 },
+  { type: 'bonbon4', y: 468 / scene.hauteur * 100, x: 404 / scene.largeur * 100 },
+  { type: 'bonbon5', y: 469 / scene.hauteur * 100, x: 328 / scene.largeur * 100 },
+  { type: 'bonbon7', y: 470 / scene.hauteur * 100, x: 751 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon1.png'), y: 471 / scene.hauteur * 100, x: 632 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon9.png'), y: 471 / scene.hauteur * 100, x: 605 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon7.png'), y: 471 / scene.hauteur * 100, x: 440 / scene.largeur * 100 },
+  { type: 'bonbon1', y: 471 / scene.hauteur * 100, x: 632 / scene.largeur * 100 },
+  { type: 'bonbon9', y: 471 / scene.hauteur * 100, x: 605 / scene.largeur * 100 },
+  { type: 'bonbon7', y: 471 / scene.hauteur * 100, x: 440 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon5.png'), y: 473 / scene.hauteur * 100, x: 654 / scene.largeur * 100 },
+  { type: 'bonbon5', y: 473 / scene.hauteur * 100, x: 654 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon4.png'), y: 474 / scene.hauteur * 100, x: 808 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon11.png'), y: 474 / scene.hauteur * 100, x: 402 / scene.largeur * 100 },
+  { type: 'bonbon4', y: 474 / scene.hauteur * 100, x: 808 / scene.largeur * 100 },
+  { type: 'bonbon11', y: 474 / scene.hauteur * 100, x: 402 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon6.png'), y: 475 / scene.hauteur * 100, x: 374 / scene.largeur * 100 },
+  { type: 'bonbon6', y: 475 / scene.hauteur * 100, x: 374 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon8.png'), y: 476 / scene.hauteur * 100, x: 713 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon8.png'), y: 476 / scene.hauteur * 100, x: 106 / scene.largeur * 100 },
+  { type: 'bonbon8', y: 476 / scene.hauteur * 100, x: 713 / scene.largeur * 100 },
+  { type: 'bonbon8', y: 476 / scene.hauteur * 100, x: 106 / scene.largeur * 100 },
 
-  { image: require('tri/assets/bonbon1.png'), y: 477 / scene.hauteur * 100, x: 795 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon4.png'), y: 477 / scene.hauteur * 100, x: 664 / scene.largeur * 100 },
-  { image: require('tri/assets/bonbon1.png'), y: 477 / scene.hauteur * 100, x: 316 / scene.largeur * 100 }
+  { type: 'bonbon1', y: 477 / scene.hauteur * 100, x: 795 / scene.largeur * 100 },
+  { type: 'bonbon4', y: 477 / scene.hauteur * 100, x: 664 / scene.largeur * 100 },
+  { type: 'bonbon1', y: 477 / scene.hauteur * 100, x: 316 / scene.largeur * 100 }
 ];
 
 export default { pieces };

--- a/src/situations/tri/infra/depot_ressources_tri.js
+++ b/src/situations/tri/infra/depot_ressources_tri.js
@@ -3,13 +3,24 @@ import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
 import sonConsigne from 'tri/assets/consigne_demarrage.mp3';
 import fondSituation from 'tri/assets/fond-situation.jpg';
 
+const bonbons = require.context('tri/assets', false, /bonbon[0-9]+\.png$/);
+
 export default class DepotRessourcesTri extends DepotRessourcesCommunes {
   constructor (chargeurs) {
     super(sonConsigne, chargeurs);
     this.charge([fondSituation]);
+    this.chargeContexte(bonbons);
+    this.bonbons = bonbons.keys().reduce((memo, fichier) => {
+      memo[fichier.match(/(bonbon[0-9]+).png/)[1]] = bonbons(fichier);
+      return memo;
+    }, {});
   }
 
   fondSituation () {
     return this.ressource(fondSituation);
+  }
+
+  piece (type) {
+    return this.bonbons[type];
   }
 }

--- a/src/situations/tri/vues/situation.js
+++ b/src/situations/tri/vues/situation.js
@@ -2,17 +2,17 @@ import 'tri/styles/situation.scss';
 import VuePiece from 'tri/vues/piece.js';
 
 export default class VueSituationTri {
-  constructor (situation, journal, depotRessource) {
-    this.depotRessource = depotRessource;
+  constructor (situation, journal, depotRessources) {
+    this.depotRessources = depotRessources;
     this.situation = situation;
   }
 
   affiche (pointInsertion, $) {
     $(pointInsertion).addClass('tri')
-      .css('background-image', `url('${this.depotRessource.fondSituation().src}')`);
+      .css('background-image', `url('${this.depotRessources.fondSituation().src}')`);
 
     this.situation.pieces.forEach((piece) => {
-      const vuePiece = new VuePiece(piece);
+      const vuePiece = new VuePiece(piece, this.depotRessources);
       vuePiece.affiche(pointInsertion, $);
     });
   }

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -3,21 +3,23 @@ import jsdom from 'jsdom-global';
 import Piece from 'commun/modeles/piece';
 import VuePiece from 'commun/vues/piece';
 
-function creeVueMinimale (piece) {
-  return new VuePiece(piece, () => {}, () => {});
+function creeVueMinimale (piece, depot) {
+  return new VuePiece(piece, depot);
 }
 
 describe('Une pièce', function () {
   let $;
+  let depot;
 
   beforeEach(function () {
     jsdom('<div id="pointInsertion" style="width: 100px; height: 100px"></div>');
     $ = jQuery(window);
+    depot = { piece () { } };
   });
 
   it("s'affiche", function () {
     const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = creeVueMinimale(piece);
+    const vuePiece = creeVueMinimale(piece, depot);
     expect($('.piece').length).to.equal(0);
 
     vuePiece.affiche('#pointInsertion', $);
@@ -25,15 +27,19 @@ describe('Une pièce', function () {
   });
 
   it("affiche l'image de la piece", function () {
-    const piece = new Piece({ x: 90, y: 40, image: 'image-url' });
-    const vuePiece = creeVueMinimale(piece);
+    depot.piece = function (type) {
+      expect(type).to.equal('image-type');
+      return 'image-url';
+    };
+    const piece = new Piece({ x: 90, y: 40, type: 'image-type' });
+    const vuePiece = creeVueMinimale(piece, depot);
     vuePiece.affiche('#pointInsertion', $);
     expect($('.piece').attr('src')).to.eql('image-url');
   });
 
   it("se positionne correctement vis-à-vis de l'élément parent", function () {
     const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = creeVueMinimale(piece);
+    const vuePiece = creeVueMinimale(piece, depot);
 
     $('#pointInsertion').width(200).height(50);
     vuePiece.affiche('#pointInsertion', $);
@@ -44,7 +50,7 @@ describe('Une pièce', function () {
 
   it('peut être bougée', function () {
     const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = creeVueMinimale(piece);
+    const vuePiece = creeVueMinimale(piece, depot);
 
     $('#pointInsertion').width(100).height(100);
     vuePiece.affiche('#pointInsertion', $);

--- a/tests/situations/controle/infra/depot_ressources_controle.js
+++ b/tests/situations/controle/infra/depot_ressources_controle.js
@@ -7,4 +7,14 @@ describe('Le dépôt de ressources de la situation contrôle', function () {
     const depot = new DepotRessourcesControle(chargeurs());
     expect(depot).to.be.a(DepotRessourcesCommunes);
   });
+
+  it('retourne les biscuits en défaut', function () {
+    const depot = new DepotRessourcesControle(chargeurs());
+    expect(depot.piece('def10')).to.not.be(undefined);
+  });
+
+  it('retourne le biscuit normal', function () {
+    const depot = new DepotRessourcesControle(chargeurs());
+    expect(depot.piece('biscuit-normal')).to.not.be(undefined);
+  });
 });

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -3,21 +3,23 @@ import { DISPARITION_PIECE } from 'controle/modeles/situation';
 import Piece from 'controle/modeles/piece';
 import VuePiece from 'controle/vues/piece';
 
-function creeVueMinimale (piece) {
-  return new VuePiece(piece, () => {}, () => {});
+function creeVueMinimale (piece, depot) {
+  return new VuePiece(piece, depot, () => {}, () => {});
 }
 
 describe('Une pièce', function () {
   let $;
+  let depot;
 
   beforeEach(function () {
     jsdom('<div id="controle" style="width: 100px; height: 100px"></div>');
     $ = jQuery(window);
+    depot = { piece () { } };
   });
 
   it('peut être sélectionnée', function () {
     const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = creeVueMinimale(piece);
+    const vuePiece = creeVueMinimale(piece, depot);
     vuePiece.affiche('#controle', $);
 
     expect(piece.estSelectionnee()).to.be(false);
@@ -29,7 +31,7 @@ describe('Une pièce', function () {
     const piece = new Piece({ x: 90, y: 40 });
     piece.selectionne({ x: 95, y: 55 });
 
-    const vuePiece = creeVueMinimale(piece);
+    const vuePiece = creeVueMinimale(piece, depot);
     vuePiece.affiche('#controle', $);
 
     expect(piece.estSelectionnee()).to.be(true);
@@ -39,7 +41,7 @@ describe('Une pièce', function () {
 
   it("suit une séquence d'animation pour apparaître", function (done) {
     const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = new VuePiece(piece, function ($element) {
+    const vuePiece = new VuePiece(piece, depot, function ($element) {
       expect($element.hasClass('.piece'));
       done();
     });
@@ -52,7 +54,7 @@ describe('Une pièce', function () {
     const sequenceAnimation = function ($element) {
       $element.animate({ left: '80px' }, 0).delay(5).animate({ left: '10px' }, 0);
     };
-    const vuePiece = new VuePiece(piece, sequenceAnimation);
+    const vuePiece = new VuePiece(piece, depot, sequenceAnimation);
 
     vuePiece.affiche('#controle', $);
 
@@ -76,7 +78,7 @@ describe('Une pièce', function () {
       done();
     };
 
-    const vuePiece = new VuePiece(piece, () => {}, callbackAvantSuppression);
+    const vuePiece = new VuePiece(piece, depot, () => {}, callbackAvantSuppression);
     vuePiece.affiche('#controle', $);
     expect($('.piece').length).to.equal(1);
     piece.emit(DISPARITION_PIECE);
@@ -91,7 +93,7 @@ describe('Une pièce', function () {
       done();
     };
 
-    const vuePiece = new VuePiece(piece, () => {}, callbackAvantSuppression);
+    const vuePiece = new VuePiece(piece, depot, () => {}, callbackAvantSuppression);
     vuePiece.affiche('#controle', $);
     expect($('.desactiver').length).to.equal(0);
     piece.emit(DISPARITION_PIECE);
@@ -100,7 +102,7 @@ describe('Une pièce', function () {
 
   it("rajoute la classe selectionne lorsqu'elle est sélectionné", function () {
     const piece = new Piece({});
-    const vuePiece = creeVueMinimale(piece);
+    const vuePiece = creeVueMinimale(piece, depot);
     vuePiece.affiche('#controle', $);
     expect($('.piece.selectionnee').length).to.equal(0);
     piece.selectionne({ x: 0, y: 0 });
@@ -109,7 +111,7 @@ describe('Une pièce', function () {
 
   it("réordonne la pièce sélectionnée pour la placer en dernier dans l'élément parent", function () {
     const piece = new Piece({});
-    const vuePiece = creeVueMinimale(piece);
+    const vuePiece = creeVueMinimale(piece, depot);
     vuePiece.affiche('#controle', $);
     $('#controle').append(`<div class="element"></div>`);
     expect($('.piece').index()).to.equal(0);

--- a/tests/situations/tri/infra/depot_ressources_tri.js
+++ b/tests/situations/tri/infra/depot_ressources_tri.js
@@ -7,4 +7,9 @@ describe('Le dépôt de ressources de la situation tri', function () {
     const depot = new DepotRessourcesTri(chargeurs());
     expect(depot).to.be.a(DepotRessourcesCommunes);
   });
+
+  it('retourne les bonbons', function () {
+    const depot = new DepotRessourcesTri(chargeurs());
+    expect(depot.piece('bonbon1')).to.not.be(undefined);
+  });
 });

--- a/tests/situations/tri/vues/situation.js
+++ b/tests/situations/tri/vues/situation.js
@@ -20,6 +20,7 @@ describe('La situation « Tri »', function () {
           src: 'image-de-fond'
         };
       }
+      piece () { }
     }();
     situation = new Situation({ pieces: [] });
     vueSituation = new VueSituation(situation, journal, mockDepotRessources);


### PR DESCRIPTION
Pour éviter d'avoir des `require` des fichiers images dans les données des situations contrôle et tri, elles contiennent désormais la référence de la pièce. La vue pièce va demander ensuite au dépot ressources le fichier image qui va bien.

Cela a également pour effet de précharger les bonbons dans la situation tri.

Cette PR est dépendante de #275, je vous invite a la lire avant.

Contribue à #213. 