### PR TITLE
Permet de saisir le code de campagne à l'identification

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -7,8 +7,8 @@
   "accueil": {
     "identification": {
       "boutton": "Démarrer",
-      "label": "Entrez votre nom et prénom",
       "campagne": "Code de la campagne",
+      "label": "Entrez votre nom et prénom",
       "titre": "Bienvenue !"
     },
     "titre": "Compétences pro"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -8,6 +8,7 @@
     "identification": {
       "boutton": "Démarrer",
       "label": "Entrez votre nom et prénom",
+      "campagne": "Code de la campagne",
       "titre": "Bienvenue !"
     },
     "titre": "Compétences pro"

--- a/src/situations/accueil/styles/formulaire_identification.scss
+++ b/src/situations/accueil/styles/formulaire_identification.scss
@@ -37,14 +37,9 @@
 
   label {
     display: inline-block;
-    padding-bottom: .5rem;
-  }
-
-  button {
-    margin-left: .5rem;
   }
 }
 
-.flex {
-  display: flex;
+.inputs {
+  margin: .5rem auto;
 }

--- a/src/situations/accueil/styles/formulaire_identification.scss
+++ b/src/situations/accueil/styles/formulaire_identification.scss
@@ -40,6 +40,6 @@
   }
 }
 
-.inputs {
+.element-formulaire {
   margin: .5rem auto;
 }

--- a/src/situations/accueil/vues/formulaire_identification.js
+++ b/src/situations/accueil/vues/formulaire_identification.js
@@ -18,16 +18,16 @@ export default class FormulaireIdentification {
           <label for="formulaire-identification-input-nom">
             ${traduction('accueil.identification.label')}
           </label>
-          <div class="inputs">
+          <div class="element-formulaire">
             <input id="formulaire-identification-input-nom" type="text" class="input-accueil" autofocus>
           </div>
           <label for="formulaire-identification-input-campagne">
             ${traduction('accueil.identification.campagne')}
           </label>
-          <div class="inputs">
+          <div class="element-formulaire">
             <input id="formulaire-identification-input-campagne" type="text" class="input-accueil">
           </div>
-          <div class="inputs">
+          <div class="element-formulaire">
             <button class="bouton-arrondi">${traduction('accueil.identification.boutton')}</button>
           </div>
         </form>

--- a/src/situations/accueil/vues/formulaire_identification.js
+++ b/src/situations/accueil/vues/formulaire_identification.js
@@ -15,11 +15,19 @@ export default class FormulaireIdentification {
       const $resultat = $(`
         <form class="formulaire-identification" id="formulaire-identification">
           <h2>${traduction('accueil.identification.titre')}</h2>
-          <label for="formulaire-identification-input">
+          <label for="formulaire-identification-input-nom">
             ${traduction('accueil.identification.label')}
           </label>
-          <div class="flex">
-            <input id="formulaire-identification-input" type="text" class="input-accueil" autofocus>
+          <div class="inputs">
+            <input id="formulaire-identification-input-nom" type="text" class="input-accueil" autofocus>
+          </div>
+          <label for="formulaire-identification-input-campagne">
+            ${traduction('accueil.identification.campagne')}
+          </label>
+          <div class="inputs">
+            <input id="formulaire-identification-input-campagne" type="text" class="input-accueil">
+          </div>
+          <div class="inputs">
             <button class="bouton-arrondi">${traduction('accueil.identification.boutton')}</button>
           </div>
         </form>
@@ -33,11 +41,14 @@ export default class FormulaireIdentification {
 
     this.$gabarit.on('submit', (e) => {
       e.preventDefault();
-      const $input = $('input[type=text]', this.$gabarit);
-      const identifiantUtilisateur = $input.val().trim();
+      const $inputNom = $('#formulaire-identification-input-nom', this.$gabarit);
+      const identifiantUtilisateur = $inputNom.val().trim();
+      const $inputCodeCampagne = $('#formulaire-identification-input-campagne', this.$gabarit);
+      const codeCampagne = $inputCodeCampagne.val().trim();
       if (identifiantUtilisateur !== '') {
-        this.registreUtilisateur.inscris(identifiantUtilisateur);
-        $input.val('');
+        this.registreUtilisateur.inscris(identifiantUtilisateur, codeCampagne);
+        $inputNom.val('');
+        $inputCodeCampagne.val('');
       }
     });
 

--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -18,7 +18,7 @@ export default class RegistreUtilisateur extends EventEmitter {
     return this.$.ajax({
       type: 'POST',
       url: `${process.env.URL_SERVEUR}/api/evaluations`,
-      data: JSON.stringify({ nom, codeCampagne }),
+      data: JSON.stringify({ nom: nom, code_campagne: codeCampagne }),
       contentType: 'application/json; charset=utf-8'
     }).then((data) => {
       window.localStorage.setItem(CLEF_IDENTIFIANT, JSON.stringify(data));

--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -14,11 +14,11 @@ export default class RegistreUtilisateur extends EventEmitter {
     this.$ = $ || jQuery;
   }
 
-  inscris (nom) {
+  inscris (nom, codeCampagne) {
     return this.$.ajax({
       type: 'POST',
       url: `${process.env.URL_SERVEUR}/api/evaluations`,
-      data: JSON.stringify({ nom }),
+      data: JSON.stringify({ nom, codeCampagne }),
       contentType: 'application/json; charset=utf-8'
     }).then((data) => {
       window.localStorage.setItem(CLEF_IDENTIFIANT, JSON.stringify(data));

--- a/tests/situations/accueil/vues/formulaire_identification.js
+++ b/tests/situations/accueil/vues/formulaire_identification.js
@@ -26,22 +26,24 @@ describe("Le formulaire d'identification", function () {
 
     vue.affiche('#formulaire', $);
     expect($('#formulaire form#formulaire-identification').length).to.equal(1);
-    expect($('#formulaire label').length).to.equal(1);
-    expect($('#formulaire input[type=text]').length).to.equal(1);
+    expect($('#formulaire label').length).to.equal(2);
+    expect($('#formulaire input[type=text]').length).to.equal(2);
   });
 
   it("sauvegarde la valeur rentrée à l'appui sur le bouton", function (done) {
-    registreUtilisateur.inscris = (identifiantUtilisateur) => {
+    registreUtilisateur.inscris = (identifiantUtilisateur, codeCampagne) => {
       expect(identifiantUtilisateur).to.equal('Mon pseudo');
+      expect(codeCampagne).to.equal('Mon code campagne');
       done();
     };
     vue.affiche('#formulaire', $);
-    $('#formulaire input[type=text]').val('Mon pseudo').trigger('submit');
+    $('#formulaire #formulaire-identification-input-campagne').val('Mon code campagne');
+    $('#formulaire #formulaire-identification-input-nom').val('Mon pseudo').trigger('submit');
   });
 
   it("réinitialise la valeur rentrée à l'appui sur le bouton", function () {
     vue.affiche('#formulaire', $);
-    $('#formulaire input[type=text]').val('Mon pseudo').trigger('submit');
+    $('#formulaire input[type=text]').val('Mon pseudo ou code').trigger('submit');
     expect($('#formulaire input[type=text]').val()).to.eql('');
   });
 

--- a/tests/situations/accueil/vues/formulaire_identification.js
+++ b/tests/situations/accueil/vues/formulaire_identification.js
@@ -43,8 +43,14 @@ describe("Le formulaire d'identification", function () {
 
   it("réinitialise la valeur rentrée à l'appui sur le bouton", function () {
     vue.affiche('#formulaire', $);
-    $('#formulaire input[type=text]').val('Mon pseudo ou code').trigger('submit');
-    expect($('#formulaire input[type=text]').val()).to.eql('');
+    $('#formulaire input[type=text]').each(function () {
+      $(this).val('Mon pseudo ou code');
+    });
+    $('#formulaire input[type=text]').trigger('submit');
+
+    $('#formulaire input[type=text]').each(function () {
+      expect($(this).val()).to.eql('');
+    });
   });
 
   it('ne sauvegarde pas la valeur rentrée si elle est vide', function () {


### PR DESCRIPTION
contribue #383 

Permet à l'utilisateur de saisir le code de la campagne à laquelle il participe, cela permettra de relier l'évaluation à cette campagne, et par la suite de récupérer la configuration de cette campagne.

En l'état, si l'utilisateur se trompe de code cela ne provoque pas d'erreur et l'affectera à la première campagne de la liste. C'est un comportement que j'espère changer dans une PR à part.

![Capture d’écran 2019-07-12 à 12 25 38](https://user-images.githubusercontent.com/28393/61121719-2ee51b00-a4a0-11e9-965f-f0cbf7820910.png)

