### PR TITLE
Inventaire: Limiter la taille des champs de saisie à 2 caractères.

### DIFF
--- a/src/situations/inventaire/vues/formulaire_saisie_inventaire.js
+++ b/src/situations/inventaire/vues/formulaire_saisie_inventaire.js
@@ -35,7 +35,7 @@ export function initialiseFormulaireSaisieInventaire (situation, pointInsertion,
       <li>
         <label>${produit.nom}</label>
         <span class='saisie'>
-          <input id="${idProduit}" type="text" placeholder= "${traduction('inventaire.placeholder')}">
+          <input id="${idProduit}" type="text" maxlength="2" placeholder="${traduction('inventaire.placeholder')}">
         </span>
         <div class="image-produit">
           <img src='${produit.image}' class="${produit.forme}">


### PR DESCRIPTION
Cela va éviter que des personnes mettent plein de caractères dans les
champs de saisie.