### PR TITLE
Permettre à l'utilisateur de relire la consigne avant de cliquer sur GO

### DIFF
--- a/src/situations/commun/styles/actions.scss
+++ b/src/situations/commun/styles/actions.scss
@@ -5,7 +5,6 @@
   background: $couleur-fond-actions;
   padding: 1rem;
   display: flex;
-  flex-direction: row-reverse;
   align-items: center;
   justify-content: space-between;
 }

--- a/src/situations/commun/styles/bouton.scss
+++ b/src/situations/commun/styles/bouton.scss
@@ -59,7 +59,7 @@
   height: 12.25rem;
   position: absolute;
   left: 50%;
-  top: 50%;
+  top: 60%;
   margin-left: -6.125rem;
   margin-top: -6.125rem;
   border-radius: 50%;

--- a/src/situations/commun/styles/cadre.scss
+++ b/src/situations/commun/styles/cadre.scss
@@ -1,7 +1,9 @@
+@import 'commun/styles/dimensions.scss';
+
 .scene {
   position: relative;
   width: 100%;
-  height: 35.375rem;
+  height: $largeur-cadre;
   background: ivory;
   overflow: hidden;
 }

--- a/src/situations/commun/styles/dimensions.scss
+++ b/src/situations/commun/styles/dimensions.scss
@@ -1,0 +1,1 @@
+$largeur-cadre: 35.375rem;

