### PR TITLE
Améliore la méthode contient() du bac.

### DIFF
--- a/src/situations/controle/modeles/bac.js
+++ b/src/situations/controle/modeles/bac.js
@@ -41,11 +41,13 @@ export default class Bac extends EventEmitter {
 
   contient (piece) {
     const { x, y } = piece.position();
-    function estEntre (positionPiece, positionBac, tailleBac) {
-      return positionPiece >= positionBac && positionPiece <= positionBac + tailleBac;
+    const { largeur, hauteur } = piece.dimensions();
+    function estEntre (positionPiece, taillePiece, positionBac, tailleBac) {
+      return (positionPiece >= positionBac && positionPiece <= positionBac + tailleBac) ||
+        (positionPiece <= positionBac && positionPiece + taillePiece >= positionBac);
     }
-    return estEntre(x, this._position.x, this._dimensions.largeur) &&
-        estEntre(y, this._position.y, this._dimensions.hauteur);
+    return estEntre(x, largeur, this._position.x, this._dimensions.largeur) &&
+      estEntre(y, hauteur, this._position.y, this._dimensions.hauteur);
   }
 
   correspondALaCategorie (piece) {

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -58,7 +58,9 @@ export default class Situation extends SituationCommune {
       y: this.positionApparition.y,
       conforme: donneesPiece.conforme,
       type: donneesPiece.type,
-      largeur: 13 });
+      largeur: 13,
+      hauteur: 30
+    });
   }
 
   piecesAffichees () {

--- a/tests/situations/controle/modeles/bac.js
+++ b/tests/situations/controle/modeles/bac.js
@@ -44,15 +44,27 @@ describe('un bac', function () {
     expect(changementEtatSurvole).to.equal(2);
   });
 
-  it('sait si une pièce est posé dessus', function () {
+  it('sait si une pièce est parfaitement posé dessus', function () {
     const bac = new Bac({ x: 10, y: 20, largeur: 10, hauteur: 20 });
-    const piece = new Piece({ x: 13, y: 30 });
+    const piece = new Piece({ x: 13, y: 30, largeur: 5, hauteur: 10 });
+    expect(bac.contient(piece)).to.be(true);
+  });
+
+  it('sait si une pièce est posé dessus décalé vers la gauche', function () {
+    const bac = new Bac({ x: 10, y: 20, largeur: 10, hauteur: 20 });
+    const piece = new Piece({ x: 6, y: 30, largeur: 5, hauteur: 10 });
+    expect(bac.contient(piece)).to.be(true);
+  });
+
+  it('sait si une pièce est posé dessus décalé vers la droite', function () {
+    const bac = new Bac({ x: 10, y: 20, largeur: 10, hauteur: 20 });
+    const piece = new Piece({ x: 17, y: 30, largeur: 5, hauteur: 10 });
     expect(bac.contient(piece)).to.be(true);
   });
 
   it("sait si une pièce n'est pas posé dessus", function () {
     const bac = new Bac({ x: 10, y: 20, largeur: 10, hauteur: 20 });
-    const piece = new Piece({ x: 5, y: 5 });
+    const piece = new Piece({ x: 5, y: 5, largeur: 5, hauteur: 10 });
     expect(bac.contient(piece)).to.be(false);
   });
 


### PR DESCRIPTION
Maintenant que nous connaissons les dimensions de la pièce, il est plus
facile de savoir si une pièce est dans un bac ou non.

![contient](https://user-images.githubusercontent.com/86659/58019845-d0866680-7b06-11e9-864e-5b977853c3e5.gif)

