### PR TITLE
Tri: Ne réinitialise pas le bonbon si il n'est pas dans un bac.

### DIFF
--- a/src/situations/tri/modeles/situation.js
+++ b/src/situations/tri/modeles/situation.js
@@ -22,7 +22,8 @@ export default class Situation extends SituationCommune {
       piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
         if (!selectionnee) {
           const bac = this.bacs().find((bac) => bac.contient(piece));
-          if (bac && bac.correspondALaCategorie(piece)) {
+          if (!bac) return;
+          if (bac.correspondALaCategorie(piece)) {
             this.faitDisparaitreLaPiece(piece, bac);
           } else {
             this.comptabiliseErreur(piece, bac);

--- a/tests/situations/tri/modeles/situation.js
+++ b/tests/situations/tri/modeles/situation.js
@@ -52,12 +52,25 @@ describe('La situation « Tri »', function () {
     const situation = new Situation({ pieces: [{ x: 4, y: 5 }], bacs: [{ x: 1, y: 2 }] });
     const bac = situation.bacs()[0];
     const piece = situation.piecesAffichees()[0];
-    bac.contient = () => false;
+    bac.contient = () => true;
+    bac.correspondALaCategorie = () => false;
     piece.selectionne({ x: 0, y: 0 });
     piece.deplaceSiSelectionnee({ x: 10, y: 20 });
     piece.deselectionne();
     expect(piece.position()).to.eql({ x: 4, y: 5 });
     expect(situation.resultat.erreurs).to.eql(1);
+  });
+
+  it("ne déplace pas la pièce si elle n'est pas dans un bac", function () {
+    const situation = new Situation({ pieces: [{ x: 4, y: 5 }], bacs: [{ x: 1, y: 2 }] });
+    const bac = situation.bacs()[0];
+    const piece = situation.piecesAffichees()[0];
+    bac.contient = () => false;
+    piece.selectionne({ x: 0, y: 0 });
+    piece.deplaceSiSelectionnee({ x: 10, y: 20 });
+    piece.deselectionne();
+    expect(piece.position()).to.eql({ x: 14, y: 25 });
+    expect(situation.resultat.erreurs).to.eql(0);
   });
 
   it("émet l'événement PIECE_MAL_PLACEE lorsque la pièce n'est pas dans son bac", function (done) {


### PR DESCRIPTION
A la dépose d'un bonbon, si il n'est pas dans un bac, celui ci n'est pas compté comme erreur et on ne réinitialise pas la position.

En cas d'erreur, la solution choisie est de remettre le bonbon dans sa position originelle. Potentiellement on pourrait le remettre dans sa dernière position.

![tri2](https://user-images.githubusercontent.com/86659/58866529-11f74400-86b9-11e9-8466-fe203c84bb65.gif)
