### PR TITLE
La fenêtre modale ne disparait plus après l'action OK

### DIFF
--- a/src/situations/commun/vues/modale.js
+++ b/src/situations/commun/vues/modale.js
@@ -28,9 +28,7 @@ export function afficheFenetreModale (pointInsertion, $,
 
   $('#OK-modale').on('click', () => {
     $modale.addClass('attendre');
-    Promise.resolve(actionOk()).finally(() => {
-      $modale.remove();
-    });
+    actionOk();
   });
 
   $('#annuler-modale').on('click', () => {

--- a/tests/situations/commun/modale.js
+++ b/tests/situations/commun/modale.js
@@ -31,31 +31,6 @@ describe('fenetre modale', function () {
     $('#OK-modale').click();
   });
 
-  it("supprime la fenêtre quand l'action Ok est finie", function () {
-    const promesseOk = Promise.resolve();
-    afficheFenetreModale($('#point-insertion'), $, {
-      actionOk: () => {
-        return promesseOk;
-      }
-    });
-
-    $('#OK-modale').click();
-    return promesseOk.then(() => {
-      expect($('#fenetre-modale').length).to.equal(0);
-    });
-  });
-
-  it("supprime la fenêtre quand l'action ok est fini même si ce n'est pas une promessse", function () {
-    afficheFenetreModale($('#point-insertion'), $, {
-      actionOk: () => { }
-    });
-
-    $('#OK-modale').click();
-    return Promise.resolve().then(() => {
-      expect($('#fenetre-modale').length).to.equal(0);
-    });
-  });
-
   it('supprime la fenêtre modal quand on clique sur annuler', () => {
     afficheFenetreModale('#point-insertion', $, {
       boutonAnnuler: 'Annuler'


### PR DESCRIPTION
Quand l'action OK consiste à naviger vers l'accueil, la fenêtre disparait trop
tôt et ça fait un effet "glitch".

Comme nous n'avons aujourd'hui pas d'autre usage que de naviguer vers
l'accueil, j'ai supprimé la disparition de la fenêtre dans le cas de l'action
OK.