### PR TITLE
Utilise jsdom en global dans les tests.

### DIFF
--- a/all-tests.js
+++ b/all-tests.js
@@ -1,5 +1,6 @@
-require('jsdom');
+afterEach(function () {
+  document.body.innerHTML = '';
+});
 
-let context = require.context('./tests', true, /\.js$/);
+const context = require.context('./tests', true, /\.js$/);
 context.keys().forEach(context);
-module.exports = context;

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 BUILD_CMD="npx webpack --progress --color --config webpack.config-test.js"
-MOCHA_OPTION="--colors";
+MOCHA_OPTION="--require ./jsdom --colors";
 if [ "$1" = "--watch" ]
 then
   $BUILD_CMD --mode development --watch &

--- a/jsdom.js
+++ b/jsdom.js
@@ -1,0 +1,1 @@
+require('jsdom-global')('', { url: 'http://localhost' });

--- a/tests/situations/accueil/vues/acces_situation.js
+++ b/tests/situations/accueil/vues/acces_situation.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import EventEmitter from 'events';
 
 import VueAccesSituation from 'accueil/vues/acces_situation';
@@ -8,13 +7,11 @@ import AccesSituation from 'accueil/modeles/acces_situation';
 import { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
 
 describe('La vue pour accéder à une situation', function () {
-  let $;
   let depotRessources;
   let registreUtilisateur;
 
   beforeEach(function () {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     depotRessources = new class {
       batimentSituation (identifiant) {
         return { src: identifiant };

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -1,19 +1,16 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import EventEmitter from 'events';
 
 import VueAccueil from 'accueil/vues/accueil';
 import AccesSituation from 'accueil/modeles/acces_situation';
 
 describe('La vue accueil', function () {
-  let $;
   let depotRessources;
   let accesSituations;
   let registreUtilisateur;
 
   beforeEach(function () {
-    jsdom('<div id="accueil"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="accueil"></div>');
     registreUtilisateur = new class extends EventEmitter {
       estConnecte () {}
       nom () {}

--- a/tests/situations/accueil/vues/formulaire_identification.js
+++ b/tests/situations/accueil/vues/formulaire_identification.js
@@ -1,17 +1,14 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import EventEmitter from 'events';
 import { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
 import FormulaireIdentification from 'accueil/vues/formulaire_identification';
 
 describe("Le formulaire d'identification", function () {
-  let $;
   let vue;
   let registreUtilisateur;
 
   beforeEach(function () {
-    jsdom('<div id="formulaire"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="formulaire"></div>');
     registreUtilisateur = new class extends EventEmitter {
       estConnecte () {}
       inscris () { return $.Deferred().resolve(); }

--- a/tests/situations/accueil/vues/progression.js
+++ b/tests/situations/accueil/vues/progression.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import EventEmitter from 'events';
 
 import VueProgression from 'accueil/vues/progression';
@@ -7,13 +6,11 @@ import VueProgression from 'accueil/vues/progression';
 import { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
 
 describe('La vue pour afficher la progression', function () {
-  let $;
   let depotRessources;
   let registreUtilisateur;
 
   beforeEach(function () {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     depotRessources = new class {
       progression (identifiant) {
         return { src: identifiant };

--- a/tests/situations/commun/composants/deplaceur_pieces.js
+++ b/tests/situations/commun/composants/deplaceur_pieces.js
@@ -1,15 +1,11 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import Piece from 'commun/modeles/piece';
 import DeplaceurPieces from 'commun/composants/deplaceur_pieces';
 
 describe('Le composant DeplaceurPieces', function () {
-  let $;
-
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
   });
 
   it('déplace les pièces sélectionnées', function () {

--- a/tests/situations/commun/infra/depot_journal.js
+++ b/tests/situations/commun/infra/depot_journal.js
@@ -1,11 +1,6 @@
 import DepotJournal from 'commun/infra/depot_journal';
-import jsdom from 'jsdom-global';
 
 describe('le depot du journal', function () {
-  beforeEach(function () {
-    jsdom('', { url: 'http://localhost' });
-  });
-
   it('fait un POST des lignes du journal vers le serveur', function () {
     const requetes = [];
     const depot = new DepotJournal({ ajax (params) { requetes.push(params); } });

--- a/tests/situations/commun/infra/depot_ressources.js
+++ b/tests/situations/commun/infra/depot_ressources.js
@@ -1,12 +1,7 @@
 import DepotRessources from 'commun/infra/depot_ressources';
-import jsdom from 'jsdom-global';
 import chargeurs from '../../commun/aides/mock_chargeurs';
 
 describe('le dépôt de ressources', function () {
-  beforeEach(function () {
-    jsdom('');
-  });
-
   it('permet de charger toutes les ressources', function () {
     const depot = new DepotRessources(chargeurs());
     depot.charge(['test.png', 'test2.png', 'test.wav']);

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -1,4 +1,3 @@
-import jsdom from 'jsdom-global';
 import RegistreUtilisateur, { CHANGEMENT_CONNEXION, CLEF_IDENTIFIANT } from 'commun/infra/registre_utilisateur';
 
 describe('le registre utilisateur', function () {
@@ -11,7 +10,7 @@ describe('le registre utilisateur', function () {
   }
 
   beforeEach(function () {
-    jsdom('', { url: 'http://localhost' });
+    window.localStorage.clear();
   });
 
   it("permet d'inscrire et de récupérer un utilisateur", function () {

--- a/tests/situations/commun/modale.js
+++ b/tests/situations/commun/modale.js
@@ -1,14 +1,10 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import { afficheFenetreModale } from 'commun/vues/modale';
 
 describe('fenetre modale', function () {
-  let $;
-
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
   });
 
   it("sait s'ajouter dans une page web", function () {

--- a/tests/situations/commun/vues/action_overlay.js
+++ b/tests/situations/commun/vues/action_overlay.js
@@ -1,15 +1,12 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import ActionOverlay from 'commun/vues/action_overlay';
 
 describe('une action overlay', () => {
-  let $;
   let vue;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     vue = new ActionOverlay('image', 'texte', 'classe-bouton');
     vue.affiche('#pointInsertion', $);
   });

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import VueActions from 'commun/vues/actions';
 import SituationCommune, { CONSIGNE_ECOUTEE, DEMARRE } from 'commun/modeles/situation';
@@ -7,11 +6,9 @@ import SituationCommune, { CONSIGNE_ECOUTEE, DEMARRE } from 'commun/modeles/situ
 describe('Affiche les éléments communs aux situations', function () {
   let vueActions;
   let situation;
-  let $;
 
   beforeEach(function () {
-    jsdom('<div id="magasin"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="magasin"></div>');
     situation = new SituationCommune();
 
     vueActions = new VueActions(situation, {}, new class {}());

--- a/tests/situations/commun/vues/bac.js
+++ b/tests/situations/commun/vues/bac.js
@@ -1,15 +1,11 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import Bac from 'commun/modeles/bac';
 import VueBac from 'commun/vues/bac';
 
 describe("La vue d'un bac", function () {
-  let $;
-
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
   });
 
   it("s'affiche à partir d'un point d'insertion", function () {

--- a/tests/situations/commun/vues/barre_dev.js
+++ b/tests/situations/commun/vues/barre_dev.js
@@ -1,17 +1,14 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import BarreDev from 'commun/vues/barre_dev';
 import Situation, { DEMARRE, FINI } from 'commun/modeles/situation';
 
 describe('la barre de developpement', () => {
-  let $;
   let situation;
   let vue;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation();
     vue = new BarreDev(situation);
     vue.affiche('#pointInsertion', $);

--- a/tests/situations/commun/vues/boite_utilisateur.js
+++ b/tests/situations/commun/vues/boite_utilisateur.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import EventEmitter from 'events';
 
 import { CHANGEMENT_CONNEXION } from 'commun/infra/registre_utilisateur';
@@ -9,11 +8,9 @@ import AccesSituation from 'accueil/modeles/acces_situation';
 describe('La boite utilisateur', function () {
   let registreUtilisateur;
   let vueBoiteUtilisateur;
-  let $;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     registreUtilisateur = new class extends EventEmitter {
       estConnecte () {}
       nom () {}

--- a/tests/situations/commun/vues/bouton.js
+++ b/tests/situations/commun/vues/bouton.js
@@ -1,14 +1,11 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import VueBouton from 'commun/vues/bouton';
 
 describe('vue Bouton', function () {
   let vue;
-  let $;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     vue = new VueBouton('bouton-lire-consigne', 'imagePlayer', () => this.click());
   });
 

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import SituationCommune, { CHANGEMENT_ETAT, CHARGEMENT, ERREUR_CHARGEMENT, ATTENTE_DEMARRAGE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI, STOPPEE } from 'commun/modeles/situation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
@@ -16,15 +15,13 @@ function uneClasseVue (callbackAffichage = () => {}) {
 }
 
 describe('Une vue du cadre', function () {
-  let $;
   let situation;
   let depotRessources;
   let journal;
   let uneVueCadre;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     depotRessources = new DepotRessourcesCommune('sonConsigne.wav', chargeurs());
     situation = new SituationCommune();
     journal = { enregistre () {}, enregistreSituationFaite () {} };

--- a/tests/situations/commun/vues/chargement.js
+++ b/tests/situations/commun/vues/chargement.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import VueChargement from 'commun/vues/chargement';
 import Situation, { CHARGEMENT, ATTENTE_DEMARRAGE, ERREUR_CHARGEMENT } from 'commun/modeles/situation';
@@ -7,13 +6,11 @@ import { traduction } from 'commun/infra/internationalisation';
 
 describe('vue chargement', function () {
   let situation;
-  let $;
   let vue;
   let depotRessources;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation();
     depotRessources = { chargement () { return Promise.resolve(); } };
     vue = new VueChargement(situation, depotRessources);

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import MockAudioNode from '../aides/mock_audio_node';
 
@@ -8,14 +7,12 @@ import Situation, { CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
 
 describe('vue consigne', function () {
   let vue;
-  let $;
   let situation;
   let consigne;
   let consigneCommune;
 
   beforeEach(function () {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation();
     consigne = new MockAudioNode();
     consigneCommune = new MockAudioNode();

--- a/tests/situations/commun/vues/erreur_chargement.js
+++ b/tests/situations/commun/vues/erreur_chargement.js
@@ -1,16 +1,13 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import VueErreurChargement from 'commun/vues/erreur_chargement';
 import { traduction } from 'commun/infra/internationalisation';
 
 describe('vue erreur chargement', function () {
-  let $;
   let vue;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     vue = new VueErreurChargement();
   });
 

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import VueGo from 'commun/vues/go';
 import Situation, { DEMARRE } from 'commun/modeles/situation';
@@ -7,12 +6,10 @@ import { traduction } from 'commun/infra/internationalisation';
 
 describe('vue Go', function () {
   let situation;
-  let $;
   let vue;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation();
     vue = new VueGo(situation);
     vue.affiche('#pointInsertion', $);

--- a/tests/situations/commun/vues/joue.js
+++ b/tests/situations/commun/vues/joue.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import Situation, { LECTURE_CONSIGNE, CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
 import Joue from 'commun/vues/joue';
@@ -7,12 +6,10 @@ import { traduction } from 'commun/infra/internationalisation';
 
 describe('la vue joue', () => {
   let situation;
-  let $;
   let vue;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation();
     vue = new Joue(situation);
     vue.affiche('#pointInsertion', $);

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import Piece, { DISPARITION_PIECE } from 'commun/modeles/piece';
 import VuePiece from 'commun/vues/piece';
@@ -9,12 +8,10 @@ function creeVueMinimale (piece, depot) {
 }
 
 describe('Une pièce', function () {
-  let $;
   let depot;
 
   beforeEach(function () {
-    jsdom('<div id="pointInsertion" style="width: 100px; height: 100px"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion" style="width: 100px; height: 100px"></div>');
     depot = { piece () { } };
   });
 

--- a/tests/situations/commun/vues/rejoue_consigne.js
+++ b/tests/situations/commun/vues/rejoue_consigne.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
 import EvenementRejoueConsigne from 'commun/modeles/evenement_rejoue_consigne';
 import MockAudioNode from '../aides/mock_audio_node';
@@ -7,14 +6,12 @@ import SituationCommune from 'commun/modeles/situation';
 
 describe('vue Rejoue Consigne', function () {
   let vue;
-  let $;
   let journal;
   let mockDepotResources;
   let situation;
 
   beforeEach(function () {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     journal = { enregistre () {} };
     situation = new SituationCommune();
     mockDepotResources = new class {

--- a/tests/situations/commun/vues/resultat.js
+++ b/tests/situations/commun/vues/resultat.js
@@ -1,16 +1,13 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import Situation, { FINI } from 'commun/modeles/situation';
 import VueResultat from 'commun/vues/resultat';
 
 describe('La vue de résultat', function () {
-  let $;
   let situation;
 
   beforeEach(function () {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation();
   });
 

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import VueStop from 'commun/vues/stop';
 import EvenementStop from 'commun/modeles/evenement_stop';
 import Situation, { STOPPEE } from 'commun/modeles/situation';
@@ -9,14 +8,12 @@ beforeEach(() => initialise());
 
 describe('vue Stop', function () {
   let vue;
-  let $;
   let retourAccueil = false;
   let mockJournal;
   let situation;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     mockJournal = {
       enregistre () {}
     };
@@ -28,7 +25,7 @@ describe('vue Stop', function () {
 
   it("sait s'insérer dans une page web", function () {
     vue.affiche('#point-insertion', $);
-    expect(document.querySelector('#point-insertion .bouton-stop').classList).to.not.contain('invisible');
+    expect($('#point-insertion .bouton-stop').hasClass('invisible')).to.be(false);
   });
 
   it('ouvre une fenêtre de confirmation avant de stopper', function () {

--- a/tests/situations/commun/vues/terminer.js
+++ b/tests/situations/commun/vues/terminer.js
@@ -1,14 +1,11 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 import VueTerminer from 'commun/vues/terminer.js';
 
 describe('Affiche les éléments liés à la fin de la situation', function () {
   let vueTerminer;
-  let $;
 
   beforeEach(function () {
-    jsdom('<div id="magasin"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="magasin"></div>');
     vueTerminer = new VueTerminer();
   });
 

--- a/tests/situations/controle/vues/fond_sonore.js
+++ b/tests/situations/controle/vues/fond_sonore.js
@@ -1,5 +1,3 @@
-import jsdom from 'jsdom-global';
-
 import MockAudioNode from '../../commun/aides/mock_audio_node';
 import { DEMARRE, FINI } from 'commun/modeles/situation';
 import Situation from 'controle/modeles/situation';
@@ -10,7 +8,7 @@ describe('Le fond sonore', () => {
   let vue;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
+    document.body.innerHTML = '<div id="pointInsertion"></div>';
   });
 
   describe('joue le bruit du tapis', () => {

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -1,16 +1,13 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import Piece from 'commun/modeles/piece';
 import VuePiece from 'controle/vues/piece';
 
 describe('Une pièce', function () {
-  let $;
   let depot;
 
   beforeEach(function () {
-    jsdom('<div id="controle" style="width: 100px; height: 100px"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="controle" style="width: 100px; height: 100px"></div>');
     depot = { piece () { } };
   });
 

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import MockDepotRessourcesControle from '../aides/mock_depot_ressources_controle';
 import EvenementPieceBienPlacee from 'commun/modeles/evenement_piece_bien_placee';
@@ -15,11 +14,8 @@ function vueSituationMinimaliste (journal) {
 }
 
 describe('La vue de la situation « Contrôle »', function () {
-  let $;
-
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
   });
 
   it('affiche le fond', function () {

--- a/tests/situations/controle/vues/tapis.js
+++ b/tests/situations/controle/vues/tapis.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import { DEMARRE, FINI } from 'commun/modeles/situation';
 import Situation from 'controle/modeles/situation';
@@ -7,14 +6,12 @@ import VueTapis from 'controle/vues/tapis';
 import MockDepotRessourcesControle from '../aides/mock_depot_ressources_controle';
 
 describe('La vue du tapis', () => {
-  let $;
   let situation;
   let vue;
   let depot;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation({});
     depot = new MockDepotRessourcesControle();
     vue = new VueTapis(situation, depot);

--- a/tests/situations/inventaire/vues/contenant.js
+++ b/tests/situations/inventaire/vues/contenant.js
@@ -2,7 +2,6 @@
 
 import Contenant from 'inventaire/modeles/contenant';
 import VueContenant from 'inventaire/vues/contenant';
-import jsdom from 'jsdom-global';
 
 describe('vue contenant', function () {
   let vue;
@@ -12,7 +11,7 @@ describe('vue contenant', function () {
   );
 
   beforeEach(function () {
-    jsdom('<div id="contenants"></div>');
+    document.body.innerHTML = '<div id="contenants"></div>';
     const pointInsertion = document.getElementById('contenants');
     vue = new VueContenant(pointInsertion, contenant);
   });

--- a/tests/situations/inventaire/vues/contenants.js
+++ b/tests/situations/inventaire/vues/contenants.js
@@ -3,7 +3,6 @@
 import Contenant from 'inventaire/modeles/contenant';
 import VueContenants from 'inventaire/vues/contenants';
 import EvenementOuvertureContenant from 'inventaire/modeles/evenement_ouverture_contenant';
-import jsdom from 'jsdom-global';
 
 describe('vue contenants', function () {
   let vue;
@@ -16,7 +15,7 @@ describe('vue contenants', function () {
   ];
 
   beforeEach(function () {
-    jsdom('<div id="stock"></div>');
+    document.body.innerHTML = '<div id="stock"></div>';
     pointInsertion = document.getElementById('stock');
     journal = {
       enregistre () {}

--- a/tests/situations/inventaire/vues/contenu.js
+++ b/tests/situations/inventaire/vues/contenu.js
@@ -2,7 +2,6 @@
 
 import Contenant from 'inventaire/modeles/contenant';
 import VueContenu from 'inventaire/vues/contenu';
-import jsdom from 'jsdom-global';
 
 describe('vue contenu', function () {
   let vue;
@@ -11,7 +10,7 @@ describe('vue contenu', function () {
   const DELAI_FERMETURE = 3;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
+    document.body.innerHTML = '<div id="point-insertion"></div>';
     let pointInsertion = document.getElementById('point-insertion');
     vue = new VueContenu(pointInsertion, DELAI_FERMETURE);
     calque = document.getElementById('calque');
@@ -54,7 +53,7 @@ describe('vue contenu', function () {
       const contenant = new Contenant({ imageOuvert: 'image_contenant', dimensionsOuvert: { largeur: 33, hauteur: 33 } }, { nom: 'Nova Sky' });
       vue.affiche(contenant);
 
-      expect(element.src).to.eql('image_contenant');
+      expect(element.src).to.eql('http://localhost/image_contenant');
     });
 
     it('affiche le contenant ouvert aux dimensions données en paramètres', function () {

--- a/tests/situations/inventaire/vues/etageres.js
+++ b/tests/situations/inventaire/vues/etageres.js
@@ -2,13 +2,12 @@
 
 import Contenant from 'inventaire/modeles/contenant';
 import VueEtageres from 'inventaire/vues/etageres';
-import jsdom from 'jsdom-global';
 
 describe('vue etagères', function () {
   let vue;
 
   beforeEach(function () {
-    jsdom('<div id="magasin"></div>');
+    document.body.innerHTML = '<div id="magasin"></div>';
     vue = new VueEtageres('#magasin');
   });
 

--- a/tests/situations/inventaire/vues/formulaire_saisie_inventaire.js
+++ b/tests/situations/inventaire/vues/formulaire_saisie_inventaire.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import { CHANGEMENT_ETAT, FINI } from 'commun/modeles/situation';
 import Contenant from 'inventaire/modeles/contenant';
@@ -10,14 +9,11 @@ import MockDepotRessourcesInventaire from '../aides/mock_depot_ressources';
 import { unMagasin, unMagasinVide } from '../aides/magasin';
 
 describe("Le formulaire de saisie d'inventaire", function () {
-  let $;
   let journal;
   let depotRessources;
 
   beforeEach(function () {
-    jsdom('<div id="magasin"></div>');
-
-    $ = jQuery(window);
+    $('body').append('<div id="magasin"></div>');
     journal = {
       enregistre () {}
     };

--- a/tests/situations/inventaire/vues/situation.js
+++ b/tests/situations/inventaire/vues/situation.js
@@ -1,20 +1,17 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import { unMagasinVide } from '../aides/magasin';
 import VueSituation from 'inventaire/vues/situation';
 import MockDepotRessourcesInventaire from '../aides/mock_depot_ressources';
 
 describe('La situation « Inventaire »', function () {
-  let $;
   let mockJournal;
   let situation;
   let vue;
   let depotRessources;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     mockJournal = {
       enregistre: () => {}
     };
@@ -24,10 +21,9 @@ describe('La situation « Inventaire »', function () {
   });
 
   it('affiche les étagères', function () {
-    expect($('#point-insertion .etageres').length).to.equal(0);
+    expect($('#pointInsertion .etageres').length).to.equal(0);
 
-    vue.affiche('#point-insertion', $);
-
-    expect($('#point-insertion .etageres').length).to.equal(1);
+    vue.affiche('#pointInsertion', $);
+    expect($('#pointInsertion .etageres').length).to.equal(1);
   });
 });

--- a/tests/situations/questions/vues/qcm.js
+++ b/tests/situations/questions/vues/qcm.js
@@ -1,15 +1,12 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import VueQCM, { EVENEMENT_REPONSE } from 'questions/vues/qcm';
 
 describe('La vue de la question QCM', function () {
-  let $;
   let question;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     question = { choix: [] };
   });
 

--- a/tests/situations/questions/vues/redaction_note.js
+++ b/tests/situations/questions/vues/redaction_note.js
@@ -1,15 +1,12 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import VueRedactionNote, { EVENEMENT_REPONSE } from 'questions/vues/redaction_note';
 
 describe('La vue de la question RedactionNote', function () {
-  let $;
   let question;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     question = {};
   });
 

--- a/tests/situations/questions/vues/situation.js
+++ b/tests/situations/questions/vues/situation.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import Situation, { EVENEMENT_REPONSE as EVENEMENT_REPONSE_SITUATION } from 'questions/modeles/situation';
 import EvenementReponse from 'questions/modeles/evenement_reponse';
@@ -7,15 +6,13 @@ import VueSituation from 'questions/vues/situation';
 import { EVENEMENT_REPONSE as EVENEMENT_REPONSE_VUE } from 'questions/vues/redaction_note';
 
 describe('La vue de la situation « Question »', function () {
-  let $;
   let depotRessources;
   let situation;
   let journal;
   let registreUtilisateur;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     $.fx.off = true;
     depotRessources = new class {}();
     depotRessources.charge = () => {};

--- a/tests/situations/tri/vues/chronometre.js
+++ b/tests/situations/tri/vues/chronometre.js
@@ -1,19 +1,16 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import { DEMARRE, FINI } from 'commun/modeles/situation';
 import Situation from 'tri/modeles/situation';
 import VueChronometre from 'tri/vues/chronometre';
 
 describe('Le chronometre', () => {
-  let $;
   let situation;
   let mockDepotRessources;
   let vue;
 
   beforeEach(() => {
-    jsdom('<div id="pointInsertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation({ pieces: [], bacs: [] });
     mockDepotRessources = new class {
       fondChronometre () {

--- a/tests/situations/tri/vues/situation.js
+++ b/tests/situations/tri/vues/situation.js
@@ -1,5 +1,4 @@
-import jsdom from 'jsdom-global';
-import jQuery from 'jquery';
+import $ from 'jquery';
 
 import VueSituation from 'tri/vues/situation';
 import Bac from 'commun/modeles/bac';
@@ -11,7 +10,6 @@ import EvenementPieceMalPlacee from 'commun/modeles/evenement_piece_mal_placee';
 import MockDepotRessourcesTri from '../aides/mock_depot_ressources_tri';
 
 describe('La situation « Tri »', function () {
-  let $;
   let mockDepotRessources;
   let situation;
   let journal;
@@ -19,8 +17,7 @@ describe('La situation « Tri »', function () {
   let mockDeplaceurPieces;
 
   beforeEach(function () {
-    jsdom('<div id="point-insertion"></div>');
-    $ = jQuery(window);
+    $('body').append('<div id="point-insertion"></div>');
     mockDepotRessources = new MockDepotRessourcesTri();
     journal = { enregistre () {} };
     situation = new Situation({ pieces: [], bacs: [] });


### PR DESCRIPTION
Plutôt que de recréer un context jsdom dans chaque test, et dans l'idée de permettre l'intégration de vue, on a désormais un contexte jsdom global partagé entre tout les tests.