### PR TITLE
Supprime webkitAudioContext et factorise le code pour jouer la consigne

### DIFF
--- a/src/situations/commun/composants/joueur_consigne.js
+++ b/src/situations/commun/composants/joueur_consigne.js
@@ -1,0 +1,13 @@
+export default function joueConsigne ($, depot, jouerConsigneCommune, lectureTerminee) {
+  function joueSon (noeudSon, callbackFin) {
+    $(noeudSon).on('ended', callbackFin);
+    noeudSon.start();
+  }
+
+  function joueConsigneCommune () {
+    joueSon(depot.consigneCommune(), lectureTerminee);
+  }
+
+  joueSon(depot.consigne(),
+    jouerConsigneCommune ? joueConsigneCommune : lectureTerminee);
+}

--- a/src/situations/commun/infra/depot_ressources.js
+++ b/src/situations/commun/infra/depot_ressources.js
@@ -1,6 +1,4 @@
 const chargeurAudio = function (src, timeout = 2000) {
-  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
-
   const request = new window.XMLHttpRequest();
 
   request.open('GET', src, true);
@@ -8,16 +6,27 @@ const chargeurAudio = function (src, timeout = 2000) {
 
   const promesse = new Promise((resolve, reject) => {
     request.onload = function () {
-      audioCtx.decodeAudioData(request.response,
-        function (buffer) {
-          resolve(() => {
-            const source = audioCtx.createBufferSource();
-            source.buffer = buffer;
-            source.connect(audioCtx.destination);
-            return source;
-          });
-        },
-        reject);
+      if (window.AudioContext) {
+        const audioCtx = new window.AudioContext();
+        audioCtx.decodeAudioData(request.response,
+          function (buffer) {
+            resolve(() => {
+              const source = audioCtx.createBufferSource();
+              source.buffer = buffer;
+              source.connect(audioCtx.destination);
+              return source;
+            });
+          },
+          reject);
+      } else {
+        resolve(() => {
+          const audio = new window.Audio();
+          audio.src = src;
+          audio.start = audio.play;
+          audio.stop = audio.pause;
+          return audio;
+        });
+      }
     };
   });
 

--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -1,5 +1,7 @@
 import { CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
+import joueConsigne from 'commun/composants/joueur_consigne';
 import VueActionOverlay from './action_overlay';
+
 import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 
 export default class VueConsigne extends VueActionOverlay {
@@ -11,23 +13,10 @@ export default class VueConsigne extends VueActionOverlay {
 
   affiche (pointInsertion, $) {
     super.affiche(pointInsertion, $);
-    this.joueConsigne($);
+    joueConsigne($, this.depot, true, () => this.lectureTerminee());
   }
 
   lectureTerminee () {
     this.situation.modifieEtat(CONSIGNE_ECOUTEE);
-  }
-
-  joueConsigne ($) {
-    this.joueSon($, this.depot.consigne(), () => this.joueConsigneCommune($));
-  }
-
-  joueConsigneCommune ($) {
-    this.joueSon($, this.depot.consigneCommune(), () => this.lectureTerminee());
-  }
-
-  joueSon ($, son, callbackFin) {
-    $(son).on('ended', callbackFin);
-    son.start();
   }
 }

--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -14,7 +14,7 @@ export default class VueConsigne extends VueActionOverlay {
     this.joueConsigne($);
   }
 
-  lectureTermine () {
+  lectureTerminee () {
     this.situation.modifieEtat(CONSIGNE_ECOUTEE);
   }
 
@@ -23,7 +23,7 @@ export default class VueConsigne extends VueActionOverlay {
   }
 
   joueConsigneCommune ($) {
-    this.joueSon($, this.depot.consigneCommune(), () => this.lectureTermine());
+    this.joueSon($, this.depot.consigneCommune(), () => this.lectureTerminee());
   }
 
   joueSon ($, son, callbackFin) {

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -38,19 +38,21 @@ export default class VueRejoueConsigne {
 
   definisConsigneAJouer ($) {
     const consigne = this.depotResources.consigne();
+    let actionSuivante;
     if (this.etat !== DEMARRE) {
-      this.joueSon($, consigne, () => this.joueConsigneCommune($));
+      actionSuivante = () => this.joueConsigneCommune($);
     } else {
-      this.joueSon($, consigne, () => this.lectureTermine($));
+      actionSuivante = () => this.lectureTerminee($);
     }
+    this.joueSon($, consigne, actionSuivante);
   }
 
   joueConsigneCommune ($) {
     const consigneCommune = this.depotResources.consigneCommune();
-    this.joueSon($, consigneCommune, () => this.lectureTermine());
+    this.joueSon($, consigneCommune, () => this.lectureTerminee());
   }
 
-  lectureTermine () {
+  lectureTerminee () {
     this.vueBoutonLectureEnCours.cache();
     this.vueBoutonLire.affiche(this.$boutonRejoueConsigne, this.$);
   }

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -1,3 +1,4 @@
+import joueConsigne from 'commun/composants/joueur_consigne';
 import { traduction } from 'commun/infra/internationalisation';
 import VueBouton from './bouton';
 import EvenementRejoueConsigne from '../modeles/evenement_rejoue_consigne';
@@ -11,7 +12,7 @@ export default class VueRejoueConsigne {
   constructor (depotResources, journal) {
     this.depotResources = depotResources;
     this.journal = journal;
-    this.vueBoutonLire = new VueBouton('bouton-lire-consigne', play, () => this.joueConsigne(this.$));
+    this.vueBoutonLire = new VueBouton('bouton-lire-consigne', play, () => this.litConsigne(this.$));
     this.vueBoutonLire.ajouteUneEtiquette(traduction('situation.repeter_consigne'));
     this.vueBoutonLectureEnCours = new VueBouton('bouton-lecture-en-cours', lectureEnCours);
   }
@@ -28,37 +29,16 @@ export default class VueRejoueConsigne {
     this.vueBoutonLire.affiche(this.$boutonRejoueConsigne, $);
   }
 
-  joueConsigne ($) {
+  litConsigne ($) {
     this.journal.enregistre(new EvenementRejoueConsigne());
     this.vueBoutonLire.cache();
 
     this.vueBoutonLectureEnCours.affiche(this.$boutonRejoueConsigne, $);
-    this.definisConsigneAJouer($);
-  }
-
-  definisConsigneAJouer ($) {
-    const consigne = this.depotResources.consigne();
-    let actionSuivante;
-    if (this.etat !== DEMARRE) {
-      actionSuivante = () => this.joueConsigneCommune($);
-    } else {
-      actionSuivante = () => this.lectureTerminee($);
-    }
-    this.joueSon($, consigne, actionSuivante);
-  }
-
-  joueConsigneCommune ($) {
-    const consigneCommune = this.depotResources.consigneCommune();
-    this.joueSon($, consigneCommune, () => this.lectureTerminee());
+    joueConsigne($, this.depotResources, this.etat !== DEMARRE, () => this.lectureTerminee());
   }
 
   lectureTerminee () {
     this.vueBoutonLectureEnCours.cache();
     this.vueBoutonLire.affiche(this.$boutonRejoueConsigne, this.$);
-  }
-
-  joueSon ($, son, callbackFin) {
-    $(son).on('ended', callbackFin);
-    son.start();
   }
 }

--- a/tests/situations/commun/vues/rejoue_consigne.js
+++ b/tests/situations/commun/vues/rejoue_consigne.js
@@ -43,7 +43,7 @@ describe('vue Rejoue Consigne', function () {
 
   it('passe en état lecture en cours', function () {
     vue.affiche('#pointInsertion', $, situation);
-    vue.joueConsigne($);
+    vue.litConsigne($);
     expect($('#pointInsertion .bouton-lire-consigne').length).to.eql(0);
     expect($('#pointInsertion .bouton-lecture-en-cours').length).to.eql(1);
   });
@@ -67,6 +67,6 @@ describe('vue Rejoue Consigne', function () {
       done();
     };
     vue.affiche('#pointInsertion', $, situation);
-    vue.joueConsigne($);
+    vue.litConsigne($);
   });
 });


### PR DESCRIPTION
Fix #358 

Nous avons rencontré les problèmes suivants avec Safari :
    - Le jeu de deux sons en même temps ne marche pas dans le contrôle (le fond sonore plus les klaxons)
    - l'événement "ended" n'est pas toujours émis
    - parfois la méthode `start` est bien appelée mais aucun son n'est joué (par exemple la deuxième partie de la consigne n'est pas jouée).

Pour corriger tous ces problèmes, cette PR supprime l'usage de webkitAudioContext. Si `window.AudioContext` n'est pas disponible, on bascule sur l'utilisation de `window.Audio`.

Conséquence pour Safari :
Les sons sont joués de manière un peu moins jolie (en particulier le son du tapis du contrôle qui est joué en boucle subit une petite coupure).