### PR TITLE
Fix lecture des sons ios

### DIFF
--- a/src/situations/commun/composants/joueur_consigne.js
+++ b/src/situations/commun/composants/joueur_consigne.js
@@ -1,7 +1,7 @@
-export default function joueConsigne ($, depot, jouerConsigneCommune, lectureTerminee) {
+export default function joueConsigne (depot, jouerConsigneCommune, lectureTerminee) {
   function joueSon (noeudSon, callbackFin) {
-    $(noeudSon).on('ended', callbackFin);
     noeudSon.start();
+    setTimeout(callbackFin, noeudSon.buffer.duration * 1000);
   }
 
   function joueConsigneCommune () {

--- a/src/situations/commun/composants/joueur_consigne.js
+++ b/src/situations/commun/composants/joueur_consigne.js
@@ -1,13 +1,18 @@
-export default function joueConsigne (depot, jouerConsigneCommune, lectureTerminee) {
-  function joueSon (noeudSon, callbackFin) {
+export default class JoueurConsigne {
+  constructor (depot) {
+    this.depot = depot;
+  }
+
+  joueSon (noeudSon, callbackFin) {
     noeudSon.start();
     setTimeout(callbackFin, noeudSon.buffer.duration * 1000);
   }
 
-  function joueConsigneCommune () {
-    joueSon(depot.consigneCommune(), lectureTerminee);
+  joue (jouerConsigneCommune, lectureTerminee) {
+    const joueConsigneCommune = () => {
+      this.joueSon(this.depot.consigneCommune(), lectureTerminee);
+    };
+    this.joueSon(this.depot.consigne(),
+      jouerConsigneCommune ? joueConsigneCommune : lectureTerminee);
   }
-
-  joueSon(depot.consigne(),
-    jouerConsigneCommune ? joueConsigneCommune : lectureTerminee);
 }

--- a/src/situations/commun/infra/depot_ressources.js
+++ b/src/situations/commun/infra/depot_ressources.js
@@ -1,6 +1,7 @@
-const chargeurAudio = function (src, timeout = 2000) {
-  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+let audioCtx;
 
+const chargeurAudio = function (src, timeout = 2000) {
+  audioCtx = audioCtx || new (window.AudioContext || window.webkitAudioContext)();
   const request = new window.XMLHttpRequest();
 
   request.open('GET', src, true);

--- a/src/situations/commun/infra/depot_ressources.js
+++ b/src/situations/commun/infra/depot_ressources.js
@@ -1,4 +1,6 @@
 const chargeurAudio = function (src, timeout = 2000) {
+  const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+
   const request = new window.XMLHttpRequest();
 
   request.open('GET', src, true);
@@ -6,27 +8,16 @@ const chargeurAudio = function (src, timeout = 2000) {
 
   const promesse = new Promise((resolve, reject) => {
     request.onload = function () {
-      if (window.AudioContext) {
-        const audioCtx = new window.AudioContext();
-        audioCtx.decodeAudioData(request.response,
-          function (buffer) {
-            resolve(() => {
-              const source = audioCtx.createBufferSource();
-              source.buffer = buffer;
-              source.connect(audioCtx.destination);
-              return source;
-            });
-          },
-          reject);
-      } else {
-        resolve(() => {
-          const audio = new window.Audio();
-          audio.src = src;
-          audio.start = audio.play;
-          audio.stop = audio.pause;
-          return audio;
-        });
-      }
+      audioCtx.decodeAudioData(request.response,
+        function (buffer) {
+          resolve(() => {
+            const source = audioCtx.createBufferSource();
+            source.buffer = buffer;
+            source.connect(audioCtx.destination);
+            return source;
+          });
+        },
+        reject);
     };
   });
 

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -4,18 +4,19 @@ import { CHANGEMENT_ETAT, CONSIGNE_ECOUTEE, DEMARRE } from 'commun/modeles/situa
 
 import VueStop from 'commun/vues/stop';
 import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
+import JoueurConsigne from 'commun/composants/joueur_consigne';
 
 export default class VueActions {
   constructor (situation, journal, depot) {
     this.situation = situation;
     this.journal = journal;
-    this.depot = depot;
+    this.joueurConsigne = new JoueurConsigne(depot);
   }
 
   affiche (pointInsertion, $) {
     this.$actions = $('<div class="actions"></div>');
     this.stop = new VueStop(this.situation, this.journal);
-    this.rejoueConsigne = new VueRejoueConsigne(this.depot, this.journal);
+    this.rejoueConsigne = new VueRejoueConsigne(this.joueurConsigne, this.journal);
     this.situation.on(CHANGEMENT_ETAT, (etat) => this.afficheBoutons(etat, $));
     this.afficheBoutons(this.situation.etat(), $);
     $(pointInsertion).append(this.$actions);

--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -1,20 +1,19 @@
 import { CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
-import _joueConsigne from 'commun/composants/joueur_consigne';
+import _JoueurConsigne from 'commun/composants/joueur_consigne';
 import VueActionOverlay from './action_overlay';
 
 import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 
 export default class VueConsigne extends VueActionOverlay {
-  constructor (situation, depot, joueConsigne = _joueConsigne) {
+  constructor (situation, depot, JoueurConsigne = _JoueurConsigne) {
     super(lectureEnCours, '', 'bouton-lecture-en-cours', 'bouton-centre-visible');
     this.situation = situation;
-    this.depot = depot;
-    this.joueConsigne = joueConsigne;
+    this.joueurConsigne = new JoueurConsigne(depot);
   }
 
   affiche (pointInsertion, $) {
     super.affiche(pointInsertion, $);
-    this.joueConsigne(this.depot, true, () => this.lectureTerminee());
+    this.joueurConsigne.joue(true, this.lectureTerminee.bind(this));
   }
 
   lectureTerminee () {

--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -1,19 +1,20 @@
 import { CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
-import joueConsigne from 'commun/composants/joueur_consigne';
+import _joueConsigne from 'commun/composants/joueur_consigne';
 import VueActionOverlay from './action_overlay';
 
 import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 
 export default class VueConsigne extends VueActionOverlay {
-  constructor (situation, depot) {
+  constructor (situation, depot, joueConsigne = _joueConsigne) {
     super(lectureEnCours, '', 'bouton-lecture-en-cours', 'bouton-centre-visible');
     this.situation = situation;
     this.depot = depot;
+    this.joueConsigne = joueConsigne;
   }
 
   affiche (pointInsertion, $) {
     super.affiche(pointInsertion, $);
-    joueConsigne($, this.depot, true, () => this.lectureTerminee());
+    this.joueConsigne(this.depot, true, () => this.lectureTerminee());
   }
 
   lectureTerminee () {

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -1,4 +1,3 @@
-import joueConsigne from 'commun/composants/joueur_consigne';
 import { traduction } from 'commun/infra/internationalisation';
 import VueBouton from './bouton';
 import EvenementRejoueConsigne from '../modeles/evenement_rejoue_consigne';
@@ -9,8 +8,8 @@ import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 import 'commun/styles/bouton.scss';
 
 export default class VueRejoueConsigne {
-  constructor (depotResources, journal) {
-    this.depotResources = depotResources;
+  constructor (joueurConsigne, journal) {
+    this.joueurConsigne = joueurConsigne;
     this.journal = journal;
     this.vueBoutonLire = new VueBouton('bouton-lire-consigne', play, () => this.litConsigne(this.$));
     this.vueBoutonLire.ajouteUneEtiquette(traduction('situation.repeter_consigne'));
@@ -34,7 +33,8 @@ export default class VueRejoueConsigne {
     this.vueBoutonLire.cache();
 
     this.vueBoutonLectureEnCours.affiche(this.$boutonRejoueConsigne, $);
-    joueConsigne(this.depotResources, this.etat !== DEMARRE, () => this.lectureTerminee());
+    this.joueurConsigne
+      .joue(this.etat !== DEMARRE, this.lectureTerminee.bind(this));
   }
 
   lectureTerminee () {

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -34,7 +34,7 @@ export default class VueRejoueConsigne {
     this.vueBoutonLire.cache();
 
     this.vueBoutonLectureEnCours.affiche(this.$boutonRejoueConsigne, $);
-    joueConsigne($, this.depotResources, this.etat !== DEMARRE, () => this.lectureTerminee());
+    joueConsigne(this.depotResources, this.etat !== DEMARRE, () => this.lectureTerminee());
   }
 
   lectureTerminee () {

--- a/tests/situations/commun/aides/mock_audio_node.js
+++ b/tests/situations/commun/aides/mock_audio_node.js
@@ -1,6 +1,7 @@
 export default class MockAudioNode {
   constructor (son) {
     this.src = son;
+    this.buffer = { duration: 0 };
   }
 
   start () {}

--- a/tests/situations/commun/composants/joueur_consigne.js
+++ b/tests/situations/commun/composants/joueur_consigne.js
@@ -1,36 +1,37 @@
-import joueConsigne from 'commun/composants/joueur_consigne';
+import JoueurConsigne from 'commun/composants/joueur_consigne';
 
 import MockAudioNode from '../aides/mock_audio_node';
 
 describe('joueur de consigne', function () {
   let uneConsigne;
   let uneConsigneCommune;
-  let depot;
+  let joueur;
 
   beforeEach(function () {
     uneConsigne = new MockAudioNode();
     uneConsigneCommune = new MockAudioNode();
-    depot = {
+    const depot = {
       consigne: () => uneConsigne,
       consigneCommune: () => uneConsigneCommune
     };
+    joueur = new JoueurConsigne(depot);
   });
 
   it('joue la consigne du dépôt', function (done) {
     uneConsigne.start = done;
-    joueConsigne(depot, false, () => {});
+    joueur.joue(false, () => {});
   });
 
   it('appelle la callback de fin après la lecture de la consigne', function (done) {
     let consigneJouee = false;
     uneConsigne.start = () => { consigneJouee = true; };
-    joueConsigne(depot, false, () => {
+    joueur.joue(false, () => {
       expect(consigneJouee).to.be(true);
       done();
     });
   });
 
-  it('joue la consigne commune après la consigne à la demande', function (done) {
+  it('joue la consigne commune après la consigne, à la demande', function (done) {
     let consigneJouee = false;
     let consigneCommuneJouee = false;
     uneConsigne.start = () => { consigneJouee = true; };
@@ -38,7 +39,7 @@ describe('joueur de consigne', function () {
       expect(consigneJouee).to.be(true);
       consigneCommuneJouee = true;
     };
-    joueConsigne(depot, true, () => {
+    joueur.joue(true, () => {
       expect(consigneCommuneJouee).to.be(true);
       done();
     });
@@ -49,7 +50,7 @@ describe('joueur de consigne', function () {
     uneConsigneCommune.start = () => {
       consigneCommuneJouee = true;
     };
-    joueConsigne(depot, false, () => {
+    joueur.joue(false, () => {
       expect(consigneCommuneJouee).to.be(false);
       done();
     });

--- a/tests/situations/commun/composants/joueur_consigne.js
+++ b/tests/situations/commun/composants/joueur_consigne.js
@@ -1,0 +1,57 @@
+import joueConsigne from 'commun/composants/joueur_consigne';
+
+import MockAudioNode from '../aides/mock_audio_node';
+
+describe('joueur de consigne', function () {
+  let uneConsigne;
+  let uneConsigneCommune;
+  let depot;
+
+  beforeEach(function () {
+    uneConsigne = new MockAudioNode();
+    uneConsigneCommune = new MockAudioNode();
+    depot = {
+      consigne: () => uneConsigne,
+      consigneCommune: () => uneConsigneCommune
+    };
+  });
+
+  it('joue la consigne du dépôt', function (done) {
+    uneConsigne.start = done;
+    joueConsigne(depot, false, () => {});
+  });
+
+  it('appelle la callback de fin après la lecture de la consigne', function (done) {
+    let consigneJouee = false;
+    uneConsigne.start = () => { consigneJouee = true; };
+    joueConsigne(depot, false, () => {
+      expect(consigneJouee).to.be(true);
+      done();
+    });
+  });
+
+  it('joue la consigne commune après la consigne à la demande', function (done) {
+    let consigneJouee = false;
+    let consigneCommuneJouee = false;
+    uneConsigne.start = () => { consigneJouee = true; };
+    uneConsigneCommune.start = () => {
+      expect(consigneJouee).to.be(true);
+      consigneCommuneJouee = true;
+    };
+    joueConsigne(depot, true, () => {
+      expect(consigneCommuneJouee).to.be(true);
+      done();
+    });
+  });
+
+  it("ne joue pas la consigne commune si ce n'est pas demandé", function (done) {
+    let consigneCommuneJouee = false;
+    uneConsigneCommune.start = () => {
+      consigneCommuneJouee = true;
+    };
+    joueConsigne(depot, false, () => {
+      expect(consigneCommuneJouee).to.be(false);
+      done();
+    });
+  });
+});

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -1,32 +1,21 @@
 import $ from 'jquery';
 
-import MockAudioNode from '../aides/mock_audio_node';
-
 import VueConsigne from 'commun/vues/consigne';
 import Situation, { CONSIGNE_ECOUTEE } from 'commun/modeles/situation';
 
 describe('vue consigne', function () {
-  let vue;
-  let situation;
-  let consigne;
-  let consigneCommune;
-
   beforeEach(function () {
     $('body').append('<div id="pointInsertion"></div>');
-    situation = new Situation();
-    consigne = new MockAudioNode();
-    consigneCommune = new MockAudioNode();
-    const depot = {
-      consigne: () => consigne,
-      consigneCommune: () => consigneCommune
-    };
-    vue = new VueConsigne(situation, depot);
   });
 
   it("change l'état a CONSIGNE_ECOUTEE une fois terminé", () => {
+    const situation = new Situation();
+    const mockJoueConsigne = (unused, alsoUnused, cbFin) => {
+      cbFin();
+    };
+    const vue = new VueConsigne(situation, null, mockJoueConsigne);
     vue.affiche('#pointInsertion', $);
-    $(consigne).trigger('ended');
-    $(consigneCommune).trigger('ended');
+
     expect(situation.etat()).to.eql(CONSIGNE_ECOUTEE);
   });
 });

--- a/tests/situations/commun/vues/consigne.js
+++ b/tests/situations/commun/vues/consigne.js
@@ -10,10 +10,12 @@ describe('vue consigne', function () {
 
   it("change l'état a CONSIGNE_ECOUTEE une fois terminé", () => {
     const situation = new Situation();
-    const mockJoueConsigne = (unused, alsoUnused, cbFin) => {
-      cbFin();
+    const mockJoueurConsigne = class {
+      joue (unused, cbFin) {
+        cbFin();
+      }
     };
-    const vue = new VueConsigne(situation, null, mockJoueConsigne);
+    const vue = new VueConsigne(situation, null, mockJoueurConsigne);
     vue.affiche('#pointInsertion', $);
 
     expect(situation.etat()).to.eql(CONSIGNE_ECOUTEE);

--- a/tests/situations/commun/vues/rejoue_consigne.js
+++ b/tests/situations/commun/vues/rejoue_consigne.js
@@ -1,36 +1,29 @@
 import $ from 'jquery';
 import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
 import EvenementRejoueConsigne from 'commun/modeles/evenement_rejoue_consigne';
-import MockAudioNode from '../aides/mock_audio_node';
-import SituationCommune from 'commun/modeles/situation';
+import SituationCommune, { ATTENTE_DEMARRAGE, DEMARRE } from 'commun/modeles/situation';
 
 describe('vue Rejoue Consigne', function () {
   let vue;
   let journal;
-  let mockDepotResources;
+  let mockJoueurConsigne;
   let situation;
 
   beforeEach(function () {
     $('body').append('<div id="pointInsertion"></div>');
     journal = { enregistre () {} };
     situation = new SituationCommune();
-    mockDepotResources = new class {
-      consigne () {
-        this.derniereConsigneRetournee = new MockAudioNode();
-        return this.derniereConsigneRetournee;
-      }
-
-      consigneCommune () {
-        this.consigneCommune = new MockAudioNode();
-        return this.consigneCommune;
+    mockJoueurConsigne = new class {
+      joue (unused, cbFin) {
+        this.cbFin = cbFin;
       }
 
       finConsigne () {
-        $(this.consigneCommune).trigger('ended');
+        this.cbFin();
       }
     }();
 
-    vue = new VueRejoueConsigne(mockDepotResources, journal);
+    vue = new VueRejoueConsigne(mockJoueurConsigne, journal);
   });
 
   it("sait s'insérer dans une page web", function () {
@@ -47,15 +40,39 @@ describe('vue Rejoue Consigne', function () {
 
   it("à la fin de la lecture, repasse à l'état initial", function () {
     vue.affiche('#pointInsertion', $, situation);
-    mockDepotResources.finConsigne();
+    vue.litConsigne($);
+    mockJoueurConsigne.finConsigne();
     expect($('#pointInsertion .bouton-lire-consigne').length).to.eql(1);
     expect($('#pointInsertion .bouton-lecture-en-cours').length).to.eql(0);
   });
 
   it('on peut lire la consigne plusieurs fois', function () {
     vue.affiche('#pointInsertion', $, situation);
-    mockDepotResources.finConsigne();
+    vue.litConsigne($);
+    mockJoueurConsigne.finConsigne();
+    vue.litConsigne($);
+    mockJoueurConsigne.finConsigne();
     expect($('#pointInsertion .bouton-lire-consigne').length).to.eql(1);
+    expect($('#pointInsertion .bouton-lecture-en-cours').length).to.eql(0);
+  });
+
+  it("rejoue aussi la consigne commune si la situation n'a pas encore demarre", function () {
+    mockJoueurConsigne.joue = (joueConsigneCommune, cbFin) => {
+      expect(joueConsigneCommune).to.be(true);
+    };
+    situation.modifieEtat(ATTENTE_DEMARRAGE);
+    vue.affiche('#pointInsertion', $, situation);
+    vue.litConsigne($);
+  });
+
+  it('ne rejoue pas la consigne commune si la situation a demarre', function () {
+    mockJoueurConsigne.joue = (joueConsigneCommune, cbFin) => {
+      expect(joueConsigneCommune).to.be(false);
+    };
+    vue.affiche('#pointInsertion', $, situation);
+    situation.modifieEtat(DEMARRE);
+    vue.affiche('#pointInsertion', $, situation);
+    vue.litConsigne($);
   });
 
   it('journalise un événement RejoueConsigne', function (done) {


### PR DESCRIPTION
Fix #411 

- On est repassé sur webkitWebAudio pour Safari.
- L'évenement "ended" n'est pas géré correctement par safari. A la place on synchronise la lecture des sons avec un timer javascript.
- La lecture de plusieurs sons en même temps (pour le contrôle) a été résolu par l'instanciation d'une instance unique pour WebAudioContext.