### PR TITLE
déplace la sélection de la pièce dans la VuePiece commune

### DIFF
--- a/src/situations/commun/vues/piece.js
+++ b/src/situations/commun/vues/piece.js
@@ -2,7 +2,7 @@ import EventEmitter from 'events';
 
 import 'commun/styles/piece.scss';
 
-import { CHANGEMENT_POSITION } from 'commun/modeles/piece';
+import { CHANGEMENT_POSITION, CHANGEMENT_SELECTION } from 'commun/modeles/piece';
 
 export default class VuePiece extends EventEmitter {
   constructor (piece, depotRessources) {
@@ -34,6 +34,27 @@ export default class VuePiece extends EventEmitter {
 
     this.piece.on(CHANGEMENT_POSITION, (nouvellePosition) => {
       metsAJourPosition(this.$piece, nouvellePosition, dimensionsElementParent);
+    });
+
+    this.$piece.mousedown(e => {
+      this.$piece.stop(true);
+      this.$piece.css('opacity', 1);
+      this.piece.changePosition({
+        x: 100 * parseInt(this.$piece.css('left')) / this.$elementParent.width(),
+        y: 100 * parseInt(this.$piece.css('top')) / this.$elementParent.height()
+      });
+      this.piece.selectionne({
+        x: 100 * e.clientX / this.$elementParent.width(),
+        y: 100 * e.clientY / this.$elementParent.height()
+      });
+    });
+
+    this.$piece.on('dragstart', function (event) { event.preventDefault(); });
+    this.$piece.mouseup(e => { this.piece.deselectionne(); });
+
+    this.piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
+      this.$elementParent.append(this.$piece);
+      this.$piece.toggleClass('selectionnee', selectionnee);
     });
   }
 }

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -1,7 +1,6 @@
 import 'controle/styles/piece.scss';
 
 import VuePieceCommune from 'commun/vues/piece';
