### PR TITLE
Accueil: déplace la logique de désactivation des situations dans la vue AccesSituation

### DIFF
--- a/src/situations/accueil/styles/acces_situation.scss
+++ b/src/situations/accueil/styles/acces_situation.scss
@@ -31,5 +31,6 @@
 
   &.desactivee {
     filter: contrast(80%) saturate(30%);
+    pointer-events: none;
   }
 }

--- a/src/situations/accueil/vues/acces_situation.js
+++ b/src/situations/accueil/vues/acces_situation.js
@@ -1,12 +1,17 @@
 import 'accueil/styles/acces_situation.scss';
 
+import { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
+
 export default class VueAccesSituation {
-  constructor (accesSituation, depotRessources) {
+  constructor (accesSituation, depotRessources, registreUtilisateur) {
     this.accesSituation = accesSituation;
     this.depotRessources = depotRessources;
+    this.registreUtilisateur = registreUtilisateur;
   }
 
   affiche (pointInsertion, $) {
+    this.registreUtilisateur.on(CHANGEMENT_CONNEXION, () => this.metsAJourAcces());
+
     this.$accesSituation = $(`
         <a href="${this.accesSituation.chemin}" class='acces-situation ${this.accesSituation.identifiant}'>
           ${this.accesSituation.nom}
@@ -16,14 +21,14 @@ export default class VueAccesSituation {
     this.$accesSituation.on('dragstart', (e) => e.preventDefault());
     this.$accesSituation.css('background-image', `url('${this.depotRessources.batimentSituation(this.accesSituation.identifiant).src}')`);
     $(pointInsertion).append(this.$accesSituation);
+
+    this.metsAJourAcces();
   }
 
-  metsAJourAcces (niveau) {
+  metsAJourAcces () {
+    const niveau = this.registreUtilisateur.progression().niveau();
     const estInaccessible = !this.accesSituation.estAccessible(niveau);
 
     this.$accesSituation.toggleClass('desactivee', estInaccessible);
-    this.$accesSituation.css('pointer-events', function () {
-      return estInaccessible ? 'none' : 'auto';
-    });
   }
 }

--- a/src/situations/accueil/vues/accueil.js
+++ b/src/situations/accueil/vues/accueil.js
@@ -12,8 +12,6 @@ export default class VueAccueil {
   }
 
   affiche (pointInsertion, $) {
-    let niveau = this.registreUtilisateur.progression().niveau();
-
     const creeListeAcces = (accesSituations) => {
       const $liste = $(`<div class='acces-situations'></div>`);
       $liste.css('background-image', `url('${this.depotRessources.fondAccueil().src}')`);
@@ -52,12 +50,12 @@ export default class VueAccueil {
         formulaireIdentification.affiche($accesSituations, $);
         boiteUtilisateur.supprime();
       } else {
-        niveau = this.registreUtilisateur.progression().niveau();
-        metsAJourAccesSituations(niveau);
         formulaireIdentification.supprime();
         boiteUtilisateur.affiche($titre, $);
       }
 
+      const niveau = this.registreUtilisateur.progression().niveau();
+      metsAJourAccesSituations(niveau);
       $progression.css('background-image', `url('${this.depotRessources.progression(niveau).src}')`);
     };
 
@@ -66,6 +64,5 @@ export default class VueAccueil {
 
     $accesSituations.prepend($progression);
     $(pointInsertion).append($titre, $accesSituations);
-    metsAJourAccesSituations(niveau);
   }
 }

--- a/src/situations/accueil/vues/accueil.js
+++ b/src/situations/accueil/vues/accueil.js
@@ -19,7 +19,7 @@ export default class VueAccueil {
       $personnages.css('background-image', `url('${this.depotRessources.personnages().src}')`);
       $liste.append($personnages);
       this.vuesAccesSituations = accesSituations.map((accesSituation) => {
-        const vue = new VueAccesSituation(accesSituation, this.depotRessources);
+        const vue = new VueAccesSituation(accesSituation, this.depotRessources, this.registreUtilisateur);
         vue.affiche($liste, $);
         return vue;
       });
@@ -41,10 +41,6 @@ export default class VueAccueil {
     const formulaireIdentification = new FormulaireIdentification(this.registreUtilisateur);
     const boiteUtilisateur = new VueBoiteUtilisateur(this.registreUtilisateur);
 
-    const metsAJourAccesSituations = (niveau) => {
-      this.vuesAccesSituations.forEach((vue) => vue.metsAJourAcces(niveau));
-    };
-
     const basculeAffichageFormulaireIdentification = () => {
       if (!this.registreUtilisateur.estConnecte()) {
         formulaireIdentification.affiche($accesSituations, $);
@@ -55,7 +51,6 @@ export default class VueAccueil {
       }
 
       const niveau = this.registreUtilisateur.progression().niveau();
-      metsAJourAccesSituations(niveau);
       $progression.css('background-image', `url('${this.depotRessources.progression(niveau).src}')`);
     };
 

--- a/tests/situations/accueil/vues/acces_situation.js
+++ b/tests/situations/accueil/vues/acces_situation.js
@@ -1,11 +1,16 @@
 import jsdom from 'jsdom-global';
 import jQuery from 'jquery';
+import EventEmitter from 'events';
+
 import VueAccesSituation from 'accueil/vues/acces_situation';
 import AccesSituation from 'accueil/modeles/acces_situation';
+
+import { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
 
 describe('La vue pour accéder à une situation', function () {
   let $;
   let depotRessources;
+  let registreUtilisateur;
 
   beforeEach(function () {
     jsdom('<div id="pointInsertion"></div>');
@@ -15,11 +20,16 @@ describe('La vue pour accéder à une situation', function () {
         return { src: identifiant };
       }
     }();
+    registreUtilisateur = new class extends EventEmitter {
+      progression () {
+        return { niveau () { } };
+      }
+    }();
   });
 
   it("sait s'afficher", function () {
     const accesSituation = new AccesSituation({ nom: 'ABC', chemin: 'abc.html', identifiant: 'identifiant-abc' });
-    const vueAccesSituation = new VueAccesSituation(accesSituation, depotRessources);
+    const vueAccesSituation = new VueAccesSituation(accesSituation, depotRessources, registreUtilisateur);
 
     vueAccesSituation.affiche('#pointInsertion', $);
     const $accesSituation = $('#pointInsertion .acces-situation');
@@ -28,5 +38,23 @@ describe('La vue pour accéder à une situation', function () {
     expect($accesSituation.attr('href')).to.equal('abc.html');
     expect($accesSituation.hasClass('identifiant-abc')).to.be(true);
     expect($accesSituation.css('background-image')).to.equal('url(identifiant-abc)');
+  });
+
+  it("sait s'afficher en étant désactivé", function () {
+    const accesSituation = new AccesSituation({ nom: 'ABC', chemin: 'abc.html', identifiant: 'identifiant-abc' });
+    accesSituation.estAccessible = () => false;
+    const vueAccesSituation = new VueAccesSituation(accesSituation, depotRessources, registreUtilisateur);
+    vueAccesSituation.affiche('#pointInsertion', $);
+    expect($('#pointInsertion .acces-situation').hasClass('desactivee')).to.be(true);
+  });
+
+  it('sait mettre à jour le status désactivé', function () {
+    const accesSituation = new AccesSituation({ nom: 'ABC', chemin: 'abc.html', identifiant: 'identifiant-abc' });
+    const vueAccesSituation = new VueAccesSituation(accesSituation, depotRessources, registreUtilisateur);
+    vueAccesSituation.affiche('#pointInsertion', $);
+
+    accesSituation.estAccessible = () => false;
+    registreUtilisateur.emit(CHANGEMENT_CONNEXION);
+    expect($('#pointInsertion .acces-situation').hasClass('desactivee')).to.be(true);
   });
 });

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -107,20 +107,6 @@ describe('La vue accueil', function () {
     expect($('.progression').attr('style')).to.equal('background-image: url(42);');
   });
 
-  it('désactive les accès aux situations qui ne sont pas dans le niveau actuel', function () {
-    progression.niveau = () => 1;
-    const vueAccueil = new VueAccueil(accesSituations, registreUtilisateur, depotRessources);
-    vueAccueil.affiche('#accueil', $);
-    const $situation = $('#accueil .acces-situation');
-    expect($situation.eq(0).text()).to.contain('ABC');
-    expect($situation.eq(0).hasClass('desactivee')).to.be(false);
-    expect($situation.eq(0).css('pointer-events')).to.equal('auto');
-
-    expect($situation.eq(1).text()).to.contain('XYZ');
-    expect($situation.eq(1).hasClass('desactivee')).to.be(true);
-    expect($situation.eq(1).css('pointer-events')).to.equal('none');
-  });
-
   it('permet de se déconnecter', function (done) {
     registreUtilisateur.estConnecte = () => true;
     registreUtilisateur.deconnecte = () => {


### PR DESCRIPTION
Avant, la logique de désactivation de situation était réparti entre la vue `Accueil` et la vue `AccesSituation`.

Désormais, `AccesSituation` sait se mettre à jour lorsque cela change.