### PR TITLE
Supprime l'utilisation du plugin Provide pour jQuery.

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -1,3 +1,5 @@
+import jQuery from 'jquery';
+
 import 'accueil/styles/app.scss';
 
 import { situations } from 'src/situations';

--- a/src/situations/commun/vues/affiche_situation.js
+++ b/src/situations/commun/vues/affiche_situation.js
@@ -1,4 +1,5 @@
 import uuidv4 from 'uuid/v4';
+import jQuery from 'jquery';
 
 import DepotJournal from 'commun/infra/depot_journal';
 import Journal from 'commun/modeles/journal';

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import VueAccueil from 'accueil/vues/accueil';
 

--- a/tests/situations/accueil/vues/formulaire_identification.js
+++ b/tests/situations/accueil/vues/formulaire_identification.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 import FormulaireIdentification from 'accueil/vues/formulaire_identification';
 
 describe("Le formulaire d'identification", function () {

--- a/tests/situations/commun/composants/deplaceur_pieces.js
+++ b/tests/situations/commun/composants/deplaceur_pieces.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import Piece from 'commun/modeles/piece';
 import DeplaceurPieces from 'commun/composants/deplaceur_pieces';

--- a/tests/situations/commun/modale.js
+++ b/tests/situations/commun/modale.js
@@ -1,4 +1,6 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
+
 import { afficheFenetreModale } from 'commun/vues/modale';
 
 describe('fenetre modale', function () {

--- a/tests/situations/commun/vues/action_overlay.js
+++ b/tests/situations/commun/vues/action_overlay.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import ActionOverlay from 'commun/vues/action_overlay';
 

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import VueActions from 'commun/vues/actions';
 import SituationCommune from 'commun/modeles/situation';

--- a/tests/situations/commun/vues/bac.js
+++ b/tests/situations/commun/vues/bac.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import Bac from 'commun/modeles/bac';
 import VueBac from 'commun/vues/bac';

--- a/tests/situations/commun/vues/barre_dev.js
+++ b/tests/situations/commun/vues/barre_dev.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import BarreDev from 'commun/vues/barre_dev';
 import Situation, { DEMARRE, FINI } from 'commun/modeles/situation';

--- a/tests/situations/commun/vues/bouton.js
+++ b/tests/situations/commun/vues/bouton.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 import VueBouton from 'commun/vues/bouton';
 
 describe('vue Bouton', function () {

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import SituationCommune, { CHANGEMENT_ETAT, CHARGEMENT, ERREUR_CHARGEMENT, ATTENTE_DEMARRAGE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI, STOPPEE } from 'commun/modeles/situation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';

--- a/tests/situations/commun/vues/chargement.js
+++ b/tests/situations/commun/vues/chargement.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import VueChargement from 'commun/vues/chargement';
 import Situation, { CHARGEMENT, ATTENTE_DEMARRAGE, ERREUR_CHARGEMENT } from 'commun/modeles/situation';

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import MockAudioNode from '../aides/mock_audio_node';
 

--- a/tests/situations/commun/vues/erreur_chargement.js
+++ b/tests/situations/commun/vues/erreur_chargement.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import VueErreurChargement from 'commun/vues/erreur_chargement';
 import { traduction } from 'commun/infra/internationalisation';

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import VueGo from 'commun/vues/go';
 import Situation, { DEMARRE } from 'commun/modeles/situation';

--- a/tests/situations/commun/vues/joue.js
+++ b/tests/situations/commun/vues/joue.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import Situation, { LECTURE_CONSIGNE, CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
 import Joue from 'commun/vues/joue';

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import Piece, { DISPARITION_PIECE } from 'commun/modeles/piece';
 import VuePiece from 'commun/vues/piece';

--- a/tests/situations/commun/vues/rejoue_consigne.js
+++ b/tests/situations/commun/vues/rejoue_consigne.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
 import EvenementRejoueConsigne from 'commun/modeles/evenement_rejoue_consigne';
 import MockAudioNode from '../aides/mock_audio_node';

--- a/tests/situations/commun/vues/resultat.js
+++ b/tests/situations/commun/vues/resultat.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import Situation, { FINI } from 'commun/modeles/situation';
 import VueResultat from 'commun/vues/resultat';

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 import VueStop from 'commun/vues/stop';
 import EvenementStop from 'commun/modeles/evenement_stop';
 import Situation, { STOPPEE } from 'commun/modeles/situation';

--- a/tests/situations/commun/vues/terminer.js
+++ b/tests/situations/commun/vues/terminer.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 import VueTerminer from 'commun/vues/terminer.js';
 
 describe('Affiche les éléments liés à la fin de la situation', function () {

--- a/tests/situations/controle/vues/fond_sonore.js
+++ b/tests/situations/controle/vues/fond_sonore.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import MockDepotRessourcesControle from '../aides/mock_depot_ressources_controle';
 import { DEMARRE, FINI } from 'commun/modeles/situation';

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -1,4 +1,6 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
+
 import Piece from 'commun/modeles/piece';
 import VuePiece from 'controle/vues/piece';
 

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import MockDepotRessourcesControle from '../aides/mock_depot_ressources_controle';
 import EvenementPieceBienPlacee from 'commun/modeles/evenement_piece_bien_placee';

--- a/tests/situations/controle/vues/tapis.js
+++ b/tests/situations/controle/vues/tapis.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import { DEMARRE, FINI } from 'commun/modeles/situation';
 import Situation from 'controle/modeles/situation';

--- a/tests/situations/inventaire/vues/formulaire_saisie_inventaire.js
+++ b/tests/situations/inventaire/vues/formulaire_saisie_inventaire.js
@@ -1,3 +1,6 @@
+import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
+
 import { CHANGEMENT_ETAT, FINI } from 'commun/modeles/situation';
 import Contenant from 'inventaire/modeles/contenant';
 import { afficheCorrection, initialiseFormulaireSaisieInventaire } from 'inventaire/vues/formulaire_saisie_inventaire';
@@ -5,8 +8,6 @@ import EvenementOuvertureSaisieInventaire from 'inventaire/modeles/evenement_ouv
 import EvenementSaisieInventaire from 'inventaire/modeles/evenement_saisie_inventaire';
 
 import { unMagasin, unMagasinVide } from '../aides/magasin';
-
-let jsdom = require('jsdom-global');
 
 describe("Le formulaire de saisie d'inventaire", function () {
   let $;

--- a/tests/situations/inventaire/vues/situation.js
+++ b/tests/situations/inventaire/vues/situation.js
@@ -1,4 +1,6 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
+
 import { unMagasinVide } from '../aides/magasin';
 import VueSituation from 'inventaire/vues/situation';
 

--- a/tests/situations/tri/vues/chronometre.js
+++ b/tests/situations/tri/vues/chronometre.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import { DEMARRE, FINI } from 'commun/modeles/situation';
 import Situation from 'tri/modeles/situation';

--- a/tests/situations/tri/vues/situation.js
+++ b/tests/situations/tri/vues/situation.js
@@ -1,4 +1,5 @@
 import jsdom from 'jsdom-global';
+import jQuery from 'jquery';
 
 import VueSituation from 'tri/vues/situation';
 import Bac from 'commun/modeles/bac';

--- a/webpack.config-test.js
+++ b/webpack.config-test.js
@@ -49,7 +49,6 @@ var config = {
 
   plugins: [
     new CleanWebpackPlugin(),
-    new webpack.ProvidePlugin({ jQuery: 'jquery' }),
     new webpack.ProvidePlugin({ expect: ['expect.js'] })
   ]
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -115,7 +115,6 @@ module.exports = {
       inject: 'head'
     }),
     ...templatesSituations,
-    new webpack.ProvidePlugin({ jQuery: 'jquery' }),
     new webpack.EnvironmentPlugin(['URL_SERVEUR', 'AFFICHE_BARRE_DEV']),
     new FaviconsWebpackPlugin('./src/public/favicon.svg')
   ],


### PR DESCRIPTION
Pour limiter l'utilisation de config spécifique webpack, j'ai supprimé l'utilisation du plugin `Provide` qui injectait automatiquement jQuery, particulièrement dans les tests.