### PR TITLE
Sécurité: Met en évidence les zones de dangers déjà trouvées.

### DIFF
--- a/src/situations/securite/styles/situation.scss
+++ b/src/situations/securite/styles/situation.scss
@@ -7,7 +7,7 @@
 .zone {
   fill: transparent;
 
-  &-selectionnee {
+  &-selectionnee, &-qualifiee {
     stroke: $couleur-accent-et-erreur;
     stroke-width: 6px;
   }

--- a/src/situations/securite/vues/situation.vue
+++ b/src/situations/securite/vues/situation.vue
@@ -9,7 +9,8 @@
         :cx="`${zone.x}%`"
         :cy="`${zone.y}%`"
         :r="`${zone.r}%`"
-        :class="{ 'zone-selectionnee': zone === zoneSelectionnee }"
+        :class="{ 'zone-selectionnee': zone === zoneSelectionnee,
+                  'zone-qualifiee': dangersQualifies.includes(zone.danger) }"
         class="zone"
         @click="selectionneZone(zone)"
       />

--- a/tests/situations/securite/vues/situation.js
+++ b/tests/situations/securite/vues/situation.js
@@ -37,6 +37,12 @@ describe('La vue de la situation Sécurité', function () {
     expect(wrapper.findAll('.zone-selectionnee').length).to.eql(1);
   });
 
+  it('une fois le danger qualifié, rajoute une classe sur la zone', function () {
+    store.commit('chargeZonesEtDangers', { zones: [{ x: 4, y: 5, r: 6, danger: 'test' }], dangers: { test: {} } });
+    store.commit('ajouteDangerQualifie', 'test');
+    expect(wrapper.findAll('.zone-qualifiee').length).to.eql(1);
+  });
+
   it('passe la situation en FINI lorsque tout les dangers ont été identifiés', function () {
     store.commit('chargeZonesEtDangers', {
       zones: [{ x: 1, y: 2, r: 3, danger: 'danger1' }, { x: 4, y: 5, r: 6, danger: 'danger2' }],


### PR DESCRIPTION
Une fois qualifiées, les zones de danger restent "active".  J'ai gardé le même style que la sélection en attendant que le design s'affine.

![Screenshot_2019-10-07 Sécurité(2)](https://user-images.githubusercontent.com/86659/66299215-60c91a80-e8f3-11e9-8894-1ce8391b13a1.png)

