### PR TITLE
gestion événements tactiles

### DIFF
--- a/src/situations/commun/composants/deplaceur_pieces.js
+++ b/src/situations/commun/composants/deplaceur_pieces.js
@@ -1,33 +1,34 @@
 export default class DeplaceurPieces {
-  constructor (situation) {
-    this.situation = situation;
-  }
-
   activeDeplacementPieces (pointInsertion, $) {
-    this.$pointInsertion = $(pointInsertion);
-    this.$pointInsertion.mousemove(e => {
+    const $pointInsertion = $(pointInsertion);
+
+    this._positionEvenement = (e) => {
+      return {
+        x: 100 * e.clientX / $pointInsertion.width(),
+        y: 100 * e.clientY / $pointInsertion.height()
+      };
+    };
+
+    $pointInsertion.mousemove(e => {
       if (e.buttons === 1) {
         this.deplacePiecesSelectionnees(e);
       } else {
-        this.deselectionneToutesLesPieces();
+        this.termineSelection();
       }
     });
   }
 
-  deplacePiecesSelectionnees (e) {
-    const piecesAffichees = this.situation.piecesAffichees();
-    piecesAffichees.forEach(p => {
-      p.deplaceSiSelectionnee({
-        x: 100 * e.clientX / this.$pointInsertion.width(),
-        y: 100 * e.clientY / this.$pointInsertion.height()
-      });
-    });
+  debuteSelection (piece, positionActuelle, e) {
+    this.pieceSelectionne = piece;
+    this.pieceSelectionne.changePosition(positionActuelle);
+    this.pieceSelectionne.selectionne(this._positionEvenement(e));
   }
 
-  deselectionneToutesLesPieces () {
-    const piecesAffichees = this.situation.piecesAffichees();
-    piecesAffichees.forEach(p => {
-      p.deselectionne();
-    });
+  deplacePiecesSelectionnees (e) {
+    this.pieceSelectionne.deplaceSiSelectionnee(this._positionEvenement(e));
+  }
+
+  termineSelection (piece) {
+    this.pieceSelectionne.deselectionne();
   }
 }

--- a/src/situations/commun/composants/deplaceur_pieces.js
+++ b/src/situations/commun/composants/deplaceur_pieces.js
@@ -10,11 +10,14 @@ export default class DeplaceurPieces {
     };
 
     $pointInsertion.mousemove(e => {
-      if (e.buttons === 1) {
-        this.deplacePiecesSelectionnees(e);
-      } else {
+      if (e.buttons === 0) {
         this.termineSelection();
+        return;
       }
+      this.deplacePiecesSelectionnees(e);
+    });
+    $pointInsertion.on('touchmove', (e) => {
+      this.deplacePiecesSelectionnees(e.changedTouches[0]);
     });
   }
 

--- a/src/situations/commun/modeles/piece.js
+++ b/src/situations/commun/modeles/piece.js
@@ -32,10 +32,10 @@ export default class Piece extends EventEmitter {
   }
 
   changePosition ({ x, y }) {
-    this.x = x;
-    this.y = y;
+    this.x = Math.min(100 - this._dimensions.largeur, Math.max(0, x));
+    this.y = Math.min(100 - this._dimensions.hauteur, Math.max(0, y));
 
-    this.emit(CHANGEMENT_POSITION, { x, y });
+    this.emit(CHANGEMENT_POSITION, { x: this.x, y: this.y });
   }
 
   estSelectionnee () {

--- a/src/situations/commun/vues/piece.js
+++ b/src/situations/commun/vues/piece.js
@@ -44,10 +44,6 @@ export default class VuePiece extends EventEmitter {
     this.$piece = creeElementPiece(this.depotRessources, this.piece, dimensionsElementParent);
     this.$elementParent.append(this.$piece);
 
-    this.piece.on(CHANGEMENT_POSITION, (nouvellePosition) => {
-      metsAJourPosition(this.$piece, nouvellePosition, dimensionsElementParent);
-    });
-
     this.$piece.mousedown(e => {
       this.$piece.stop(true);
       this.$piece.css('opacity', 1);
@@ -61,8 +57,13 @@ export default class VuePiece extends EventEmitter {
       });
     });
 
-    this.$piece.on('dragstart', function (event) { event.preventDefault(); });
     this.$piece.mouseup(e => { this.piece.deselectionne(); });
+
+    this.$piece.on('dragstart', function (event) { event.preventDefault(); });
+
+    this.piece.on(CHANGEMENT_POSITION, (nouvellePosition) => {
+      metsAJourPosition(this.$piece, nouvellePosition, dimensionsElementParent);
+    });
 
     this.piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
       this.$elementParent.append(this.$piece);

--- a/src/situations/commun/vues/piece.js
+++ b/src/situations/commun/vues/piece.js
@@ -9,10 +9,11 @@ export function animationFinale ($element, done) {
 }
 
 export default class VuePiece extends EventEmitter {
-  constructor (piece, depotRessources, animationDisparition = animationFinale) {
+  constructor (piece, depotRessources, deplaceur, animationDisparition = animationFinale) {
     super();
     this.piece = piece;
     this.depotRessources = depotRessources;
+    this.deplaceur = deplaceur;
     this.animationDisparition = animationDisparition;
   }
 
@@ -47,17 +48,17 @@ export default class VuePiece extends EventEmitter {
     this.$piece.mousedown(e => {
       this.$piece.stop(true);
       this.$piece.css('opacity', 1);
-      this.piece.changePosition({
+
+      const positionActuelle = {
         x: 100 * parseInt(this.$piece.css('left')) / this.$elementParent.width(),
         y: 100 * parseInt(this.$piece.css('top')) / this.$elementParent.height()
-      });
-      this.piece.selectionne({
-        x: 100 * e.clientX / this.$elementParent.width(),
-        y: 100 * e.clientY / this.$elementParent.height()
-      });
+      };
+      this.deplaceur.debuteSelection(this.piece, positionActuelle, e);
     });
 
-    this.$piece.mouseup(e => { this.piece.deselectionne(); });
+    this.$piece.mouseup((e) => {
+      this.deplaceur.termineSelection(this.piece);
+    });
 
     this.$piece.on('dragstart', function (event) { event.preventDefault(); });
 

--- a/src/situations/commun/vues/piece.js
+++ b/src/situations/commun/vues/piece.js
@@ -45,7 +45,7 @@ export default class VuePiece extends EventEmitter {
     this.$piece = creeElementPiece(this.depotRessources, this.piece, dimensionsElementParent);
     this.$elementParent.append(this.$piece);
 
-    this.$piece.mousedown(e => {
+    const debuteSelection = e => {
       this.$piece.stop(true);
       this.$piece.css('opacity', 1);
 
@@ -54,11 +54,18 @@ export default class VuePiece extends EventEmitter {
         y: 100 * parseInt(this.$piece.css('top')) / this.$elementParent.height()
       };
       this.deplaceur.debuteSelection(this.piece, positionActuelle, e);
+    };
+    this.$piece.on('touchstart', (e) => {
+      e.preventDefault();
+      debuteSelection(e.changedTouches[0]);
     });
+    this.$piece.mousedown(debuteSelection);
 
-    this.$piece.mouseup((e) => {
+    const termineSelection = (e) => {
       this.deplaceur.termineSelection(this.piece);
-    });
+    };
+    this.$piece.on('touchend', termineSelection);
+    this.$piece.mouseup(termineSelection);
 
     this.$piece.on('dragstart', function (event) { event.preventDefault(); });
 

--- a/src/situations/controle/vues/piece.js
+++ b/src/situations/controle/vues/piece.js
@@ -5,10 +5,8 @@ export function animationInitiale ($element) {
 }
 
 export default class VuePiece extends VuePieceCommune {
-  constructor (piece,
-    depotRessources,
-    callbackApresApparition = animationInitiale) {
-    super(piece, depotRessources);
+  constructor (piece, depotRessources, deplaceur, callbackApresApparition = animationInitiale) {
+    super(piece, depotRessources, deplaceur);
 
     this.callbackApresApparition = callbackApresApparition;
   }

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -17,11 +17,11 @@ export default class VueSituation {
     this.journal = journal;
     this.depotRessources = depotRessources;
     this.tapis = new VueTapis(situation, depotRessources);
-    this.deplaceurPieces = new DeplaceurPieces(situation);
+    this.deplaceurPieces = new DeplaceurPieces();
   }
 
   creeVuePiece (piece) {
-    return new VuePiece(piece, this.depotRessources);
+    return new VuePiece(piece, this.depotRessources, this.deplaceurPieces);
   }
 
   affiche (pointInsertion, $) {

--- a/src/situations/tri/vues/situation.js
+++ b/src/situations/tri/vues/situation.js
@@ -12,7 +12,7 @@ export default class VueSituationTri {
     this.depotRessources = depotRessources;
     this.chronometre = new VueChronometre(situation, depotRessources);
     this.situation = situation;
-    this.deplaceurPieces = new DeplaceurPieces(situation);
+    this.deplaceurPieces = new DeplaceurPieces();
     this.envoiEvenementsAuJournal(journal);
     this.ajoutEcouteursPourLesSons();
   }
@@ -27,7 +27,7 @@ export default class VueSituationTri {
     });
 
     this.situation.piecesAffichees().forEach((piece) => {
-      const vuePiece = new VuePiece(piece, this.depotRessources);
+      const vuePiece = new VuePiece(piece, this.depotRessources, this.deplaceurPieces);
       vuePiece.affiche(pointInsertion, $);
     });
 

--- a/tests/situations/commun/composants/deplaceur_pieces.js
+++ b/tests/situations/commun/composants/deplaceur_pieces.js
@@ -4,34 +4,48 @@ import Piece from 'commun/modeles/piece';
 import DeplaceurPieces from 'commun/composants/deplaceur_pieces';
 
 describe('Le composant DeplaceurPieces', function () {
+  let $pointInsertion;
+  let deplaceur;
+
   beforeEach(function () {
     $('body').append('<div id="point-insertion"></div>');
+    $pointInsertion = $('#point-insertion');
+    deplaceur = new DeplaceurPieces();
+    deplaceur.activeDeplacementPieces('#point-insertion', $);
   });
 
-  it('déplace les pièces sélectionnées', function () {
-    const piece = new Piece({ x: 90, y: 55 });
-    const deplaceur = new DeplaceurPieces();
-    const $pointInsertion = $('#point-insertion');
-    $pointInsertion.width(50).height(200);
+  describe('déplace les pièces selectionnées', function () {
+    let piece;
 
-    deplaceur.activeDeplacementPieces('#point-insertion', $);
-    deplaceur.debuteSelection(piece, { x: 90, y: 55 }, { clientX: 45, clientY: 110 });
+    beforeEach(function () {
+      $pointInsertion.width(50).height(200);
+      piece = new Piece({ x: 90, y: 55, largeur: 10, hauteur: 10 });
+      deplaceur.debuteSelection(piece, { x: 90, y: 55 }, { clientX: 45, clientY: 110 });
+    });
 
-    $pointInsertion.trigger($.Event('mousemove', { buttons: 1, clientX: 30, clientY: 20 }));
+    it('à la souris', function () {
+      $pointInsertion.trigger($.Event('mousemove', { buttons: 1, clientX: 30, clientY: 20 }));
 
-    expect(piece.position()).to.eql({ x: 60, y: 10 });
+      expect(piece.position()).to.eql({ x: 60, y: 10 });
+    });
+
+    it('avec un doigt', function () {
+      $pointInsertion.trigger($.Event('touchmove',
+        {
+          changedTouches: [{ clientX: 30, clientY: 20 }]
+        }));
+
+      expect(piece.position()).to.eql({ x: 60, y: 10 });
+    });
   });
 
   it('déselectionne les pièces si il y a un mousemove sans maintien du clic', function () {
     const piece = new Piece({});
-    const deplaceur = new DeplaceurPieces();
-    const $pointInsertion = $('#point-insertion');
 
-    deplaceur.activeDeplacementPieces('#point-insertion', $);
-    deplaceur.debuteSelection(piece, {}, { clientX: 95, clientY: 55 });
+    deplaceur.debuteSelection(piece, {}, {});
     expect(piece.estSelectionnee()).to.be(true);
 
-    $pointInsertion.trigger($.Event('mousemove', { buttons: 0, clientX: 30, clientY: 20 }));
+    $pointInsertion.trigger($.Event('mousemove', { buttons: 0 }));
 
     expect(piece.estSelectionnee()).to.be(false);
   });

--- a/tests/situations/commun/composants/deplaceur_pieces.js
+++ b/tests/situations/commun/composants/deplaceur_pieces.js
@@ -9,17 +9,13 @@ describe('Le composant DeplaceurPieces', function () {
   });
 
   it('déplace les pièces sélectionnées', function () {
-    const piece = new Piece({ x: 95, y: 55 });
-    const deplaceur = new DeplaceurPieces({
-      piecesAffichees () {
-        return [piece];
-      }
-    });
+    const piece = new Piece({ x: 90, y: 55 });
+    const deplaceur = new DeplaceurPieces();
     const $pointInsertion = $('#point-insertion');
-
-    piece.selectionne({ x: 95, y: 55 });
     $pointInsertion.width(50).height(200);
+
     deplaceur.activeDeplacementPieces('#point-insertion', $);
+    deplaceur.debuteSelection(piece, { x: 90, y: 55 }, { clientX: 45, clientY: 110 });
 
     $pointInsertion.trigger($.Event('mousemove', { buttons: 1, clientX: 30, clientY: 20 }));
 
@@ -28,15 +24,12 @@ describe('Le composant DeplaceurPieces', function () {
 
   it('déselectionne les pièces si il y a un mousemove sans maintien du clic', function () {
     const piece = new Piece({});
-    const deplaceur = new DeplaceurPieces({
-      piecesAffichees () {
-        return [piece];
-      }
-    });
+    const deplaceur = new DeplaceurPieces();
     const $pointInsertion = $('#point-insertion');
 
-    piece.selectionne({ x: 95, y: 55 });
     deplaceur.activeDeplacementPieces('#point-insertion', $);
+    deplaceur.debuteSelection(piece, {}, { clientX: 95, clientY: 55 });
+    expect(piece.estSelectionnee()).to.be(true);
 
     $pointInsertion.trigger($.Event('mousemove', { buttons: 0, clientX: 30, clientY: 20 }));
 

--- a/tests/situations/commun/modeles/piece.js
+++ b/tests/situations/commun/modeles/piece.js
@@ -15,21 +15,38 @@ describe("Le modèle commun d'une pièce", function () {
     expect(pieceDefectueuse.categorie()).to.be(false);
   });
 
-  it('peut changer de position', function () {
-    const piece = new Piece({ x: 90, y: 50 });
-
-    piece.changePosition({ x: 12, y: 34 });
-    expect(piece.position()).to.eql({ x: 12, y: 34 });
-  });
-
   it('a des dimensions', function () {
     const piece = new Piece({ largeur: 10, hauteur: 20 });
 
     expect(piece.dimensions()).to.eql({ largeur: 10, hauteur: 20 });
   });
 
+  it('peut changer de position', function () {
+    const piece = new Piece({ x: 90, y: 50, largeur: 1, hauteur: 1 });
+
+    piece.changePosition({ x: 12, y: 34 });
+    expect(piece.position()).to.eql({ x: 12, y: 34 });
+  });
+
+  describe('ne peut pas être positionnée en dehors de la scène', function () {
+    let piece;
+
+    beforeEach(function () {
+      piece = new Piece({ x: 50, y: 50, largeur: 10, hauteur: 11 });
+    });
+
+    it('ne peut pas sortir ni à gauche ni en haut', function () {
+      piece.changePosition({ x: -1, y: -1 });
+      expect(piece.position()).to.eql({ x: 0, y: 0 });
+    });
+    it('ne peut pas sortir ni à droite ni en bas', function () {
+      piece.changePosition({ x: 100, y: 100 });
+      expect(piece.position()).to.eql({ x: 90, y: 89 });
+    });
+  });
+
   it('notifie ses abonnés des changements de position', function (done) {
-    const piece = new Piece({ x: 90, y: 50 });
+    const piece = new Piece({ x: 90, y: 50, hauteur: 1, largeur: 1 });
     piece.on(CHANGEMENT_POSITION, ({ x, y }) => {
       expect(x).to.equal(35);
       expect(y).to.equal(20);
@@ -72,7 +89,7 @@ describe("Le modèle commun d'une pièce", function () {
   });
 
   it('peut être déplacée quand sélectionnée', function () {
-    const piece = new Piece({ x: 90, y: 50 });
+    const piece = new Piece({ x: 90, y: 50, largeur: 1, hauteur: 1 });
     piece.selectionne({ x: 95, y: 65 });
 
     piece.deplaceSiSelectionnee({ x: 30, y: 35 });
@@ -80,7 +97,7 @@ describe("Le modèle commun d'une pièce", function () {
   });
 
   it('ne peut pas être déplacée quand déselectionnée', function () {
-    const piece = new Piece({ x: 90, y: 50 });
+    const piece = new Piece({ x: 90, y: 50, largeur: 1, hauteur: 1 });
     expect(piece.estSelectionnee()).to.be(false);
 
     piece.deplaceSiSelectionnee({ x: 30, y: 35 });

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -1,10 +1,18 @@
 import $ from 'jquery';
 
+import DeplaceurPieces from 'commun/composants/deplaceur_pieces';
 import Piece, { DISPARITION_PIECE } from 'commun/modeles/piece';
 import VuePiece from 'commun/vues/piece';
 
+function activeDeplaceur (pointInsertion = '#pointInsertion') {
+  const deplaceur = new DeplaceurPieces();
+  deplaceur.activeDeplacementPieces(pointInsertion, $);
+  return deplaceur;
+}
+
 function creeVueMinimale (piece, depot) {
-  return new VuePiece(piece, depot);
+  const deplaceur = activeDeplaceur();
+  return new VuePiece(piece, depot, deplaceur);
 }
 
 describe('Une pièce', function () {
@@ -82,10 +90,12 @@ describe('Une pièce', function () {
 
   it('peut être désélectionnée', function () {
     const piece = new Piece({ x: 90, y: 40 });
-    piece.selectionne({ x: 95, y: 55 });
 
-    const vuePiece = creeVueMinimale(piece, depot);
+    const deplaceur = activeDeplaceur();
+    const vuePiece = new VuePiece(piece, depot, deplaceur);
     vuePiece.affiche('#pointInsertion', $);
+
+    deplaceur.debuteSelection(piece, { x: 90, y: 40 }, { clientX: 95, clientY: 55 });
 
     expect(piece.estSelectionnee()).to.be(true);
     $('.piece').trigger($.Event('mouseup'));
@@ -129,7 +139,8 @@ describe('Une pièce', function () {
       done();
     };
 
-    const vuePiece = new VuePiece(piece, depot, callbackAvantSuppression);
+    const deplaceur = activeDeplaceur();
+    const vuePiece = new VuePiece(piece, depot, deplaceur, callbackAvantSuppression);
     vuePiece.affiche('#pointInsertion', $);
     expect($('.desactiver').length).to.equal(0);
     piece.emit(DISPARITION_PIECE);

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -78,28 +78,54 @@ describe('Une pièce', function () {
     expect($('.piece').css('top')).to.eql('5px');
   });
 
-  it('peut être sélectionnée', function () {
-    const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = creeVueMinimale(piece, depot);
-    vuePiece.affiche('#pointInsertion', $);
+  describe('peut être sélectionnée', function () {
+    let piece;
 
-    expect(piece.estSelectionnee()).to.be(false);
-    $('.piece').trigger($.Event('mousedown', { clientX: 95, clientY: 55 }));
-    expect(piece.estSelectionnee()).to.be(true);
+    beforeEach(function () {
+      piece = new Piece({ x: 90, y: 40 });
+      const vuePiece = creeVueMinimale(piece, depot);
+      vuePiece.affiche('#pointInsertion', $);
+    });
+
+    it('à la souris', function () {
+      expect(piece.estSelectionnee()).to.be(false);
+      $('.piece').trigger($.Event('mousedown', { clientX: 95, clientY: 55 }));
+      expect(piece.estSelectionnee()).to.be(true);
+    });
+
+    it('au doight', function () {
+      expect(piece.estSelectionnee()).to.be(false);
+      $('.piece').trigger($.Event('touchstart', {
+        changedTouches: [{ clientX: 95, clientY: 55 }]
+      }));
+      expect(piece.estSelectionnee()).to.be(true);
+    });
   });
 
-  it('peut être désélectionnée', function () {
-    const piece = new Piece({ x: 90, y: 40 });
+  describe('peut être désélectionnée', function () {
+    let piece;
 
-    const deplaceur = activeDeplaceur();
-    const vuePiece = new VuePiece(piece, depot, deplaceur);
-    vuePiece.affiche('#pointInsertion', $);
+    beforeEach(function () {
+      piece = new Piece({ x: 90, y: 40 });
 
-    deplaceur.debuteSelection(piece, { x: 90, y: 40 }, { clientX: 95, clientY: 55 });
+      const deplaceur = activeDeplaceur();
+      const vuePiece = new VuePiece(piece, depot, deplaceur);
+      vuePiece.affiche('#pointInsertion', $);
 
-    expect(piece.estSelectionnee()).to.be(true);
-    $('.piece').trigger($.Event('mouseup'));
-    expect(piece.estSelectionnee()).to.be(false);
+      deplaceur.debuteSelection(piece, { x: 90, y: 40 }, { clientX: 95, clientY: 55 });
+    });
+
+    it('à la souris', function () {
+      expect(piece.estSelectionnee()).to.be(true);
+      $('.piece').trigger($.Event('mouseup'));
+      expect(piece.estSelectionnee()).to.be(false);
+    });
+
+    it('au doight', function () {
+      expect(piece.estSelectionnee()).to.be(true);
+      $('.piece').trigger($.Event('touchend'));
+      expect(piece.estSelectionnee()).to.be(false);
+    });
   });
 
   it("rajoute la classe selectionne lorsqu'elle est sélectionné", function () {

--- a/tests/situations/commun/vues/piece.js
+++ b/tests/situations/commun/vues/piece.js
@@ -63,7 +63,7 @@ describe('Une pièce', function () {
   });
 
   it('peut être bougée', function () {
-    const piece = new Piece({ x: 90, y: 40 });
+    const piece = new Piece({ x: 90, y: 40, largeur: 1, hauteur: 1 });
     const vuePiece = creeVueMinimale(piece, depot);
 
     $('#pointInsertion').width(100).height(100);

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -4,7 +4,7 @@ import DeplaceurPieces from 'commun/composants/deplaceur_pieces';
 import Piece from 'commun/modeles/piece';
 import VuePiece from 'controle/vues/piece';
 
-describe('Une pièce', function () {
+describe('Une pièce du Contrôle', function () {
   let deplaceur;
   let depot;
 
@@ -26,7 +26,7 @@ describe('Une pièce', function () {
   });
 
   it("interrompt la séquence d'animation quand sélection de la pièce", function (done) {
-    const piece = new Piece({ x: 90, y: 40 });
+    const piece = new Piece({ x: 90, y: 40, largeur: 1, hauteur: 1 });
     const sequenceAnimation = function ($element) {
       $element.animate({ left: '80px' }, 0).delay(5).animate({ left: '10px' }, 0);
     };

--- a/tests/situations/controle/vues/piece.js
+++ b/tests/situations/controle/vues/piece.js
@@ -1,19 +1,23 @@
 import $ from 'jquery';
 
+import DeplaceurPieces from 'commun/composants/deplaceur_pieces';
 import Piece from 'commun/modeles/piece';
 import VuePiece from 'controle/vues/piece';
 
 describe('Une pièce', function () {
+  let deplaceur;
   let depot;
 
   beforeEach(function () {
     $('body').append('<div id="controle" style="width: 100px; height: 100px"></div>');
+    deplaceur = new DeplaceurPieces();
+    deplaceur.activeDeplacementPieces('#controle', $);
     depot = { piece () { } };
   });
 
   it("suit une séquence d'animation pour apparaître", function (done) {
     const piece = new Piece({ x: 90, y: 40 });
-    const vuePiece = new VuePiece(piece, depot, function ($element) {
+    const vuePiece = new VuePiece(piece, depot, deplaceur, function ($element) {
       expect($element.hasClass('.piece'));
       done();
     });
@@ -26,7 +30,7 @@ describe('Une pièce', function () {
     const sequenceAnimation = function ($element) {
       $element.animate({ left: '80px' }, 0).delay(5).animate({ left: '10px' }, 0);
     };
-    const vuePiece = new VuePiece(piece, depot, sequenceAnimation);
+    const vuePiece = new VuePiece(piece, depot, deplaceur, sequenceAnimation);
 
     vuePiece.affiche('#controle', $);
 


### PR DESCRIPTION
fix #206 

Ajoute la gestion des événements tactils pour que l'on puisse jouer sur tablette.

Il reste malgré tout d'autres adaptations à faire. 
- Les consignes audios parlent de cliquer
- à valider que l'écran s'affiche correctement en mode paysage.

Cette PR ne prend pas en charge le multi-touch. Il n'est possible de déplacer qu'une seule pièce à la fois. 