### PR TITLE
[CORRECTION] Fait tourner les aiguilles de la situation tri sur safari

### DIFF
--- a/src/situations/tri/styles/chronometre.scss
+++ b/src/situations/tri/styles/chronometre.scss
@@ -12,7 +12,7 @@
     width: 100%;
     position: absolute;
     transform: scale(1.1);
-    top: 0.625rem;
+    top: 0.5rem;
     left: 0;
   }
 

--- a/src/situations/tri/styles/chronometre.scss
+++ b/src/situations/tri/styles/chronometre.scss
@@ -11,7 +11,7 @@
   .aiguille-seconde {
     width: 100%;
     position: absolute;
-    transform: scale(1.1);
+    transform: scale(1.1) rotateZ(0deg);
     top: 0.5rem;
     left: 0;
   }
@@ -26,6 +26,6 @@
   }
 }
 
- @keyframes rotate {
- to { transform: scale(1.1) rotateZ(360deg); }
+@keyframes rotate {
+  to { transform: scale(1.1) rotateZ(360deg); }
 }


### PR DESCRIPTION
Pour Safari, il est indispensable que les deux propriétés `transform` (celle
de départ et celle de l'animation) contiennent les mêmes transformations.

Cette PR recentre aussi les aiguilles qui était quelques fraction de `rem` trop basses

fix #313
