### PR TITLE
[Bureau] Désactive le bouton réponse lorsque aucune réponse est sélectionné et une fois répondu 

### DIFF
--- a/src/situations/questions/vues/qcm.js
+++ b/src/situations/questions/vues/qcm.js
@@ -27,16 +27,19 @@ export default class VueQCM extends VueQuestion {
           <p class="couleur-grise sans-marge">${this.question.description}</p>
           <p class="sans-marge">${this.question.intitule}</p>
           ${$valeursPossibles}
-          <button id="envoi-reponse" class="question-bouton bouton-arrondi">
+          <button id="envoi-reponse" class="question-bouton bouton-arrondi" disabled>
             ${traduction('questions.qcm.valider')}
           </button>
         </div
       </div>
     `);
-
     $(pointInsertion).append(this.$vue);
-    $('#envoi-reponse', this.$vue).click(() => {
-      const reponse = $('input[name="numeratie"]:checked').val();
+    const $envoiReponse = $('#envoi-reponse', this.$vue);
+    $('input[name="numeratie"]', this.$vue).on('input', () => {
+      $envoiReponse.prop('disabled', false);
+    });
+    $envoiReponse.click(() => {
+      const reponse = $('input[name="numeratie"]:checked', this.$vue).val();
       this.emit(EVENEMENT_REPONSE, reponse);
     });
   }

--- a/src/situations/questions/vues/qcm.js
+++ b/src/situations/questions/vues/qcm.js
@@ -39,6 +39,7 @@ export default class VueQCM extends VueQuestion {
       $envoiReponse.prop('disabled', false);
     });
     $envoiReponse.click(() => {
+      $envoiReponse.prop('disabled', true);
       const reponse = $('input[name="numeratie"]:checked', this.$vue).val();
       this.emit(EVENEMENT_REPONSE, reponse);
     });

--- a/tests/situations/questions/vues/qcm.js
+++ b/tests/situations/questions/vues/qcm.js
@@ -60,4 +60,19 @@ describe('La vue de la question QCM', function () {
 
     $('#point-insertion #envoi-reponse').click();
   });
+
+  it('désactive le bouton une fois répondu pour éviter le double click', function (done) {
+    question.choix = [{ id: '32' }];
+    const $vue = new VueQCM(question);
+
+    $vue.affiche('#point-insertion', $);
+    $('#point-insertion input[type=radio][value=32]').prop('checked', true).trigger('input');
+    expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(false);
+    $vue.on(EVENEMENT_REPONSE, (reponse) => {
+      expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(true);
+      done();
+    });
+
+    $('#point-insertion #envoi-reponse').click();
+  });
 });

--- a/tests/situations/questions/vues/qcm.js
+++ b/tests/situations/questions/vues/qcm.js
@@ -38,7 +38,16 @@ describe('La vue de la question QCM', function () {
     expect($('#point-insertion #envoi-reponse').length).to.equal(1);
   });
 
-  it('emet un événément réponse quand on appuie sur le bouton envoi', function (done) {
+  it("désactive le bouton lorsqu'aucune réponse n'est sélectionnée", function () {
+    question.choix = [{ id: '32' }];
+    const $vue = new VueQCM(question);
+    $vue.affiche('#point-insertion', $);
+    expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(true);
+    $('#point-insertion input[type=radio][value=32]').prop('checked', true).trigger('input');
+    expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(false);
+  });
+
+  it('emet un événement réponse quand on appuie sur le bouton envoi', function (done) {
     question.choix = [{ id: '32' }];
     const $vue = new VueQCM(question);
 


### PR DESCRIPTION
Cela corrige les problèmes de double click et d'événements avec une réponse vide qui casse la restitution.