### PR TITLE
Initialise la progression de l'évalué au moment de la connexion

### DIFF
--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -16,6 +16,7 @@ export function creeStore (registreUtilisateur, fetch = window.fetch) {
       connecte (state, nom) {
         state.estConnecte = true;
         state.nom = nom;
+        state.situationsFaites = [];
       },
 
       deconnecte (state) {

--- a/src/situations/commun/infra/registre_utilisateur.js
+++ b/src/situations/commun/infra/registre_utilisateur.js
@@ -24,6 +24,7 @@ export default class RegistreUtilisateur extends EventEmitter {
       });
     }).then((data) => {
       window.localStorage.setItem(CLEF_IDENTIFIANT, JSON.stringify(data));
+      window.localStorage.removeItem(CLEF_SITUATIONS_FAITES);
       this.emit(CHANGEMENT_CONNEXION);
     });
   }

--- a/tests/situations/accueil/modeles/store.js
+++ b/tests/situations/accueil/modeles/store.js
@@ -43,6 +43,14 @@ describe("Le store de l'accueil", function () {
     expect(store.state.situations.length).to.eql(0);
   });
 
+  it('initialise à la connexion', function () {
+    registreUtilisateur.situationsFaites = () => [1];
+    const store = creeStore(registreUtilisateur);
+    store.commit('connecte', 'nom évalué');
+    expect(store.state.nom).to.equal('nom évalué');
+    expect(store.state.situationsFaites.length).to.eql(0);
+  });
+
   it('mets à jour les situations accessible', function () {
     const store = creeStore(registreUtilisateur);
     store.commit('metsAJourSituations', [1, 2]);

--- a/tests/situations/commun/infra/registre_utilisateur.js
+++ b/tests/situations/commun/infra/registre_utilisateur.js
@@ -21,6 +21,14 @@ describe('le registre utilisateur', function () {
     });
   });
 
+  it("ré-initialise la progression au moment de l'inscription", function () {
+    const registre = unRegistre(1, 'autre test');
+    registre.enregistreSituationFaite('tri');
+    return registre.inscris('test').then(() => {
+      expect(registre.situationsFaites()).to.eql([]);
+    });
+  });
+
   it("émet un événement lorsque le nom de l'utilisateur change", function (done) {
     const registre = unRegistre(1, 'test');
     registre.on(CHANGEMENT_CONNEXION, done);


### PR DESCRIPTION
De manière à s'assurer que la progression qui se trouve dans le localstorage est
bien vide au moment de commencer.

Fix #465 