### PR TITLE
Tri: fait disparaitre les pièces bien placées et réinitialise celles mal placées

### DIFF
--- a/src/situations/commun/modeles/piece.js
+++ b/src/situations/commun/modeles/piece.js
@@ -3,6 +3,8 @@ import EventEmitter from 'events';
 export const CHANGEMENT_POSITION = 'changementPosition';
 export const CHANGEMENT_SELECTION = 'changementSelection';
 
+export const DISPARITION_PIECE = 'disparitionPiece';
+
 export default class Piece extends EventEmitter {
   constructor ({ x, y, type, largeur, hauteur, categorie }) {
     super();

--- a/src/situations/commun/vues/piece.js
+++ b/src/situations/commun/vues/piece.js
@@ -2,13 +2,18 @@ import EventEmitter from 'events';
 
 import 'commun/styles/piece.scss';
 
-import { CHANGEMENT_POSITION, CHANGEMENT_SELECTION } from 'commun/modeles/piece';
+import { CHANGEMENT_POSITION, CHANGEMENT_SELECTION, DISPARITION_PIECE } from 'commun/modeles/piece';
+
+export function animationFinale ($element, done) {
+  $element.fadeOut(500, () => { done($element); });
+}
 
 export default class VuePiece extends EventEmitter {
-  constructor (piece, depotRessources) {
+  constructor (piece, depotRessources, animationDisparition = animationFinale) {
     super();
     this.piece = piece;
     this.depotRessources = depotRessources;
+    this.animationDisparition = animationDisparition;
   }
 
   affiche (pointInsertion, $) {
@@ -62,6 +67,14 @@ export default class VuePiece extends EventEmitter {
     this.piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
       this.$elementParent.append(this.$piece);
       this.$piece.toggleClass('selectionnee', selectionnee);
+    });
+
+    this.piece.on(DISPARITION_PIECE, () => {
+      this.$piece.addClass('desactiver');
+
+      this.animationDisparition(this.$piece, () => {
+        this.$piece.remove();
+      });
     });
   }
 }

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -1,11 +1,10 @@
-import Piece, { CHANGEMENT_POSITION, CHANGEMENT_SELECTION } from 'commun/modeles/piece';
+import Piece, { CHANGEMENT_POSITION, CHANGEMENT_SELECTION, DISPARITION_PIECE } from 'commun/modeles/piece';
 import Bac from 'commun/modeles/bac';
 import SituationCommune, { FINI } from 'commun/modeles/situation';
 
 import sonFondSonore from 'controle/assets/fond_sonore.mp3';
 
 export const NOUVELLE_PIECE = 'nouvellePiece';
-export const DISPARITION_PIECE = 'disparitionPiece';
 export const PIECE_BIEN_PLACEE = 'pieceBienPlacée';
 export const PIECE_MAL_PLACEE = 'pieceMalPlacée';
 export const PIECE_RATEE = 'pieceRatée';

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -1,34 +1,20 @@
 import VuePieceCommune from 'commun/vues/piece';
-import { DISPARITION_PIECE } from 'controle/modeles/situation';
 
 export function animationInitiale ($element) {
   $element.animate({ left: '-' + $element.css('width') }, 10000, 'linear');
 }
 
-export function animationFinale ($element, done) {
-  $element.fadeOut(500, () => { done($element); });
-}
-
 export default class VuePiece extends VuePieceCommune {
   constructor (piece,
     depotRessources,
-    callbackApresApparition = animationInitiale,
-    callbackAvantSuppression = animationFinale) {
+    callbackApresApparition = animationInitiale) {
     super(piece, depotRessources);
 
     this.callbackApresApparition = callbackApresApparition;
-    this.callbackAvantSuppression = callbackAvantSuppression;
   }
 
   affiche (pointInsertion, $) {
     super.affiche(pointInsertion, $);
     this.$piece.show(() => { this.callbackApresApparition(this.$piece); });
-
-    this.piece.on(DISPARITION_PIECE, () => {
-      this.$piece.addClass('desactiver');
-      this.callbackAvantSuppression(this.$piece, () => {
-        this.$piece.remove();
-      });
-    });
   }
 }

--- a/src/situations/tri/modeles/piece.js
+++ b/src/situations/tri/modeles/piece.js
@@ -1,0 +1,14 @@
+import PieceCommune, { CHANGEMENT_POSITION, CHANGEMENT_SELECTION, DISPARITION_PIECE } from 'commun/modeles/piece';
+
+export { CHANGEMENT_POSITION, CHANGEMENT_SELECTION, DISPARITION_PIECE };
+
+export default class Piece extends PieceCommune {
+  constructor (parametres) {
+    super(parametres);
+    this._positionOriginelle = this.position();
+  }
+
+  positionOriginelle () {
+    return this._positionOriginelle;
+  }
+}

--- a/src/situations/tri/modeles/situation.js
+++ b/src/situations/tri/modeles/situation.js
@@ -1,8 +1,6 @@
 import SituationCommune from 'commun/modeles/situation';
-import Piece, { CHANGEMENT_SELECTION } from 'commun/modeles/piece';
+import Piece, { CHANGEMENT_SELECTION, DISPARITION_PIECE } from 'commun/modeles/piece';
 import Bac from 'commun/modeles/bac';
-
-export const DISPARITION_PIECE = 'disparitionPiece';
 
 export default class Situation extends SituationCommune {
   constructor ({ pieces, bacs }) {

--- a/src/situations/tri/modeles/situation.js
+++ b/src/situations/tri/modeles/situation.js
@@ -10,11 +10,14 @@ export default class Situation extends SituationCommune {
     this.pieces = pieces.map((piece) => new Piece({ ...piece, categorie: piece.type, largeur: 7.44, hauteur: 11.3 }));
     this._bacs = bacs.map((bac) => new Bac({ ...bac, largeur: 15, hauteur: 22.5 }));
     this.pieces.forEach((piece) => {
+      const positionInitiale = piece.position();
       piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
         if (!selectionnee) {
           const bac = this.bacs().find((bac) => bac.contient(piece));
-          if (bac.correspondALaCategorie(piece)) {
+          if (bac && bac.correspondALaCategorie(piece)) {
             piece.emit(DISPARITION_PIECE);
+          } else {
+            piece.changePosition(positionInitiale);
           }
         }
       });

--- a/src/situations/tri/modeles/situation.js
+++ b/src/situations/tri/modeles/situation.js
@@ -1,12 +1,24 @@
 import SituationCommune from 'commun/modeles/situation';
-import Piece from 'commun/modeles/piece';
+import Piece, { CHANGEMENT_SELECTION } from 'commun/modeles/piece';
 import Bac from 'commun/modeles/bac';
+
+export const DISPARITION_PIECE = 'disparitionPiece';
 
 export default class Situation extends SituationCommune {
   constructor ({ pieces, bacs }) {
     super();
     this.pieces = pieces.map((piece) => new Piece({ ...piece, categorie: piece.type, largeur: 7.44, hauteur: 11.3 }));
     this._bacs = bacs.map((bac) => new Bac({ ...bac, largeur: 15, hauteur: 22.5 }));
+    this.pieces.forEach((piece) => {
+      piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
+        if (!selectionnee) {
+          const bac = this.bacs().find((bac) => bac.contient(piece));
+          if (bac.correspondALaCategorie(piece)) {
+            piece.emit(DISPARITION_PIECE);
+          }
+        }
+      });
+    });
   }
 
   piecesAffichees () {

--- a/src/situations/tri/modeles/situation.js
+++ b/src/situations/tri/modeles/situation.js
@@ -1,5 +1,5 @@
 import SituationCommune from 'commun/modeles/situation';
-import Piece, { CHANGEMENT_SELECTION, DISPARITION_PIECE } from 'commun/modeles/piece';
+import Piece, { CHANGEMENT_SELECTION, DISPARITION_PIECE } from 'tri/modeles/piece';
 import Bac from 'commun/modeles/bac';
 
 export default class Situation extends SituationCommune {
@@ -8,14 +8,13 @@ export default class Situation extends SituationCommune {
     this.pieces = pieces.map((piece) => new Piece({ ...piece, categorie: piece.type, largeur: 7.44, hauteur: 11.3 }));
     this._bacs = bacs.map((bac) => new Bac({ ...bac, largeur: 15, hauteur: 22.5 }));
     this.pieces.forEach((piece) => {
-      const positionInitiale = piece.position();
       piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
         if (!selectionnee) {
           const bac = this.bacs().find((bac) => bac.contient(piece));
           if (bac && bac.correspondALaCategorie(piece)) {
             piece.emit(DISPARITION_PIECE);
           } else {
-            piece.changePosition(positionInitiale);
+            piece.changePosition(piece.positionOriginelle());
           }
         }
       });

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -1,6 +1,6 @@
 import jsdom from 'jsdom-global';
 
-import Piece from 'commun/modeles/piece';
+import Piece, { DISPARITION_PIECE } from 'commun/modeles/piece';
 import VuePiece from 'commun/vues/piece';
 
 function creeVueMinimale (piece, depot) {
@@ -111,5 +111,29 @@ describe('Une pièce', function () {
     expect($('.piece').index()).to.equal(0);
     piece.selectionne({ x: 0, y: 0 });
     expect($('.piece').index()).to.equal(1);
+  });
+
+  it("au moment de l'événement DISPARITION_PIECE, disparait", function () {
+    $.fx.off = true;
+    const piece = new Piece({ x: 90, y: 40 });
+    const vuePiece = new VuePiece(piece, depot);
+    vuePiece.affiche('#pointInsertion', $);
+    expect($('.piece').length).to.equal(1);
+    piece.emit(DISPARITION_PIECE);
+    expect($('.piece').length).to.equal(0);
+  });
+
+  it("rajoute la classe desactiver au moment de l'événement DISPARITION_PIECE", function (done) {
+    const piece = new Piece({});
+
+    const callbackAvantSuppression = () => {
+      expect($('.desactiver').length).to.equal(1);
+      done();
+    };
+
+    const vuePiece = new VuePiece(piece, depot, callbackAvantSuppression);
+    vuePiece.affiche('#pointInsertion', $);
+    expect($('.desactiver').length).to.equal(0);
+    piece.emit(DISPARITION_PIECE);
   });
 });

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -1,6 +1,6 @@
 import { FINI } from 'commun/modeles/situation';
-import Situation, { NOUVELLE_PIECE, DISPARITION_PIECE, PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE, PIECE_RATEE } from 'controle/modeles/situation';
-import Piece from 'commun/modeles/piece';
+import Situation, { NOUVELLE_PIECE, PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE, PIECE_RATEE } from 'controle/modeles/situation';
+import Piece, { DISPARITION_PIECE } from 'commun/modeles/piece';
 
 function creeSituationMinimale (bacs = []) {
   return new Situation({

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -1,5 +1,4 @@
 import jsdom from 'jsdom-global';
-import { DISPARITION_PIECE } from 'controle/modeles/situation';
 import Piece from 'commun/modeles/piece';
 import VuePiece from 'controle/vues/piece';
 
@@ -41,36 +40,5 @@ describe('Une pièce', function () {
       expect(piece.position()).to.eql({ x: 80, y: 40 });
       done();
     }, 10);
-  });
-
-  it("au moment de l'événement DISPARITION_PIECE, disparait", function (done) {
-    const piece = new Piece({ x: 90, y: 40 });
-
-    const callbackAvantSuppression = (_, callbackSuppression) => {
-      callbackSuppression();
-      expect($('.piece').length).to.equal(0);
-      done();
-    };
-
-    const vuePiece = new VuePiece(piece, depot, () => {}, callbackAvantSuppression);
-    vuePiece.affiche('#controle', $);
-    expect($('.piece').length).to.equal(1);
-    piece.emit(DISPARITION_PIECE);
-  });
-
-  it("rajoute la classe desactiver au moment de l'événement DISPARITION_PIECE", function (done) {
-    const piece = new Piece({});
-
-    const callbackAvantSuppression = (_, callbackSuppression) => {
-      callbackSuppression();
-      expect($('.piece').length).to.equal(0);
-      done();
-    };
-
-    const vuePiece = new VuePiece(piece, depot, () => {}, callbackAvantSuppression);
-    vuePiece.affiche('#controle', $);
-    expect($('.desactiver').length).to.equal(0);
-    piece.emit(DISPARITION_PIECE);
-    expect($('.desactiver').length).to.equal(1);
   });
 });

--- a/tests/situations/tri/modeles/piece.js
+++ b/tests/situations/tri/modeles/piece.js
@@ -1,0 +1,9 @@
+import Piece from 'tri/modeles/piece';
+
+describe('La pièce du « Tri »', function () {
+  it('stocke la position originelle', function () {
+    const piece = new Piece({ x: 5, y: 10 });
+    piece.changePosition({ x: 30, y: 5 });
+    expect(piece.positionOriginelle()).to.eql({ x: 5, y: 10 });
+  });
+});

--- a/tests/situations/tri/modeles/situation.js
+++ b/tests/situations/tri/modeles/situation.js
@@ -1,5 +1,6 @@
+import { DISPARITION_PIECE } from 'commun/modeles/piece';
 import Bac from 'commun/modeles/bac';
-import Situation, { DISPARITION_PIECE } from 'tri/modeles/situation';
+import Situation from 'tri/modeles/situation';
 
 describe('La situation « Tri »', function () {
   it('répond que toutes ses pièces sont affichées', function () {

--- a/tests/situations/tri/modeles/situation.js
+++ b/tests/situations/tri/modeles/situation.js
@@ -21,7 +21,7 @@ describe('La situation « Tri »', function () {
   });
 
   it('fait disparaitre la pièce lorsque la pièce est bien placée', function (done) {
-    const situation = new Situation({ pieces: [{ categorie: 1 }], bacs: [{ categorie: 1, x: 1, y: 2 }] });
+    const situation = new Situation({ pieces: [{}], bacs: [{ x: 1, y: 2 }] });
     const bac = situation.bacs()[0];
     const piece = situation.piecesAffichees()[0];
     bac.contient = () => true;
@@ -31,5 +31,16 @@ describe('La situation « Tri »', function () {
     });
     piece.selectionne({});
     piece.deselectionne();
+  });
+
+  it("remet la pièce dans sa position initiale lorsqu'elle n'est dans son bac", function () {
+    const situation = new Situation({ pieces: [{ x: 4, y: 5 }], bacs: [{ x: 1, y: 2 }] });
+    const bac = situation.bacs()[0];
+    const piece = situation.piecesAffichees()[0];
+    bac.contient = () => false;
+    piece.selectionne({ x: 0, y: 0 });
+    piece.deplaceSiSelectionnee({ x: 10, y: 20 });
+    piece.deselectionne();
+    expect(piece.position()).to.eql({ x: 4, y: 5 });
   });
 });

--- a/tests/situations/tri/modeles/situation.js
+++ b/tests/situations/tri/modeles/situation.js
@@ -1,12 +1,11 @@
 import Bac from 'commun/modeles/bac';
-import Piece from 'commun/modeles/piece';
-import Situation from 'tri/modeles/situation';
+import Situation, { DISPARITION_PIECE } from 'tri/modeles/situation';
 
 describe('La situation « Tri »', function () {
   it('répond que toutes ses pièces sont affichées', function () {
-    const pieces = [new Piece({ x: 1, y: 2, largeur: 7.44, hauteur: 11.3 })];
+    const pieces = [{}];
     const situation = new Situation({ pieces, bacs: [] });
-    expect(situation.piecesAffichees()).to.eql(pieces);
+    expect(situation.piecesAffichees().length).to.eql(1);
   });
 
   it('spécifie que les pièces ont la categorie de leur type', function () {
@@ -19,5 +18,18 @@ describe('La situation « Tri »', function () {
     const situation = new Situation({ pieces: [], bacs: [{ categorie: 1, x: 1, y: 2 }] });
     const bac = new Bac({ x: 1, y: 2, largeur: 15, hauteur: 22.5, categorie: 1 });
     expect(situation.bacs()).to.eql([bac]);
+  });
+
+  it('fait disparaitre la pièce lorsque la pièce est bien placée', function (done) {
+    const situation = new Situation({ pieces: [{ categorie: 1 }], bacs: [{ categorie: 1, x: 1, y: 2 }] });
+    const bac = situation.bacs()[0];
+    const piece = situation.piecesAffichees()[0];
+    bac.contient = () => true;
+    bac.correspondALaCategorie = () => true;
+    piece.on(DISPARITION_PIECE, () => {
+      done();
+    });
+    piece.selectionne({});
+    piece.deselectionne();
   });
 });


### PR DESCRIPTION
J'ai rajouté la logique de disparition et de réinitialisation des pièces dans le modèle.

Le code de la vue pour la disparition a été mis en commun entre le contrôle et le tri.

![tri](https://user-images.githubusercontent.com/86659/58159565-15340e00-7c7d-11e9-8267-d4c8ebcd8d54.gif)
