### PR TITLE
[CORRECTION] Inventaire : supprime l'attente sur l'événement load pour l'ouverture contenant

### DIFF
--- a/src/situations/inventaire/vues/contenu.js
+++ b/src/situations/inventaire/vues/contenu.js
@@ -35,12 +35,10 @@ export default class VueContenu {
     this.element.style.height = contenant.dimensionsOuvert.hauteur + '%';
     this.element.style.width = contenant.dimensionsOuvert.largeur + '%';
 
-    this.element.addEventListener('load', () => {
-      this.calque.classList.remove('invisible');
-      this.element.classList.remove('invisible');
-      setTimeout(() => {
-        this.element.classList.replace('fermer', 'ouvrir');
-      }, 50);
-    });
+    this.calque.classList.remove('invisible');
+    this.element.classList.remove('invisible');
+    setTimeout(() => {
+      this.element.classList.replace('fermer', 'ouvrir');
+    }, 50);
   }
 }

--- a/tests/situations/inventaire/vues/contenu.js
+++ b/tests/situations/inventaire/vues/contenu.js
@@ -25,7 +25,6 @@ describe('vue contenu', function () {
   it("sait s'afficher puis se cacher", function (done) {
     const contenant = new Contenant({ idProduit: '0', quantite: 1, dimensionsOuvert: { largeur: 33, hauteur: 33 } });
     vue.affiche(contenant);
-    vue.element.dispatchEvent(new Event('load'));
 
     expect(calque.classList).to.not.contain('invisible');
     expect(vue.element.classList).to.not.contain('invisible');
@@ -53,7 +52,6 @@ describe('vue contenu', function () {
     it("sait afficher l'image du contenant ouvert", function () {
       const contenant = new Contenant({ imageOuvert: 'image_contenant', dimensionsOuvert: { largeur: 33, hauteur: 33 } }, { nom: 'Nova Sky' });
       vue.affiche(contenant);
-      vue.element.dispatchEvent(new Event('load'));
 
       expect(element.src).to.eql('image_contenant');
     });


### PR DESCRIPTION
fix #321 

Sur Safari, l'événement `load` n'est pas envoyé si l'image n'est pas modifié
(ré-affectation d'une nouvelle valeur à l'attribut `src`). Ceci avait pour conséquence de ne pas pouvoir ouvrir deux fois de suite le même contenant.

Comme nous n'avons plus besoin d'attendre la fin du chargement de l'image
depuis que nous avons mis en place le préchargement, la solution a simplement
consisté à supprimer l'attente de l'événement `load` dans la vue contenu.