### PR TITLE
Supprime le `tap-highlight` de l'inventaire à la fermeture d'un contenant

### DIFF
--- a/src/situations/inventaire/styles/contenu.scss
+++ b/src/situations/inventaire/styles/contenu.scss
@@ -24,5 +24,7 @@
     height: 100%;
     z-index: 99;
     cursor: pointer;
+
+    -webkit-tap-highlight-color: transparent;
   }
 }


### PR DESCRIPTION
contribue à #464 