### PR TITLE
[Contrôle] Attendre 5 secondes avant d'afficher le premier biscuit

### DIFF
--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -65,7 +65,6 @@ export default class Situation extends SituationCommune {
 
       this.faisApparaitreLaNouvellePiece();
     };
-    afficheProchainePiece();
     this.identifiantIntervalle = setInterval(
       afficheProchainePiece,
       this.cadence

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -45,11 +45,11 @@ describe('La situation « Contrôle »', function () {
     expect(piece.position()).to.eql({ x: 25, y: 50 });
   });
 
-  it('démarre la situation et ajoute la piece dans les pieces en cours', function () {
+  it("démarre la situation mais n'ajoute pas immediatement une piece dans les pieces en cours", function () {
     const situation = creeSituationMinimale();
     expect(situation.piecesAffichees().length).to.eql(0);
     situation.demarre();
-    expect(situation.piecesAffichees().length).to.eql(1);
+    expect(situation.piecesAffichees().length).to.eql(0);
   });
 
   it("démarre la situation et déclenche un événement a l'ajout de la piece dans les pieces en cours", function (done) {


### PR DESCRIPTION
fix #336 sauf que pour simplifier j'attends un cycle du cadencement qui est de 5 secondes et non 4.

Je propose cette solution pour l'instant en attendant que nous implémentions peut-être un jour la sequence variable d'affichage des biscuits.