### PR TITLE
Questions: corrige la description de numératie

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -36,7 +36,7 @@
       "objet_reponse": "Réponse : Note Accident Carine"
     },
     "numeratie": {
-      "description": "Cette palette est complète. Chaque carton contient 4 cartons de 8 bouteilles.",
+      "description": "Cette palette est complète. Chaque carton contient 4 packs de 8 bouteilles.",
       "ne_sait_pas": "Je ne sais pas faire ce calcul",
       "question": "Combien y a t-il de bouteilles de O'cola au total ?",
       "valider": "Valider"


### PR DESCRIPTION
Pour éviter une répétition qui répète le mot carton.