### PR TITLE
N'émet aucun événements si la sélection d'une pièce n'a pas changé.

### DIFF
--- a/src/situations/commun/modeles/piece.js
+++ b/src/situations/commun/modeles/piece.js
@@ -42,8 +42,10 @@ export default class Piece extends EventEmitter {
   }
 
   changeSelection (selectionne) {
-    this.selectionnee = selectionne;
-    this.emit(CHANGEMENT_SELECTION, selectionne);
+    if (this.selectionnee !== selectionne) {
+      this.selectionnee = selectionne;
+      this.emit(CHANGEMENT_SELECTION, selectionne);
+    }
   }
 
   deplaceSiSelectionnee ({ x, y }) {

--- a/tests/situations/commun/modeles/piece.js
+++ b/tests/situations/commun/modeles/piece.js
@@ -54,6 +54,15 @@ describe("Le modèle commun d'une pièce", function () {
     piece.selectionne({ x: 95, y: 65 });
   });
 
+  it('ne notifie pas lorsque la sélection ne change pas', function () {
+    let nombreAppels = 0;
+    const piece = new Piece({ x: 90, y: 50 });
+    piece.on(CHANGEMENT_SELECTION, () => nombreAppels++);
+    piece.selectionne({ x: 95, y: 65 });
+    piece.selectionne({ x: 95, y: 65 });
+    expect(nombreAppels).to.eql(1);
+  });
+
   it('peut être déplacée quand sélectionnée', function () {
     let piece = new Piece({ x: 90, y: 50 });
     piece.selectionne({ x: 95, y: 65 });


### PR DESCRIPTION
Lorsque nous déplaçons les pièces, nous nous assurons de désélectionner toute les pièces dans certains cas, ce qui arrive ici: https://github.com/betagouv/competences-pro/blob/d4d9c0b2220cdd03573ff1ea384260134bb1785c/src/situations/commun/composants/deplaceur_pieces.js#L30

Ce qui a pour effet d'appeler les callbacks, comme celui de la vue pièce qui s'assure que la dernière pièce sélectionnée est toujours en dernier dans le dom pour avoir un ordre naturel https://github.com/betagouv/competences-pro/blob/d4d9c0b2220cdd03573ff1ea384260134bb1785c/src/situations/commun/vues/piece.js#L63

Mais comme le callback était appelé même lorsque la pièce n'était pas sélectionnée, on réordonnait toute les pièces en permanence ce qui cassait l'ordre d'affichage voulu. 