### PR TITLE
Ajoute un flex-shrink pour Safari

### DIFF
--- a/src/situations/accueil/styles/accueil.scss
+++ b/src/situations/accueil/styles/accueil.scss
@@ -5,6 +5,7 @@
 #accueil {
   display: flex;
   flex-direction: column;
+  flex-shrink: 0;
   @include conteneur;
 
   .titre {


### PR DESCRIPTION
Sur safari, l'accueil se réduit si la fenetre d'affichage est trop petite. Avec
cette correction la fenêtre ne se réduit plus et il faut scroller pour tout voir.
De cette façon, l'application se comporte de la même manière avec Safari
qu'avec Firefox et Chrome.