### PR TITLE
[CORRECTION] Remets la progression au début quand déconnexion utilisateur

### DIFF
--- a/src/situations/accueil/vues/accueil.js
+++ b/src/situations/accueil/vues/accueil.js
@@ -14,24 +14,27 @@ export default class VueAccueil {
     let niveau = this.registreUtilisateur.progression().niveau();
 
     const creeElementSituation = (situation, index) => {
-      const desactivee = index + 1 > niveau;
       let $situation = $(`
         <a href="${situation.chemin}" class='situation ${situation.identifiant}'>
           ${situation.nom}
         </a>
       `);
 
-      if (desactivee) {
-        $situation = $(`
-        <span class='situation ${situation.identifiant} desactivee'>
-          ${situation.nom}
-        </span>
-      `);
-      }
-
       $situation.on('dragstart', (e) => e.preventDefault());
       $situation.css('background-image', `url('${this.depotRessources.batimentSituation(situation.identifiant).src}')`);
       return $situation;
+    };
+
+    const metsAJourAccesSituations = (niveau) => {
+      function estInaccessible (index) { return index + 1 > niveau; }
+
+      $('.situations .situation').each((index, element) => {
+        $(element).toggleClass('desactivee', estInaccessible(index));
+      });
+
+      $('.situations .situation').css('pointer-events', function (index) {
+        return estInaccessible(index) ? 'none' : 'auto';
+      });
     };
 
     const creeElementListe = (situations) => {
@@ -56,6 +59,7 @@ export default class VueAccueil {
     const $progression = $(`<div class='progression'></div>`);
 
     const $situations = creeElementListe(this.situations);
+
     const formulaireIdentification = new FormulaireIdentification(this.registreUtilisateur);
     const boiteUtilisateur = new VueBoiteUtilisateur(this.registreUtilisateur);
 
@@ -65,6 +69,7 @@ export default class VueAccueil {
         boiteUtilisateur.supprime();
       } else {
         niveau = this.registreUtilisateur.progression().niveau();
+        metsAJourAccesSituations(niveau);
         formulaireIdentification.supprime();
         boiteUtilisateur.affiche($titre, $);
       }
@@ -76,5 +81,6 @@ export default class VueAccueil {
 
     $situations.prepend($progression);
     $(pointInsertion).append($titre, $situations);
+    metsAJourAccesSituations(niveau);
   }
 }

--- a/src/situations/accueil/vues/accueil.js
+++ b/src/situations/accueil/vues/accueil.js
@@ -11,7 +11,7 @@ export default class VueAccueil {
   }
 
   affiche (pointInsertion, $) {
-    const niveau = this.registreUtilisateur.progression().niveau();
+    let niveau = this.registreUtilisateur.progression().niveau();
 
     const creeElementSituation = (situation, index) => {
       const desactivee = index + 1 > niveau;
@@ -54,7 +54,6 @@ export default class VueAccueil {
 
     const $titre = creeTitre();
     const $progression = $(`<div class='progression'></div>`);
-    $progression.css('background-image', `url('${this.depotRessources.progression(niveau).src}')`);
 
     const $situations = creeElementListe(this.situations);
     const formulaireIdentification = new FormulaireIdentification(this.registreUtilisateur);
@@ -65,9 +64,12 @@ export default class VueAccueil {
         formulaireIdentification.affiche($situations, $);
         boiteUtilisateur.supprime();
       } else {
+        niveau = this.registreUtilisateur.progression().niveau();
         formulaireIdentification.supprime();
         boiteUtilisateur.affiche($titre, $);
       }
+
+      $progression.css('background-image', `url('${this.depotRessources.progression(niveau).src}')`);
     };
     this.registreUtilisateur.on(CHANGEMENT_CONNEXION, basculeAffichageFormulaireIdentification);
     basculeAffichageFormulaireIdentification();

--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -43,6 +43,7 @@ export default class RegistreUtilisateur extends EventEmitter {
 
   deconnecte () {
     window.localStorage.removeItem(CLEF_IDENTIFIANT);
+    window.localStorage.removeItem(CLEF_SITUATIONS_FAITES);
     this.emit(CHANGEMENT_CONNEXION);
   }
 }

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -7,13 +7,14 @@ describe('La vue accueil', function () {
   let $;
   let depotRessources;
   let progression;
-  const registreUtilisateur = { on () {}, estConnecte () {}, consulte () {}, deconnecte () {} };
+  const registreUtilisateur = { on () {}, estConnecte () {}, consulte () {} };
 
   beforeEach(function () {
     jsdom('<div id="accueil"></div>');
     $ = jQuery(window);
     progression = { niveau () { } };
     registreUtilisateur.progression = () => progression;
+    registreUtilisateur.deconnecte = () => {};
     depotRessources = new class {
       fondAccueil () {
         return { src: '' };
@@ -129,6 +130,21 @@ describe('La vue accueil', function () {
     const vueAccueil = new VueAccueil([], registreUtilisateur, depotRessources);
     vueAccueil.affiche('#accueil', $);
     $('.deconnexion').click();
+  });
+
+  it('actualise la progression quand on se déconnecte', function () {
+    let nombreDeFoisProgressionRaffraîchie = 0;
+    registreUtilisateur.progression = () => {
+      nombreDeFoisProgressionRaffraîchie += 1;
+      return { niveau () {} };
+    };
+    registreUtilisateur.estConnecte = () => true;
+    const vueAccueil = new VueAccueil([], registreUtilisateur, depotRessources);
+
+    vueAccueil.affiche('#accueil', $);
+    $('.deconnexion').click();
+
+    expect(nombreDeFoisProgressionRaffraîchie).to.equal(2);
   });
 
   it("enlève la déconnexion lorsque l'utilisateur se déconnecte", function () {

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -49,12 +49,12 @@ describe('La vue accueil', function () {
     expect($liensSituations.eq(0).text()).to.contain('ABC');
     expect($liensSituations.eq(0).attr('href')).to.equal('abc.html');
     expect($liensSituations.eq(0).attr('class')).to.equal('situation identifiant-abc');
-    expect($liensSituations.eq(0).attr('style')).to.equal('background-image: url(identifiant-abc);');
+    expect($liensSituations.eq(0).css('background-image')).to.equal('url(identifiant-abc)');
 
     expect($liensSituations.eq(1).text()).to.contain('XYZ');
     expect($liensSituations.eq(1).attr('href')).to.equal('xyz.html');
     expect($liensSituations.eq(1).attr('class')).to.equal('situation identifiant-xyz');
-    expect($liensSituations.eq(1).attr('style')).to.equal('background-image: url(identifiant-xyz);');
+    expect($liensSituations.eq(1).css('background-image')).to.equal('url(identifiant-xyz)');
   });
 
   it("affiche le fond de l'accueil et les personnages", function () {
@@ -117,9 +117,11 @@ describe('La vue accueil', function () {
     const $situation = $('#accueil .situation');
     expect($situation.eq(0).text()).to.contain('ABC');
     expect($situation.eq(0).hasClass('desactivee')).to.be(false);
+    expect($situation.eq(0).css('pointer-events')).to.equal('auto');
 
     expect($situation.eq(1).text()).to.contain('XYZ');
     expect($situation.eq(1).hasClass('desactivee')).to.be(true);
+    expect($situation.eq(1).css('pointer-events')).to.equal('none');
   });
 
   it('permet de se déconnecter', function (done) {
@@ -145,6 +147,28 @@ describe('La vue accueil', function () {
     $('.deconnexion').click();
 
     expect(nombreDeFoisProgressionRaffraîchie).to.equal(2);
+  });
+
+  it("actualise l'accès aux situations quand on se déconnecte", function () {
+    let callbackChangementConnexion;
+    registreUtilisateur.on = (_nom, callback) => {
+      callbackChangementConnexion = callback;
+    };
+
+    const situations = [
+      { nom: 'ABC', chemin: 'abc.html', identifiant: 'identifiant-abc' },
+      { nom: 'XYZ', chemin: 'xyz.html', identifiant: 'identifiant-xyz' }
+    ];
+    registreUtilisateur.estConnecte = () => true;
+    progression.niveau = () => 2;
+    const vueAccueil = new VueAccueil(situations, registreUtilisateur, depotRessources);
+    vueAccueil.affiche('#accueil', $);
+    const $situations = $('#accueil .situation');
+    expect($situations.eq(1).hasClass('desactivee')).to.be(false);
+
+    progression.niveau = () => 1;
+    callbackChangementConnexion();
+    expect($situations.eq(1).hasClass('desactivee')).to.be(true);
   });
 
   it("enlève la déconnexion lorsque l'utilisateur se déconnecte", function () {

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -61,6 +61,14 @@ describe('le registre utilisateur', function () {
     expect(progression.niveau()).to.eql(2);
   });
 
+  it('à la déconnexion, remet la progression au début', function () {
+    const registre = new RegistreUtilisateur();
+    registre.enregistreSituationFaite('tri');
+    registre.deconnecte();
+    const progression = registre.progression();
+    expect(progression.niveau()).to.equal(1);
+  });
+
   it('à la déconnexion, nous ne sommes plus connectés', function () {
     const registre = new RegistreUtilisateur();
     registre.inscris('test');


### PR DESCRIPTION
Si je suis connecté en tant que `Roger`, que j'effectue l'exercice d'une première situation, et que je reviens à la page d'accueil, la progression pointe vers la 2e situation (jusqu'ici, tout va bien).

Si je me déconnecte et que je me reconnecte en tant que `Gérard`, la progression doit pointer vers la 1ère situation. Et seule la première situation doit être accessible.