### PR TITLE
Récupère et utilise l'id de l'évaluation

### DIFF
--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -4,7 +4,6 @@ import jQuery from 'jquery';
 import Progression from 'commun/modeles/progression';
 
 const CLEF_IDENTIFIANT = 'identifiantUtilisateur';
-const CLEF_IDENTIFIANT_EVALUATION = 'identifiantEvaluation';
 const CLEF_SITUATIONS_FAITES = 'situationsFaites';
 
 export const CHANGEMENT_CONNEXION = 'changementConnexion';
@@ -22,8 +21,7 @@ export default class RegistreUtilisateur extends EventEmitter {
       data: JSON.stringify({ nom }),
       contentType: 'application/json; charset=utf-8'
     }).then((data) => {
-      window.localStorage.setItem(CLEF_IDENTIFIANT, data.nom);
-      window.localStorage.setItem(CLEF_IDENTIFIANT_EVALUATION, data.id);
+      window.localStorage.setItem(CLEF_IDENTIFIANT, JSON.stringify(data));
       this.emit(CHANGEMENT_CONNEXION);
     });
   }
@@ -32,12 +30,17 @@ export default class RegistreUtilisateur extends EventEmitter {
     return !!this.identifiant();
   }
 
+  parseLocalStorage (clef) {
+    const valeur = window.localStorage.getItem(clef) || '{}';
+    return JSON.parse(valeur);
+  }
+
   nom () {
-    return window.localStorage.getItem(CLEF_IDENTIFIANT);
+    return this.parseLocalStorage(CLEF_IDENTIFIANT).nom;
   }
 
   identifiant () {
-    return window.localStorage.getItem(CLEF_IDENTIFIANT_EVALUATION);
+    return this.parseLocalStorage(CLEF_IDENTIFIANT).id;
   }
 
   enregistreSituationFaite (situation) {
@@ -63,7 +66,6 @@ export default class RegistreUtilisateur extends EventEmitter {
   deconnecte () {
     window.localStorage.removeItem(CLEF_IDENTIFIANT);
     window.localStorage.removeItem(CLEF_SITUATIONS_FAITES);
-    window.localStorage.removeItem(CLEF_IDENTIFIANT_EVALUATION);
     this.emit(CHANGEMENT_CONNEXION);
   }
 }

--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -3,9 +3,9 @@ import jQuery from 'jquery';
 
 import Progression from 'commun/modeles/progression';
 
-const CLEF_IDENTIFIANT = 'identifiantUtilisateur';
 const CLEF_SITUATIONS_FAITES = 'situationsFaites';
 
+export const CLEF_IDENTIFIANT = 'identifiantUtilisateur';
 export const CHANGEMENT_CONNEXION = 'changementConnexion';
 
 export default class RegistreUtilisateur extends EventEmitter {
@@ -32,7 +32,11 @@ export default class RegistreUtilisateur extends EventEmitter {
 
   parseLocalStorage (clef) {
     const valeur = window.localStorage.getItem(clef) || '{}';
-    return JSON.parse(valeur);
+    try {
+      return JSON.parse(valeur);
+    } catch (ex) {
+      return {};
+    }
   }
 
   nom () {

--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -1,24 +1,43 @@
 import EventEmitter from 'events';
+import jQuery from 'jquery';
 
 import Progression from 'commun/modeles/progression';
 
 const CLEF_IDENTIFIANT = 'identifiantUtilisateur';
+const CLEF_IDENTIFIANT_EVALUATION = 'identifiantEvaluation';
 const CLEF_SITUATIONS_FAITES = 'situationsFaites';
 
 export const CHANGEMENT_CONNEXION = 'changementConnexion';
 
 export default class RegistreUtilisateur extends EventEmitter {
-  inscris (identifiantUtilisateur) {
-    window.localStorage.setItem(CLEF_IDENTIFIANT, identifiantUtilisateur);
-    this.emit(CHANGEMENT_CONNEXION);
+  constructor ($) {
+    super();
+    this.$ = $ || jQuery;
+  }
+
+  inscris (nom) {
+    return this.$.ajax({
+      type: 'POST',
+      url: `${process.env.URL_SERVEUR}/api/evaluations`,
+      data: JSON.stringify({ nom }),
+      contentType: 'application/json; charset=utf-8'
+    }).then((data) => {
+      window.localStorage.setItem(CLEF_IDENTIFIANT, data.nom);
+      window.localStorage.setItem(CLEF_IDENTIFIANT_EVALUATION, data.id);
+      this.emit(CHANGEMENT_CONNEXION);
+    });
   }
 
   estConnecte () {
-    return !!this.consulte();
+    return !!this.identifiant();
   }
 
-  consulte () {
+  nom () {
     return window.localStorage.getItem(CLEF_IDENTIFIANT);
+  }
+
+  identifiant () {
+    return window.localStorage.getItem(CLEF_IDENTIFIANT_EVALUATION);
   }
 
   enregistreSituationFaite (situation) {
@@ -44,6 +63,7 @@ export default class RegistreUtilisateur extends EventEmitter {
   deconnecte () {
     window.localStorage.removeItem(CLEF_IDENTIFIANT);
     window.localStorage.removeItem(CLEF_SITUATIONS_FAITES);
+    window.localStorage.removeItem(CLEF_IDENTIFIANT_EVALUATION);
     this.emit(CHANGEMENT_CONNEXION);
   }
 }

--- a/src/situations/commun/modeles/journal.js
+++ b/src/situations/commun/modeles/journal.js
@@ -19,7 +19,7 @@ export class Journal {
       situation: this.situation,
       nom: evenement.nom(),
       donnees: evenement.donnees(),
-      utilisateur: this.registreUtilisateur.consulte()
+      evaluation_id: this.registreUtilisateur.identifiant()
     };
     return this.depot.enregistre(payLoad, timeout);
   }

--- a/src/situations/commun/vues/boite_utilisateur.js
+++ b/src/situations/commun/vues/boite_utilisateur.js
@@ -13,7 +13,7 @@ export default class VueBoiteUtilisateur {
 
     this.$boiteUtilisateur = $(`
       <div class="boite-utilisateur">
-        <div class='nom-utilisateur'> ${this.registreUtilisateur.consulte()}</div>
+        <div class='nom-utilisateur'> ${this.registreUtilisateur.nom()}</div>
         <div class="progression-utilisateur">${this.afficheEtapesUtilisateur()}</div>
         <a class='deconnexion' href='#'>
           <i class='fas fa-sign-out-alt'></i>
@@ -31,7 +31,7 @@ export default class VueBoiteUtilisateur {
 
   rafraichis () {
     this.$boiteUtilisateur.toggleClass('invisible', !this.registreUtilisateur.estConnecte());
-    this.$boiteUtilisateur.find('.nom-utilisateur').text(this.registreUtilisateur.consulte());
+    this.$boiteUtilisateur.find('.nom-utilisateur').text(this.registreUtilisateur.nom());
     this.$boiteUtilisateur.find('.progression-utilisateur').text(this.afficheEtapesUtilisateur());
   }
 

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -18,7 +18,7 @@ describe('La vue accueil', function () {
     progression = { niveau () { } };
     registreUtilisateur = new class extends EventEmitter {
       estConnecte () {}
-      consulte () {}
+      nom () {}
     }();
 
     registreUtilisateur.situationsFaites = () => ['tri'];

--- a/tests/situations/accueil/vues/formulaire_identification.js
+++ b/tests/situations/accueil/vues/formulaire_identification.js
@@ -16,7 +16,7 @@ describe("Le formulaire d'identification", function () {
     registreUtilisateur = new class extends EventEmitter {
       estConnecte () {}
       inscris () {}
-      consulte () {}
+      nom () {}
     }();
     vue = new FormulaireIdentification(registreUtilisateur);
   });

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -2,26 +2,36 @@ import jsdom from 'jsdom-global';
 import RegistreUtilisateur, { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
 
 describe('le registre utilisateur', function () {
+  function unRegistre (id, nom) {
+    return new RegistreUtilisateur({
+      ajax () {
+        return Promise.resolve({ id, nom });
+      }
+    });
+  }
   beforeEach(function () {
     jsdom('', { url: 'http://localhost' });
   });
 
   it("permet d'inscrire et de récupérer un utilisateur", function () {
-    const registre = new RegistreUtilisateur();
-    registre.inscris('test');
-    expect(registre.consulte()).to.eql('test');
+    const registre = unRegistre(1, 'autre test');
+    registre.inscris('test').then(() => {
+      expect(registre.nom()).to.eql('autre test');
+      expect(registre.identifiant()).to.eql(1);
+    });
   });
 
   it("émet un événement lorsque le nom de l'utilisateur change", function (done) {
-    const registre = new RegistreUtilisateur();
+    const registre = unRegistre(1, 'test');
     registre.on(CHANGEMENT_CONNEXION, done);
     registre.inscris('test');
   });
 
   it("estConnecte retourne true lorsque l'utilisateur a rempli un nom", function () {
-    const registre = new RegistreUtilisateur();
-    registre.inscris('test');
-    expect(registre.estConnecte()).to.be(true);
+    const registre = unRegistre(1, 'test');
+    return registre.inscris('test').then(() => {
+      expect(registre.estConnecte()).to.be(true);
+    });
   });
 
   it("estConnecte retourne false lorsque l'utilisateur n'a pas rempli un nom", function () {
@@ -70,11 +80,12 @@ describe('le registre utilisateur', function () {
   });
 
   it('à la déconnexion, nous ne sommes plus connectés', function () {
-    const registre = new RegistreUtilisateur();
-    registre.inscris('test');
-    expect(registre.estConnecte()).to.be(true);
-    registre.deconnecte();
-    expect(registre.estConnecte()).to.be(false);
+    const registre = unRegistre(1, 'test');
+    return registre.inscris('test').then(() => {
+      expect(registre.estConnecte()).to.be(true);
+      registre.deconnecte();
+      expect(registre.estConnecte()).to.be(false);
+    });
   });
 
   it("émet un événement lorsque l'utilisateur se déconnecte", function (done) {

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -1,7 +1,7 @@
 import jsdom from 'jsdom-global';
 import RegistreUtilisateur, { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
 
-describe('le registre utilisateur', function () {
+describe.only('le registre utilisateur', function () {
   function unRegistre (id, nom) {
     return new RegistreUtilisateur({
       ajax () {

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -1,5 +1,5 @@
 import jsdom from 'jsdom-global';
-import RegistreUtilisateur, { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
+import RegistreUtilisateur, { CHANGEMENT_CONNEXION, CLEF_IDENTIFIANT } from 'commun/infra/registre_utilisateur';
 
 describe('le registre utilisateur', function () {
   function unRegistre (id, nom) {
@@ -92,5 +92,11 @@ describe('le registre utilisateur', function () {
     const registre = new RegistreUtilisateur();
     registre.on(CHANGEMENT_CONNEXION, done);
     registre.deconnecte();
+  });
+
+  it('déconnecte si ancienne données présentes', function () {
+    window.localStorage.setItem(CLEF_IDENTIFIANT, 'nom utilisateur');
+    const registre = new RegistreUtilisateur();
+    expect(registre.estConnecte()).to.be(false);
   });
 });

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -1,7 +1,7 @@
 import jsdom from 'jsdom-global';
 import RegistreUtilisateur, { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
 
-describe.only('le registre utilisateur', function () {
+describe('le registre utilisateur', function () {
   function unRegistre (id, nom) {
     return new RegistreUtilisateur({
       ajax () {

--- a/tests/situations/commun/modeles/journal.js
+++ b/tests/situations/commun/modeles/journal.js
@@ -6,7 +6,7 @@ describe('le journal', function () {
   let journal;
   let mockMaintenant;
   let mockDepot;
-  const registre = { consulte () {} };
+  const registre = { identifiant () {} };
   const sessionId = 42;
   const identifiantSituation = 'inventaire';
 
@@ -17,17 +17,17 @@ describe('le journal', function () {
   });
 
   it('enregistre un événement', function () {
-    registre.consulte = () => 'identifiant utilisateur';
+    registre.identifiant = () => 'identifiant utilisateur';
     journal.enregistre(new Evenement('test'));
 
     const enregistrement = mockDepot.evenements();
     expect(enregistrement.length).to.equal(1);
-    expect(enregistrement[0]).to.only.have.keys('date', 'session_id', 'nom', 'donnees', 'situation', 'utilisateur');
+    expect(enregistrement[0]).to.only.have.keys('date', 'session_id', 'nom', 'donnees', 'situation', 'evaluation_id');
     expect(enregistrement[0]).to.have.property('nom', 'test');
     expect(enregistrement[0]).to.have.property('date', 123);
     expect(enregistrement[0]).to.have.property('session_id', sessionId);
     expect(enregistrement[0]).to.have.property('situation', identifiantSituation);
-    expect(enregistrement[0]).to.have.property('utilisateur', 'identifiant utilisateur');
+    expect(enregistrement[0]).to.have.property('evaluation_id', 'identifiant utilisateur');
   });
 
   it('enregistre la situation faite', function (done) {

--- a/tests/situations/commun/vues/boite_utilisateur.js
+++ b/tests/situations/commun/vues/boite_utilisateur.js
@@ -16,7 +16,7 @@ describe('La boite utilisateur', function () {
     $ = jQuery(window);
     registreUtilisateur = new class extends EventEmitter {
       estConnecte () {}
-      consulte () {}
+      nom () {}
       deconnecte () {}
       progression () {}
     }();
@@ -29,7 +29,7 @@ describe('La boite utilisateur', function () {
   });
 
   it("affiche le nom de l'évalué·e et le bouton de déconnexion", function () {
-    registreUtilisateur.consulte = () => 'Jacques Adit';
+    registreUtilisateur.nom = () => 'Jacques Adit';
     vueBoiteUtilisateur.affiche('#point-insertion', $);
     expect($('#point-insertion .nom-utilisateur').text().trim()).to.equal('Jacques Adit');
     expect($('#point-insertion .deconnexion').length).to.equal(1);
@@ -63,7 +63,7 @@ describe('La boite utilisateur', function () {
     registreUtilisateur.estConnecte = () => false;
     vueBoiteUtilisateur.affiche('#point-insertion', $);
     registreUtilisateur.estConnecte = () => true;
-    registreUtilisateur.consulte = () => 'Jacques Adit';
+    registreUtilisateur.nom = () => 'Jacques Adit';
     registreUtilisateur.emit(CHANGEMENT_CONNEXION);
     expect($('#point-insertion .nom-utilisateur').text()).to.eql('Jacques Adit');
   });


### PR DESCRIPTION
Avec betagouv/competences-pro-serveur#92 qui rajoute le modèle d'évaluation, désormais à l'identification, on fait un appel au serveur pour en créer une. On sauvegarde son identifiant pour le passer aux événements a la place du nom de l'utilisateur.

Cela ne change pas le workflow actuel, mais il faudra penser a améliorer l'UX du formulaire d'identification pour gérer un spinner et la désactivation du bouton lorsqu'une requête est faite (ainsi que gérer les erreurs). 