### PR TITLE
Ajoute un test pour vérifier qu'une situation est bien inaccessible si le niveau n'est pas précisé.

### DIFF
--- a/tests/situations/accueil/modeles/acces_situation.js
+++ b/tests/situations/accueil/modeles/acces_situation.js
@@ -18,4 +18,9 @@ describe("l'acces à une situation", function () {
   it('est accessible quand le niveau actuel est superieur à son niveau', function () {
     expect(accesSituation.estAccessible(3)).to.equal(true);
   });
+
+  it("est inaccesible si le niveau n'est pas précisé", function () {
+    accesSituation = new AccesSituation({});
+    expect(accesSituation.estAccessible(1)).to.equal(false);
+  });
 });


### PR DESCRIPTION
C'est le cas aujourd'hui de la situation compte-rendu et j'avais peur que ça plante.