### PR TITLE
Déplace l'import SCSS à l'endroit approprié

### DIFF
--- a/src/situations/inventaire/styles/formulaire_saisie_inventaire.scss
+++ b/src/situations/inventaire/styles/formulaire_saisie_inventaire.scss
@@ -1,5 +1,4 @@
 @import 'commun/styles/bouton.scss';
-@import 'commun/styles/font_awesome.scss';
 
 .affiche-saisie {
   position: absolute;

--- a/src/situations/inventaire/vues/formulaire_saisie_inventaire.js
+++ b/src/situations/inventaire/vues/formulaire_saisie_inventaire.js
@@ -6,6 +6,7 @@ import EvenementSaisieInventaire from 'inventaire/modeles/evenement_saisie_inven
 import boutonSaisie from 'inventaire/assets/saisie-reponse.svg';
 
 import 'commun/styles/commun.scss';
+import 'commun/styles/font_awesome.scss';
 import 'commun/styles/overlay.scss';
 import 'inventaire/styles/formulaire_saisie_inventaire.scss';
 


### PR DESCRIPTION
Contribue à #315 (… mais le problème est beaucoup plus large !)

En l'état, le fait d'enlever le `@import` de `font_awesome.scss` de `formulaire_saisie_inventaire.scss` supprime une des duplications d'import. Et ce n'est déjà pas si mal 😉 