### PR TITLE
Corrige le fond de l'accueil pour ne pas se déformer en redimensionnant.

### DIFF
--- a/src/situations/accueil/styles/accueil.scss
+++ b/src/situations/accueil/styles/accueil.scss
@@ -19,7 +19,7 @@
     @include bords-arrondis;
     height: 566px;
     position: relative;
-    background: center / contain no-repeat;
+    background-repeat: no-repeat;
   }
 
   .situation {


### PR DESCRIPTION
Avec une petite résolution en hauteur, l'image de fond de l'accueil rétrécissait. 