### PR TITLE
cache l'affichage de la situation tant que cette dernière n'a pas fini son chargement 

### DIFF
--- a/src/situations/commun/vues/action_overlay.js
+++ b/src/situations/commun/vues/action_overlay.js
@@ -2,11 +2,12 @@ import VueBouton from './bouton';
 import 'commun/styles/action_overlay.scss';
 
 export default class VueActionOverlay {
-  constructor (image, message, classe, classeBouton) {
+  constructor (image, message, classe, classeBouton, dimensionOverlay = '') {
     this.image = image;
     this.message = message;
     this.classe = classe;
     this.classeBouton = classeBouton;
+    this.dimensionOverlay = dimensionOverlay;
     this.vueBouton = new VueBouton(this.classe, this.image, () => this.click());
   }
 
@@ -16,7 +17,7 @@ export default class VueActionOverlay {
 
     this.vueBouton.affiche($conteneurBouton, $);
 
-    this.$overlay = $('<div class="overlay hors-actions"></div>');
+    this.$overlay = $(`<div class="overlay ${this.dimensionOverlay}"></div>`);
 
     this.$overlay.append($conteneurBouton);
     this.$overlay.append(this.$message);

--- a/src/situations/commun/vues/consigne.js
+++ b/src/situations/commun/vues/consigne.js
@@ -6,7 +6,7 @@ import lectureEnCours from 'commun/assets/lecture-en-cours.svg';
 
 export default class VueConsigne extends VueActionOverlay {
   constructor (situation, depot, JoueurConsigne = _JoueurConsigne) {
-    super(lectureEnCours, '', 'bouton-lecture-en-cours', 'bouton-centre-visible');
+    super(lectureEnCours, '', 'bouton-lecture-en-cours', 'bouton-centre-visible', 'hors-actions');
     this.situation = situation;
     this.joueurConsigne = new JoueurConsigne(depot);
   }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -6,7 +6,7 @@ import { traduction } from 'commun/infra/internationalisation';
 
 export default class VueGo extends VueActionOverlay {
   constructor (situation) {
-    super(go, traduction('situation.go'), 'bouton-go', 'bouton-centre-visible');
+    super(go, traduction('situation.go'), 'bouton-go', 'bouton-centre-visible', 'hors-actions');
     this.situation = situation;
   }
 

--- a/src/situations/commun/vues/joue.js
+++ b/src/situations/commun/vues/joue.js
@@ -6,7 +6,7 @@ import { traduction } from 'commun/infra/internationalisation';
 
 export default class VueJoue extends VueActionOverlay {
   constructor (situation) {
-    super(play, traduction('situation.ecouter-consigne'), 'bouton-lire-consigne', 'bouton-centre-visible');
+    super(play, traduction('situation.ecouter-consigne'), 'bouton-lire-consigne', 'bouton-centre-visible', 'hors-actions');
     this.situation = situation;
   }
 

--- a/tests/situations/commun/vues/action_overlay.js
+++ b/tests/situations/commun/vues/action_overlay.js
@@ -7,7 +7,7 @@ describe('une action overlay', () => {
 
   beforeEach(() => {
     $('body').append('<div id="pointInsertion"></div>');
-    vue = new ActionOverlay('image', 'texte', 'classe-bouton');
+    vue = new ActionOverlay('image', 'texte', 'classe-bouton', 'hors-actions');
     vue.affiche('#pointInsertion', $);
   });
 
@@ -18,6 +18,7 @@ describe('une action overlay', () => {
   it("affiche le message, l'image et la classe spécifique", () => {
     expect($('#pointInsertion .message').text()).to.eql('texte');
     expect($('#pointInsertion .classe-bouton').length).to.eql(1);
+    expect($('#pointInsertion .hors-actions').length).to.eql(1);
     expect($('#pointInsertion .classe-bouton img').attr('src')).to.eql('image');
   });
 


### PR DESCRIPTION
Pour éviter le genre de comportement ci-dessous je n'ai pas limité l'overlay de chargement à la hauteur de la `scene`, ainsi il prend tout le `conteneur`.

Avant

![Capture d’écran 2019-08-16 à 12 23 41](https://user-images.githubusercontent.com/20596535/63164122-b71e8900-c027-11e9-95f8-f5ccd7e24952.png)

Aprés

![Capture d’écran 2019-08-16 à 12 36 11](https://user-images.githubusercontent.com/20596535/63164101-a706a980-c027-11e9-80f4-af0468be31b1.png)