--- a/src/situations/commun/styles/modale.scss
+++ b/src/situations/commun/styles/modale.scss
@@ -16,7 +16,6 @@
 
   &.modale {
     background: rgba(0, 0, 0, 0.7);
-    height: 100%;
     label {
       display: block;
       width: 100%;

--- a/src/situations/commun/styles/modale.scss
+++ b/src/situations/commun/styles/modale.scss
@@ -16,6 +16,7 @@
 
   &.modale {
     background: rgba(0, 0, 0, 0.7);
+    height: 100%;
     label {
       display: block;
       width: 100%;

--- a/src/situations/commun/styles/overlay.scss
+++ b/src/situations/commun/styles/overlay.scss
@@ -9,7 +9,6 @@
   outline: none;
   display: flex;
   align-items: center;
-
   &.opaque {
     background: black;
   }

--- a/src/situations/commun/styles/overlay.scss
+++ b/src/situations/commun/styles/overlay.scss
@@ -1,3 +1,5 @@
+@import 'commun/styles/dimensions.scss';
+
 .overlay {
   z-index: 100;
   position: absolute;
@@ -9,7 +11,12 @@
   outline: none;
   display: flex;
   align-items: center;
+
   &.opaque {
     background: black;
+  }
+
+  &.hors-actions {
+    height: $largeur-cadre;
   }
 }

--- a/src/situations/commun/styles/terminer.scss
+++ b/src/situations/commun/styles/terminer.scss
@@ -20,6 +20,8 @@
   cursor: pointer;
   color: $blanc;
   background-color: $couleur-fond-bouton-terminer;
+  position: absolute;
+  right: 1rem;
   &:active {
     border-color: $couleur-fond-bouton-terminer;
   }

--- a/src/situations/commun/vues/action_overlay.js
+++ b/src/situations/commun/vues/action_overlay.js
@@ -16,11 +16,10 @@ export default class VueActionOverlay {
 
     this.vueBouton.affiche($conteneurBouton, $);
 
-    this.$overlay = $('<div class="overlay"></div>');
+    this.$overlay = $('<div class="overlay hors-actions"></div>');
 
     this.$overlay.append($conteneurBouton);
     this.$overlay.append(this.$message);
-
     $(pointInsertion).append(this.$overlay);
   }
 

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -27,7 +27,6 @@ export default class VueActions {
       this.rejoueConsigne.affiche(this.$actions, $);
     });
     actionsEtat.set(DEMARRE, () => {
-      this.rejoueConsigne.affiche(this.$actions, $);
       this.stop.affiche(this.$actions, $);
     });
     const changements = actionsEtat.get(etat);

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -1,5 +1,6 @@
 import 'commun/styles/actions.scss';
 import 'commun/styles/stop.scss';
+import { CHANGEMENT_ETAT, CONSIGNE_ECOUTEE, DEMARRE } from 'commun/modeles/situation';
 
 import VueStop from 'commun/vues/stop';
 import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
@@ -13,12 +14,26 @@ export default class VueActions {
 
   affiche (pointInsertion, $) {
     this.$actions = $('<div class="actions"></div>');
-    const stop = new VueStop(this.situation, this.journal);
-    const rejoueConsigne = new VueRejoueConsigne(this.depot, this.journal);
-
-    stop.affiche(this.$actions, $);
-    rejoueConsigne.affiche(this.$actions, $);
+    this.stop = new VueStop(this.situation, this.journal);
+    this.rejoueConsigne = new VueRejoueConsigne(this.depot, this.journal);
+    this.situation.on(CHANGEMENT_ETAT, (etat) => this.afficheBoutons(etat, $));
+    this.afficheBoutons(this.situation.etat(), $);
     $(pointInsertion).append(this.$actions);
+  }
+
+  afficheBoutons (etat, $) {
+    const actionsEtat = new Map();
+    actionsEtat.set(CONSIGNE_ECOUTEE, () => {
+      this.rejoueConsigne.affiche(this.$actions, $);
+    });
+    actionsEtat.set(DEMARRE, () => {
+      this.rejoueConsigne.affiche(this.$actions, $);
+      this.stop.affiche(this.$actions, $);
+    });
+    const changements = actionsEtat.get(etat);
+    if (changements) {
+      changements();
+    }
   }
 
   cache () {

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -24,10 +24,11 @@ export default class VueActions {
   afficheBoutons (etat, $) {
     const actionsEtat = new Map();
     actionsEtat.set(CONSIGNE_ECOUTEE, () => {
-      this.rejoueConsigne.affiche(this.$actions, $);
+      this.rejoueConsigne.affiche(this.$actions, $, this.situation);
     });
     actionsEtat.set(DEMARRE, () => {
       this.stop.affiche(this.$actions, $);
+      this.rejoueConsigne.affiche(this.$actions, $, this.situation);
     });
     const changements = actionsEtat.get(etat);
     if (changements) {

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -1,6 +1,7 @@
 import { traduction } from 'commun/infra/internationalisation';
 import VueBouton from './bouton';
 import EvenementRejoueConsigne from '../modeles/evenement_rejoue_consigne';
+import { DEMARRE } from 'commun/modeles/situation';
 
 import play from 'commun/assets/play.svg';
 import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
@@ -13,14 +14,13 @@ export default class VueRejoueConsigne {
     this.vueBoutonLire = new VueBouton('bouton-lire-consigne', play, () => this.joueConsigne(this.$));
     this.vueBoutonLire.ajouteUneEtiquette(traduction('situation.repeter_consigne'));
     this.vueBoutonLectureEnCours = new VueBouton('bouton-lecture-en-cours', lectureEnCours);
-    this.affichee = false;
   }
 
-  affiche (pointInsertion, $) {
-    if (this.affichee) {
+  affiche (pointInsertion, $, situation) {
+    this.etat = situation._etat;
+    if (this.etat === DEMARRE) {
       return;
     }
-    this.affichee = true;
     this.$ = $;
     this.$boutonRejoueConsigne = $('<div></div>');
     this.pointInsertion = pointInsertion;
@@ -31,14 +31,32 @@ export default class VueRejoueConsigne {
   joueConsigne ($) {
     this.journal.enregistre(new EvenementRejoueConsigne());
     this.vueBoutonLire.cache();
+
     this.vueBoutonLectureEnCours.affiche(this.$boutonRejoueConsigne, $);
+    this.definisConsigneAJouer($);
+  }
+
+  definisConsigneAJouer ($) {
     const consigne = this.depotResources.consigne();
-    $(consigne).on('ended', this.lectureTermine.bind(this));
-    consigne.start();
+    if (this.etat !== DEMARRE) {
+      this.joueSon($, consigne, () => this.joueConsigneCommune($));
+    } else {
+      this.joueSon($, consigne, () => this.lectureTermine($));
+    }
+  }
+
+  joueConsigneCommune ($) {
+    const consigneCommune = this.depotResources.consigneCommune();
+    this.joueSon($, consigneCommune, () => this.lectureTermine());
   }
 
   lectureTermine () {
     this.vueBoutonLectureEnCours.cache();
     this.vueBoutonLire.affiche(this.$boutonRejoueConsigne, this.$);
+  }
+
+  joueSon ($, son, callbackFin) {
+    $(son).on('ended', callbackFin);
+    son.start();
   }
 }

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -22,14 +22,16 @@ export default class VueRejoueConsigne {
     }
     this.affichee = true;
     this.$ = $;
+    this.$boutonRejoueConsigne = $('<div></div>');
     this.pointInsertion = pointInsertion;
-    this.vueBoutonLire.affiche(this.pointInsertion, $);
+    $(pointInsertion).append(this.$boutonRejoueConsigne);
+    this.vueBoutonLire.affiche(this.$boutonRejoueConsigne, $);
   }
 
   joueConsigne ($) {
     this.journal.enregistre(new EvenementRejoueConsigne());
     this.vueBoutonLire.cache();
-    this.vueBoutonLectureEnCours.affiche(this.pointInsertion, $);
+    this.vueBoutonLectureEnCours.affiche(this.$boutonRejoueConsigne, $);
     const consigne = this.depotResources.consigne();
     $(consigne).on('ended', this.lectureTermine.bind(this));
     consigne.start();
@@ -37,6 +39,6 @@ export default class VueRejoueConsigne {
 
   lectureTermine () {
     this.vueBoutonLectureEnCours.cache();
-    this.vueBoutonLire.affiche(this.pointInsertion, this.$);
+    this.vueBoutonLire.affiche(this.$boutonRejoueConsigne, this.$);
   }
 }

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -13,9 +13,14 @@ export default class VueRejoueConsigne {
     this.vueBoutonLire = new VueBouton('bouton-lire-consigne', play, () => this.joueConsigne(this.$));
     this.vueBoutonLire.ajouteUneEtiquette(traduction('situation.repeter_consigne'));
     this.vueBoutonLectureEnCours = new VueBouton('bouton-lecture-en-cours', lectureEnCours);
+    this.affichee = false;
   }
 
   affiche (pointInsertion, $) {
+    if (this.affichee) {
+      return;
+    }
+    this.affichee = true;
     this.$ = $;
     this.pointInsertion = pointInsertion;
     this.vueBoutonLire.affiche(this.pointInsertion, $);

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -17,7 +17,7 @@ export default class VueStop {
   }
 
   affiche (pointInsertion, $) {
-    const boutonStop = new VueBouton('bouton-stop', stop, () => { this.clickSurStop(pointInsertion, $); });
+    const boutonStop = new VueBouton('bouton-stop', stop, () => { this.clickSurStop($(pointInsertion).parent(), $); });
     boutonStop.ajouteUneEtiquette(traduction('situation.arreter_mission'), true);
     boutonStop.affiche(pointInsertion, $);
   }

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -34,11 +34,11 @@ describe('Affiche les éléments communs aux situations', function () {
     expect($('.bouton-lire-consigne', '.actions').length).to.equal(1);
   });
 
-  it("Affiche le bouton rejoue consigne et le bouton une fois que l'utilisateur à cliqué sur GO", function () {
+  it("Affiche bouton stop une fois que l'utilisateur à cliqué sur GO", function () {
     vueActions.affiche('#magasin', $);
     situation.modifieEtat(DEMARRE);
     expect($('.bouton-stop').length).to.equal(1);
-    expect($('.bouton-lire-consigne', '.actions').length).to.equal(1);
+    expect($('.bouton-lire-consigne', '.actions').length).to.equal(0);
   });
 
   it('cache le conteneur', function () {

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -1,7 +1,7 @@
 import jsdom from 'jsdom-global';
 
 import VueActions from 'commun/vues/actions';
-import SituationCommune from 'commun/modeles/situation';
+import SituationCommune, { CONSIGNE_ECOUTEE, DEMARRE } from 'commun/modeles/situation';
 
 describe('Affiche les éléments communs aux situations', function () {
   let vueActions;
@@ -21,8 +21,22 @@ describe('Affiche les éléments communs aux situations', function () {
     expect($('.actions').length).to.equal(1);
   });
 
-  it('Affiche les éléments en commun des situations (bouton stop, bouton rejoue consigne)', function () {
+  it("N'affiche pas les éléments communs au situation par défaut (bouton stop, bouton rejoue consigne)", function () {
     vueActions.affiche('#magasin', $);
+    expect($('.bouton-stop').length).to.equal(0);
+    expect($('.bouton-lire-consigne', '.actions').length).to.equal(0);
+  });
+
+  it("Affiche le bouton rejoue consigne une fois que l'utilisateur à joué une fois la consigne", function () {
+    vueActions.affiche('#magasin', $);
+    situation.modifieEtat(CONSIGNE_ECOUTEE);
+    expect($('.bouton-stop').length).to.equal(0);
+    expect($('.bouton-lire-consigne', '.actions').length).to.equal(1);
+  });
+
+  it("Affiche le bouton rejoue consigne et le bouton une fois que l'utilisateur à cliqué sur GO", function () {
+    vueActions.affiche('#magasin', $);
+    situation.modifieEtat(DEMARRE);
     expect($('.bouton-stop').length).to.equal(1);
     expect($('.bouton-lire-consigne', '.actions').length).to.equal(1);
   });


### PR DESCRIPTION
- [x] Cacher les boutons rejoueConsigne et stop tant que l'on a pas joué au moins une fois la consigne
- [x] Ne pas mettre l'overlay sur la partie actions
- [x] Faire apparaitre le bouton Stop une fois que l'on a cliqué sur GO
 ~~Si on clique sur le bouton relectureConsigne avant que la situation a démarré il faudrait disable le bouton Go tant que la relecture de la consigne n'est pas terminé~~