### PR TITLE
[Safari] corrige l'affichage de la checkbox sur le formulaire d'identification

### DIFF
--- a/src/situations/accueil/styles/formulaire_identification.scss
+++ b/src/situations/accueil/styles/formulaire_identification.scss
@@ -39,6 +39,10 @@
   display: flex;
   align-items: flex-start;
   max-width: 70%;
+
+  input[type="checkbox"] {
+    flex-shrink: 0;
+  }
 }
 
 .cgu-text {


### PR DESCRIPTION
Il faut donner une largeur à la case à cocher quand on l'utilise dans un `flex`.