### PR TITLE
Contrôle : demande le fond sonore au dépôt ressources

### DIFF
--- a/src/situations/commun/vues/affiche_situation.js
+++ b/src/situations/commun/vues/affiche_situation.js
@@ -12,9 +12,8 @@ export function afficheSituation (nomSituation, modeleSituation, VueSituation, d
   function affiche (pointInsertion, $) {
     const session = uuidv4();
     const journal = new Journal(Date.now, session, nomSituation, new DepotJournal(), new RegistreUtilisateur());
-    const vueSituation = new VueSituation(modeleSituation, journal, depotRessources);
 
-    const vueCadre = new VueCadre(vueSituation, modeleSituation, journal, depotRessources, barreDev);
+    const vueCadre = new VueCadre(VueSituation, modeleSituation, journal, depotRessources, barreDev);
     vueCadre.affiche(pointInsertion, $);
   }
 

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -11,12 +11,12 @@ import VueTerminer from 'commun/vues/terminer';
 import VueBarreDev from 'commun/vues/barre_dev';
 
 export default class VueCadre {
-  constructor (vueSituation, situation, journal, depotRessources, barreDev) {
-    this.vueSituation = vueSituation;
+  constructor (VueSituation, situation, journal, depotRessources, barreDev) {
+    this.VueSituation = VueSituation;
+    this.journal = journal;
     this.situation = situation;
     this.depotRessources = depotRessources;
     this.barreDev = barreDev;
-    this.vueActions = new VueActions(situation, journal, this.depotRessources);
     this.vuesEtats = new Map();
     this.vuesEtats.set(CHARGEMENT, VueChargement);
     this.vuesEtats.set(ERREUR_CHARGEMENT, VueErreurChargement);
@@ -58,8 +58,10 @@ export default class VueCadre {
     }
 
     return this.depotRessources.chargement().then(() => {
-      this.vueSituation.affiche('.scene', $);
+      const vueSituation = new this.VueSituation(this.situation, this.journal, this.depotRessources);
+      vueSituation.affiche('.scene', $);
 
+      this.vueActions = new VueActions(this.situation, this.journal, this.depotRessources);
       this.vueActions.affiche(selecteurCadre, $);
     });
   }

--- a/src/situations/controle/infra/depot_ressources_controle.js
+++ b/src/situations/controle/infra/depot_ressources_controle.js
@@ -1,6 +1,7 @@
 import DepotRessourcesCommunes from 'commun/infra/depot_ressources_communes';
 
 import sonConsigne from 'controle/assets/consigne_demarrage.wav';
+import sonFondSonore from 'controle/assets/fond_sonore.wav';
 
 const biscuits = require.context('controle/assets', false, /(def[0-9]+|biscuit-normal)\.png$/);
 
@@ -8,6 +9,7 @@ export default class DepotRessourcesControle extends DepotRessourcesCommunes {
   constructor (chargeurs) {
     super(sonConsigne, chargeurs);
     this.chargeContexte(require.context('controle/assets'));
+    this.charge([sonFondSonore]);
 
     this.biscuits = biscuits.keys().reduce((memo, fichier) => {
       memo[fichier.match(/(def[0-9]+|biscuit-normal).png/)[1]] = biscuits(fichier);
@@ -17,5 +19,9 @@ export default class DepotRessourcesControle extends DepotRessourcesCommunes {
 
   piece (type) {
     return this.biscuits[type];
+  }
+
+  fondSonore () {
+    return this.ressource(sonFondSonore);
   }
 }

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -2,8 +2,6 @@ import Piece, { CHANGEMENT_POSITION, CHANGEMENT_SELECTION, DISPARITION_PIECE } f
 import Bac from 'commun/modeles/bac';
 import SituationCommune, { FINI } from 'commun/modeles/situation';
 
-import sonFondSonore from 'controle/assets/fond_sonore.wav';
-
 export const NOUVELLE_PIECE = 'nouvellePiece';
 export const PIECE_BIEN_PLACEE = 'pieceBienPlacée';
 export const PIECE_MAL_PLACEE = 'pieceMalPlacée';
@@ -16,9 +14,6 @@ export default class Situation extends SituationCommune {
     this.scenario = scenario;
     this.positionApparition = positionApparitionPieces;
     this._dureeViePiece = dureeViePiece;
-    this.audios = {
-      fondSonore: new window.Audio(sonFondSonore)
-    };
     this.resultat = {
       bien_placees: 0,
       mal_placees: 0,

--- a/src/situations/controle/vues/fond_sonore.js
+++ b/src/situations/controle/vues/fond_sonore.js
@@ -1,11 +1,11 @@
 import 'controle/styles/tapis.scss';
 
-import { DEMARRE, CHANGEMENT_ETAT } from 'commun/modeles/situation';
+import { DEMARRE, CHANGEMENT_ETAT, FINI } from 'commun/modeles/situation';
 
 export default class VueFondSonore {
-  constructor (situation) {
+  constructor (situation, depotRessources) {
     this.situation = situation;
-    this.audio = situation.audios.fondSonore;
+    this.audio = depotRessources.fondSonore();
     this.audio.loop = true;
   }
 
@@ -18,9 +18,9 @@ export default class VueFondSonore {
 
   changeEtat (pointInsertion, $) {
     if (this.situation.etat() === DEMARRE) {
-      this.audio.play();
-    } else {
-      this.audio.pause();
+      this.audio.start();
+    } else if (this.situation.etat() === FINI) {
+      this.audio.stop();
     }
   }
 }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -17,7 +17,7 @@ export default class VueSituation {
     this.journal = journal;
     this.depotRessources = depotRessources;
     this.tapis = new VueTapis(situation);
-    this.fondSonore = new VueFondSonore(situation);
+    this.fondSonore = new VueFondSonore(situation, this.depotRessources);
     this.resultat = new VueResultat(situation, 'controle');
     this.deplaceurPieces = new DeplaceurPieces(situation);
   }

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -1,23 +1,19 @@
 import jsdom from 'jsdom-global';
+
 import VueActions from 'commun/vues/actions';
 import SituationCommune from 'commun/modeles/situation';
-import DepotRessourcesControle from 'controle/infra/depot_ressources_controle';
-import chargeurs from '../../commun/aides/mock_chargeurs';
 
 describe('Affiche les éléments communs aux situations', function () {
   let vueActions;
   let situation;
   let $;
-  let depotRessources;
 
   beforeEach(function () {
     jsdom('<div id="magasin"></div>');
     $ = jQuery(window);
     situation = new SituationCommune();
-    depotRessources = new DepotRessourcesControle(chargeurs());
 
-    vueActions = new VueActions(situation, {}, depotRessources);
-    return depotRessources.chargement();
+    vueActions = new VueActions(situation, {}, new class {}());
   });
 
   it('regroupe les éléments dans un conteneur', function () {

--- a/tests/situations/controle/aides/mock_depot_ressources_controle.js
+++ b/tests/situations/controle/aides/mock_depot_ressources_controle.js
@@ -1,0 +1,7 @@
+import MockAudioNode from '../../commun/aides/mock_audio_node';
+
+export default class MockDepotRessources {
+  fondSonore () {
+    return new MockAudioNode();
+  }
+}

--- a/tests/situations/controle/vues/fond_sonore.js
+++ b/tests/situations/controle/vues/fond_sonore.js
@@ -1,5 +1,6 @@
 import jsdom from 'jsdom-global';
 
+import MockDepotRessourcesControle from '../aides/mock_depot_ressources_controle';
 import { DEMARRE, FINI } from 'commun/modeles/situation';
 import Situation from 'controle/modeles/situation';
 import VueFondSonore from 'controle/vues/fond_sonore';
@@ -17,31 +18,31 @@ describe('Le fond sonore', () => {
       pause () {}
     };
     situation = new Situation({});
-    vue = new VueFondSonore(situation);
+    vue = new VueFondSonore(situation, new MockDepotRessourcesControle());
   });
 
   it("ne joue rien a l'affichage", () => {
-    let play = 0;
-    vue.audio.play = e => play++;
+    let jouee = 0;
+    vue.audio.start = e => jouee++;
     vue.affiche('#pointInsertion', $);
-    expect(play).to.equal(0);
+    expect(jouee).to.equal(0);
   });
 
   it("joue le fond sonore a l'état DEMARRE", () => {
-    let play = 0;
-    vue.audio.play = e => play++;
+    let jouee = 0;
+    vue.audio.start = e => jouee++;
     situation.modifieEtat(DEMARRE);
     vue.affiche('#pointInsertion', $);
 
-    expect(play).to.equal(1);
+    expect(jouee).to.equal(1);
   });
 
   it("stoppe le fond sonore lorsque c'est fini", () => {
-    let pause = 0;
-    vue.audio.pause = e => pause++;
+    let stope = 0;
+    vue.audio.stop = e => stope++;
     situation.modifieEtat(DEMARRE);
     vue.affiche('#pointInsertion', $);
     situation.modifieEtat(FINI);
-    expect(pause).to.equal(1);
+    expect(stope).to.equal(1);
   });
 });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -1,24 +1,16 @@
 import jsdom from 'jsdom-global';
 
+import MockDepotRessourcesControle from '../aides/mock_depot_ressources_controle';
 import EvenementPieceBienPlacee from 'controle/modeles/evenement_piece_bien_placee';
 import EvenementPieceMalPlacee from 'controle/modeles/evenement_piece_mal_placee';
 import EvenementPieceRatee from 'controle/modeles/evenement_piece_ratee';
 import Piece from 'commun/modeles/piece';
 import Situation, { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE, PIECE_RATEE } from 'controle/modeles/situation';
 import VueSituation from 'controle/vues/situation';
-import MockAudio from '../../commun/aides/mock_audio';
-
-class SituationDeTest extends Situation {
-  constructor (donnees) {
-    super(donnees);
-    this.audios.fondSonore = new MockAudio();
-  }
-  demarre () {}
-}
 
 function vueSituationMinimaliste (journal) {
-  const situation = new SituationDeTest({ scenario: [], bacs: [{}, {}] });
-  return new VueSituation(situation, journal);
+  const situation = new Situation({ scenario: [], bacs: [{}, {}] });
+  return new VueSituation(situation, journal, new MockDepotRessourcesControle());
 }
 
 describe('La situation « Contrôle »', function () {


### PR DESCRIPTION
Ceci nécessite la création de la vueSituation seulement après le chargement des
ressources

Grace à cette PR on passe à un `AudioNode` généré par `webAudio` qui gère mieux que `Audio` le bouclage d'un échantillon sonore (loop)