### PR TITLE
Tablette/amelioration affichage

### DIFF
--- a/src/situations/commun/styles/barre_dev.scss
+++ b/src/situations/commun/styles/barre_dev.scss
@@ -2,6 +2,8 @@
 @import './mixins/boutons.scss';
 
 .barre-dev {
+  position: fixed;
+  bottom: 0;
   border-top: 1px solid black;
   background-color: gray;
   width: 100vw;

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -3,21 +3,29 @@
 @import url('https://fonts.googleapis.com/css?family=Quicksand:400,500,700|Work+Sans:400,700&display=swap&subset=latin-ext');
 
 html, body {
-  height: 100%;
   margin: 0;
 }
 
 body {
+  min-height: 100vh;
+  font-family: 'Work Sans', sans-serif;
+  font-size: 16px;
+  display: flex;
+  position: relative;
+  background-color: $couleur-fond;
+}
+
+body:after {
+  content: "";
+  z-index: -1;
   background: url('../assets/fond-footer.svg') center;
   background-size: cover;
   background-position: bottom;
   background-repeat: repeat;
-  display: flex;
-  font-family: 'Work Sans', sans-serif;
-  font-size: 16px;
-  min-height: 100%;
-  align-items: center;
-  flex-direction: column;
+  width: 100%;
+  height: 400px;
+  position: absolute;
+  bottom: 0;
 }
 
 * {


### PR DESCRIPTION
contribue à #464

- Ajuster la largeur (meta layout) pour que la hauteur soit suffisante n'est plus nécessaire.
- corriger le problème de clignotement du fond (les vagues en arrière plan, derrière la scène) quand le clavier est actif.
- pour la question littéraire : quand le clavier est ouvert en mode paysage on ne vois plus l'image en entier MAIS maintenant on peut scroller.
- de même sur le formulaire de saisie de l'inventaire, on peut scroller.