### PR TITLE
Revoit l'affichage du nom de l'évalué·e.

### DIFF
--- a/src/situations/accueil/styles/accueil.scss
+++ b/src/situations/accueil/styles/accueil.scss
@@ -9,7 +9,7 @@
 
   .titre {
     display: flex;
-    align-items: baseline;
+    align-items: center;
 
     h1 {
       flex-grow: 1;

--- a/src/situations/commun/styles/boite_utilisateur.scss
+++ b/src/situations/commun/styles/boite_utilisateur.scss
@@ -1,18 +1,29 @@
 @import 'commun/styles/couleurs.scss';
 
-
 .boite-utilisateur {
-  border: 1px solid $couleur-bordure-input-accueil;
-  border-radius: 1rem;
+  border: 1px solid $bleu-clair;
+  border-radius: 3rem;
   color: $couleur-texte;
-  padding: 1.375rem 1rem;
   font-size: 1.125rem;
-  display: flex;
+  overflow: hidden;
+  position: relative;
+
+  .progression {
+    position: absolute;
+    background-color: $bleu-clair;
+    height: 100%;
+    z-index: -1;
+  }
+
+  .contenu {
+    padding: 1rem;
+    display: flex;
+  }
 
   .progression-utilisateur {
     margin-left: 1rem;
   }
-  
+
   .deconnexion {
     margin-left: 1rem;
     color: $couleur-texte;

--- a/src/situations/commun/vues/boite_utilisateur.vue
+++ b/src/situations/commun/vues/boite_utilisateur.vue
@@ -1,11 +1,19 @@
 <template>
-  <div v-if="estConnecte"
-       class="boite-utilisateur">
-    <div>{{ nom }}</div>
-    <div class="progression-utilisateur">{{ situationsFaites.length }}/{{ situations.length }}</div>
-    <a class="deconnexion" href="#" @click.prevent="deconnecte">
-      <i class="fas fa-sign-out-alt"></i>
-    </a>
+  <div
+    v-if="estConnecte"
+    class="boite-utilisateur"
+  >
+    <div
+      :style="{ width: pourcentProgression }"
+      class="progression"
+    />
+    <div class="contenu">
+      <div>{{ nom }}</div>
+      <div class="progression-utilisateur">{{ situationsFaites.length }}/{{ situations.length }}</div>
+      <a class="deconnexion" href="#" @click.prevent="deconnecte">
+        <i class="fas fa-sign-out-alt"></i>
+      </a>
+    </div>
   </div>
 </template>
 
@@ -16,7 +24,11 @@ import 'commun/styles/font_awesome.scss';
 
 export default {
   computed: {
-    ...mapState(['estConnecte', 'nom', 'situations', 'situationsFaites'])
+    ...mapState(['estConnecte', 'nom', 'situations', 'situationsFaites']),
+
+    pourcentProgression () {
+      return `${this.situationsFaites.length * 100 / this.situations.length}%`;
+    }
   },
   methods: {
     ...mapActions(['deconnecte']),

--- a/tests/situations/commun/vues/boite_utilisateur.js
+++ b/tests/situations/commun/vues/boite_utilisateur.js
@@ -34,4 +34,8 @@ describe('La boite utilisateur', function () {
   it("affiche la progression de l'évalué·e", function () {
     expect(wrapper.find('.progression-utilisateur').text()).to.equal('1/2');
   });
+
+  it('renvoit la progression en pourcentage', function () {
+    expect(wrapper.vm.pourcentProgression).to.equal('50%');
+  });
 });


### PR DESCRIPTION
![Screenshot_2019-09-18 Compétences pro](https://user-images.githubusercontent.com/86659/65147505-8c589380-da1e-11e9-930f-0f8e818e53b8.png)

Fix #372 