-import { CHANGEMENT_SELECTION } from 'controle/modeles/piece';
 import { DISPARITION_PIECE } from 'controle/modeles/situation';
 
 export function animationInitiale ($element) {
@@ -25,27 +24,6 @@ export default class VuePiece extends VuePieceCommune {
 
   affiche (pointInsertion, $) {
     super.affiche(pointInsertion, $);
-
-    this.$piece.mousedown(e => {
-      this.$piece.stop(true);
-      this.$piece.css('opacity', 1);
-      this.piece.changePosition({
-        x: 100 * parseInt(this.$piece.css('left')) / this.$elementParent.width(),
-        y: 100 * parseInt(this.$piece.css('top')) / this.$elementParent.height()
-      });
-      this.piece.selectionne({
-        x: 100 * e.clientX / this.$elementParent.width(),
-        y: 100 * e.clientY / this.$elementParent.height()
-      });
-    });
-
-    this.$piece.on('dragstart', function (event) { event.preventDefault(); });
-    this.$piece.mouseup(e => { this.piece.deselectionne(); });
-
-    this.piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
-      this.$elementParent.append(this.$piece);
-      this.$piece.toggleClass('selectionnee', selectionnee);
-    });
     this.$piece.show(() => { this.callbackApresApparition(this.$piece); });
 
     this.piece.on(DISPARITION_PIECE, () => {

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -63,4 +63,45 @@ describe('Une pièce', function () {
     expect($('.piece').css('left')).to.eql('25px');
     expect($('.piece').css('top')).to.eql('5px');
   });
+
+  it('peut être sélectionnée', function () {
+    const piece = new Piece({ x: 90, y: 40 });
+    const vuePiece = creeVueMinimale(piece, depot);
+    vuePiece.affiche('#pointInsertion', $);
+
+    expect(piece.estSelectionnee()).to.be(false);
+    $('.piece').trigger($.Event('mousedown', { clientX: 95, clientY: 55 }));
+    expect(piece.estSelectionnee()).to.be(true);
+  });
+
+  it('peut être désélectionnée', function () {
+    const piece = new Piece({ x: 90, y: 40 });
+    piece.selectionne({ x: 95, y: 55 });
+
+    const vuePiece = creeVueMinimale(piece, depot);
+    vuePiece.affiche('#pointInsertion', $);
+
+    expect(piece.estSelectionnee()).to.be(true);
+    $('.piece').trigger($.Event('mouseup'));
+    expect(piece.estSelectionnee()).to.be(false);
+  });
+
+  it("rajoute la classe selectionne lorsqu'elle est sélectionné", function () {
+    const piece = new Piece({});
+    const vuePiece = creeVueMinimale(piece, depot);
+    vuePiece.affiche('#pointInsertion', $);
+    expect($('.piece.selectionnee').length).to.equal(0);
+    piece.selectionne({ x: 0, y: 0 });
+    expect($('.piece.selectionnee').length).to.equal(1);
+  });
+
+  it("réordonne la pièce sélectionnée pour la placer en dernier dans l'élément parent", function () {
+    const piece = new Piece({});
+    const vuePiece = creeVueMinimale(piece, depot);
+    vuePiece.affiche('#pointInsertion', $);
+    $('#pointInsertion').append(`<div class="element"></div>`);
+    expect($('.piece').index()).to.equal(0);
+    piece.selectionne({ x: 0, y: 0 });
+    expect($('.piece').index()).to.equal(1);
+  });
 });

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -3,10 +3,6 @@ import { DISPARITION_PIECE } from 'controle/modeles/situation';
 import Piece from 'controle/modeles/piece';
 import VuePiece from 'controle/vues/piece';
 
-function creeVueMinimale (piece, depot) {
-  return new VuePiece(piece, depot, () => {}, () => {});
-}
-
 describe('Une pièce', function () {
   let $;
   let depot;
@@ -15,28 +11,6 @@ describe('Une pièce', function () {
     jsdom('<div id="controle" style="width: 100px; height: 100px"></div>');
     $ = jQuery(window);
     depot = { piece () { } };
-  });
-
-  it('peut être sélectionnée', function () {
-    const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = creeVueMinimale(piece, depot);
-    vuePiece.affiche('#controle', $);
-
-    expect(piece.estSelectionnee()).to.be(false);
-    $('.piece').trigger($.Event('mousedown', { clientX: 95, clientY: 55 }));
-    expect(piece.estSelectionnee()).to.be(true);
-  });
-
-  it('peut être désélectionnée', function () {
-    const piece = new Piece({ x: 90, y: 40 });
-    piece.selectionne({ x: 95, y: 55 });
-
-    const vuePiece = creeVueMinimale(piece, depot);
-    vuePiece.affiche('#controle', $);
-
-    expect(piece.estSelectionnee()).to.be(true);
-    $('.piece').trigger($.Event('mouseup'));
-    expect(piece.estSelectionnee()).to.be(false);
   });
 
   it("suit une séquence d'animation pour apparaître", function (done) {
@@ -98,24 +72,5 @@ describe('Une pièce', function () {
     expect($('.desactiver').length).to.equal(0);
     piece.emit(DISPARITION_PIECE);
     expect($('.desactiver').length).to.equal(1);
-  });
-
-  it("rajoute la classe selectionne lorsqu'elle est sélectionné", function () {
-    const piece = new Piece({});
-    const vuePiece = creeVueMinimale(piece, depot);
-    vuePiece.affiche('#controle', $);
-    expect($('.piece.selectionnee').length).to.equal(0);
-    piece.selectionne({ x: 0, y: 0 });
-    expect($('.piece.selectionnee').length).to.equal(1);
-  });
-
-  it("réordonne la pièce sélectionnée pour la placer en dernier dans l'élément parent", function () {
-    const piece = new Piece({});
-    const vuePiece = creeVueMinimale(piece, depot);
-    vuePiece.affiche('#controle', $);
-    $('#controle').append(`<div class="element"></div>`);
-    expect($('.piece').index()).to.equal(0);
-    piece.selectionne({ x: 0, y: 0 });
-    expect($('.piece').index()).to.equal(1);
   });
 });


### PR DESCRIPTION
Le comportement de sélection d'une pièce est déplacée de la `VuePiece` du contrôle vers la `VuePiece` commune. 

Le tri en hérite par conséquent : on peut cliquer sur une pièce et constater qu'elle prend le focus. Ça lui redonne un côté flottant mais j'ai fait le choix de tolérer ça pour le moment.

Contribue à #213 

![Capture d’écran 2019-05-20 à 12 05 17](https://user-images.githubusercontent.com/28393/58013738-8ea1f400-7af7-11e9-9083-f27351a0eb59.png)


