### PR TITLE
Charge les resources audio en ajax et converti en audio avec webaudio

### DIFF
--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -14,7 +14,7 @@ export default class VueActions {
   affiche (pointInsertion, $) {
     this.$actions = $('<div class="actions"></div>');
     const stop = new VueStop(this.situation, this.journal);
-    const rejoueConsigne = new VueRejoueConsigne(this.depot.consigne(), this.journal);
+    const rejoueConsigne = new VueRejoueConsigne(this.depot, this.journal);
 
     stop.affiche(this.$actions, $);
     rejoueConsigne.affiche(this.$actions, $);

--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -29,6 +29,6 @@ export default class VueConsigne extends VueActionOverlay {
 
   joueSon ($, son, callbackFin) {
     $(son).on('ended', callbackFin);
-    son.play();
+    son.start();
   }
 }

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -7,8 +7,8 @@ import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 import 'commun/styles/bouton.scss';
 
 export default class VueRejoueConsigne {
-  constructor (consigne, journal) {
-    this.consigne = consigne;
+  constructor (depotResources, journal) {
+    this.depotResources = depotResources;
     this.journal = journal;
     this.vueBoutonLire = new VueBouton('bouton-lire-consigne', play, () => this.joueConsigne(this.$));
     this.vueBoutonLire.ajouteUneEtiquette(traduction('situation.repeter_consigne'));
@@ -19,14 +19,15 @@ export default class VueRejoueConsigne {
     this.$ = $;
     this.pointInsertion = pointInsertion;
     this.vueBoutonLire.affiche(this.pointInsertion, $);
-    $(this.consigne).on('ended', this.lectureTermine.bind(this));
   }
 
   joueConsigne ($) {
     this.journal.enregistre(new EvenementRejoueConsigne());
     this.vueBoutonLire.cache();
     this.vueBoutonLectureEnCours.affiche(this.pointInsertion, $);
-    this.consigne.play();
+    const consigne = this.depotResources.consigne();
+    $(consigne).on('ended', this.lectureTermine.bind(this));
+    consigne.start();
   }
 
   lectureTermine () {

--- a/tests/situations/commun/aides/mock_audio_node.js
+++ b/tests/situations/commun/aides/mock_audio_node.js
@@ -1,0 +1,9 @@
+export default class MockAudioNode {
+  constructor (son) {
+    this.src = son;
+  }
+
+  start () {}
+
+  stop () {}
+}

--- a/tests/situations/commun/aides/mock_chargeurs.js
+++ b/tests/situations/commun/aides/mock_chargeurs.js
@@ -1,10 +1,10 @@
-import MockAudio from './mock_audio';
+import MockAudioNode from '../aides/mock_audio_node';
 const chargeurDefaut = () => Promise.resolve(() => {});
 
 export default function (chargeurs = {}) {
   return {
     svg: chargeurDefaut,
-    mp3: () => Promise.resolve(() => new MockAudio()),
+    mp3: () => Promise.resolve(() => new MockAudioNode()),
     png: chargeurDefaut,
     jpg: chargeurDefaut,
     ...chargeurs

--- a/tests/situations/commun/infra/depot_ressources.js
+++ b/tests/situations/commun/infra/depot_ressources.js
@@ -1,5 +1,6 @@
 import DepotRessources from 'commun/infra/depot_ressources';
 import jsdom from 'jsdom-global';
+import chargeurs from '../../commun/aides/mock_chargeurs';
 
 describe('le dépôt de ressources', function () {
   beforeEach(function () {
@@ -7,16 +8,13 @@ describe('le dépôt de ressources', function () {
   });
 
   it('permet de charger toutes les ressources', function () {
-    const depot = new DepotRessources();
+    const depot = new DepotRessources(chargeurs());
     depot.charge(['test.png', 'test2.png', 'test.mp3']);
     expect(depot.promesses.length).to.equal(3);
   });
 
   it('résout la promesse lorsque toutes les ressources sont chargées', function (done) {
-    const depot = new DepotRessources({
-      mp3: () => Promise.resolve(),
-      png: () => Promise.resolve()
-    });
+    const depot = new DepotRessources(chargeurs());
     depot.charge(['test.png', 'test.mp3']);
     depot.chargement().then(() => done());
   });
@@ -31,7 +29,7 @@ describe('le dépôt de ressources', function () {
   });
 
   it('sait charger des ressources en plusieurs fois', function () {
-    const depot = new DepotRessources();
+    const depot = new DepotRessources(chargeurs());
     depot.charge(['test.png', 'test.mp3']);
     depot.charge(['unFichierSupplementaire.png']);
 

--- a/tests/situations/commun/infra/depot_ressources_communes.js
+++ b/tests/situations/commun/infra/depot_ressources_communes.js
@@ -1,14 +1,21 @@
+import chargeurs from '../aides/mock_chargeurs';
 import DepotRessources from 'commun/infra/depot_ressources';
 import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
-import chargeurs from '../../commun/aides/mock_chargeurs';
 
 describe('Le dépot de ressources communes', function () {
   let depot;
   let son;
+  let dernierSonCharge;
 
   beforeEach(function () {
     son = 'test.mp3';
-    depot = new DepotRessourcesCommunes(son, chargeurs());
+    const _chargeurs = chargeurs({
+      mp3: (_son) => {
+        dernierSonCharge = _son;
+        return Promise.resolve(() => 'mp3_precharge');
+      }
+    });
+    depot = new DepotRessourcesCommunes(son, _chargeurs);
   });
 
   it('étend DépotRessources', function () {
@@ -19,19 +26,19 @@ describe('Le dépot de ressources communes', function () {
     expect(depot.promesses.length).not.to.equal(0);
   });
 
+  it('charge la consigne', function () {
+    expect(dernierSonCharge).to.equal(son);
+  });
+
   it('retourne la consigne', function () {
-    const _chargeurs = chargeurs({
-      mp3: () => Promise.resolve(() => 'plop')
-    });
-    depot = new DepotRessourcesCommunes(son, _chargeurs);
     return depot.chargement().then(() => {
-      expect(depot.consigne()).to.eql('plop');
+      expect(depot.consigne()).to.eql('mp3_precharge');
     });
   });
 
   it('retourne la consigne commune', function () {
     return depot.chargement().then(() => {
-      expect(depot.consigneCommune()).to.not.be(undefined);
+      expect(depot.consigneCommune()).to.eql('mp3_precharge');
     });
   });
 });

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
 
-import MockAudio from '../aides/mock_audio';
+import MockAudioNode from '../aides/mock_audio_node';
 
 import VueConsigne from 'commun/vues/consigne';
 import Situation, { CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
@@ -15,8 +15,8 @@ describe('vue consigne', function () {
     $ = jQuery(window);
     situation = new Situation();
     const depot = {
-      consigne: () => new MockAudio(),
-      consigneCommune: () => new MockAudio()
+      consigne: () => new MockAudioNode(),
+      consigneCommune: () => new MockAudioNode()
     };
     vue = new VueConsigne(situation, depot);
   });

--- a/tests/situations/inventaire/infra/depot_ressources_inventaire.js
+++ b/tests/situations/inventaire/infra/depot_ressources_inventaire.js
@@ -1,9 +1,10 @@
 import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
 import DepotRessourcesInventaire from 'inventaire/infra/depot_ressources_inventaire';
+import chargeurs from '../../commun/aides/mock_chargeurs';
 
 describe('Le dépôt de ressources de la situation inventaire', function () {
   it('étend DepotRessourcesCommunes', function () {
-    const depot = new DepotRessourcesInventaire();
+    const depot = new DepotRessourcesInventaire(chargeurs());
     expect(depot).to.be.a(DepotRessourcesCommunes);
   });
 });


### PR DESCRIPTION
En effet, il semble que le chargement des ressources audio n'émette pas forcément
l'événement 'canplaythrough' sur Safari.

fix #270 