### PR TITLE
Tri: Permet de sélectionner les pièces qui sont juste devant un bac.

### DIFF
--- a/src/situations/tri/vues/situation.js
+++ b/src/situations/tri/vues/situation.js
@@ -23,14 +23,14 @@ export default class VueSituationTri {
     $(pointInsertion).addClass('tri')
       .css('background-image', `url('${this.depotRessources.fondSituation().src}')`);
 
-    this.situation.piecesAffichees().forEach((piece) => {
-      const vuePiece = new VuePiece(piece, this.depotRessources);
-      vuePiece.affiche(pointInsertion, $);
-    });
-
     this.situation.bacs().forEach((bac) => {
       const vueBac = new VueBac(bac);
       vueBac.affiche(pointInsertion, $);
+    });
+
+    this.situation.piecesAffichees().forEach((piece) => {
+      const vuePiece = new VuePiece(piece, this.depotRessources);
+      vuePiece.affiche(pointInsertion, $);
     });
 
     this.chronometre.affiche(pointInsertion, $);


### PR DESCRIPTION
Certaines pièces sont placés juste devant les bacs, ce qui empéchait
leur sélection sur la partie qui recouvrait le bac.