### PR TITLE
Sécurité: Déselectionne la zone une fois l'identification ou la qualification terminée

### DIFF
--- a/src/situations/securite/vues/fenetre_zone.vue
+++ b/src/situations/securite/vues/fenetre_zone.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    v-if="etat != 'termine'"
     :style="{ bottom: bottom, left: left, right: right }"
     class="fenetre-zone">
 
@@ -80,12 +79,16 @@ export default {
       if (this.zone.danger) {
         this.etat = 'qualification';
       } else {
-        this.etat = 'termine';
+        this.ferme();
       }
     },
     qualifie (choix) {
       this.$store.commit('ajouteDangerQualifie', { nom: this.zone.danger, choix });
-      this.etat = 'termine';
+      this.ferme();
+    },
+
+    ferme () {
+      this.$emit('ferme');
     }
   }
 }

--- a/src/situations/securite/vues/formulaire_radio.vue
+++ b/src/situations/securite/vues/formulaire_radio.vue
@@ -1,5 +1,5 @@
 <template>
-  <form @submit="submit">
+  <form @submit.prevent="submit">
     <h3>{{ question.titre }}</h3>
     <div
       v-for="option in question.options"

--- a/src/situations/securite/vues/situation.vue
+++ b/src/situations/securite/vues/situation.vue
@@ -20,6 +20,7 @@
       v-if="zoneSelectionnee"
       :key="`${zoneSelectionnee.x}${zoneSelectionnee.y}`"
       :zone="zoneSelectionnee"
+      @ferme="deselectionneZone"
      />
   </div>
 </template>
@@ -59,6 +60,9 @@ export default {
   methods: {
     selectionneZone (zone) {
       this.zoneSelectionnee = zone;
+    },
+    deselectionneZone () {
+      this.zoneSelectionnee = null;
     }
   }
 }

--- a/tests/situations/securite/vues/fenetre_zone.js
+++ b/tests/situations/securite/vues/fenetre_zone.js
@@ -64,7 +64,7 @@ describe('Le composant FenetreZone', function () {
       wrapper.vm.question.submit();
       expect(wrapper.vm.etat).to.equal('qualification');
       wrapper.vm.question.submit();
-      expect(wrapper.vm.etat).to.equal('termine');
+      expect(wrapper.emitted('ferme').length).to.equal(1);
     });
 
     it('mets à jour le store pour stocker le danger qualifié', function (done) {
@@ -97,13 +97,7 @@ describe('Le composant FenetreZone', function () {
     it("ne propose que l'étape d'identification", function () {
       expect(wrapper.vm.etat).to.equal('identification');
       wrapper.vm.question.submit();
-      expect(wrapper.vm.etat).to.equal('termine');
+      expect(wrapper.emitted('ferme').length).to.equal(1);
     });
-  });
-
-  it('ne rend plus rien une fois terminé', function () {
-    expect(wrapper.isEmpty()).to.be(false);
-    wrapper.vm.etat = 'termine';
-    expect(wrapper.isEmpty()).to.be(true);
   });
 });

--- a/tests/situations/securite/vues/situation.js
+++ b/tests/situations/securite/vues/situation.js
@@ -51,6 +51,14 @@ describe('La vue de la situation Sécurité', function () {
     expect(wrapper.vm.nombreDangersAQualifies).to.equal(2);
   });
 
+  it('déselectionne la zone courante', function () {
+    store.commit('chargeZonesEtDangers', { zones: [{ x: 1, y: 2, r: 3 }, { x: 4, y: 5, r: 6 }], dangers: {} });
+    wrapper.find('.zone').trigger('click');
+    expect(wrapper.findAll('.zone-selectionnee').length).to.eql(1);
+    wrapper.vm.deselectionneZone();
+    expect(wrapper.findAll('.zone-selectionnee').length).to.eql(0);
+  });
+
   it('passe la situation en FINI lorsque tout les dangers ont été identifiés', function () {
     store.commit('chargeZonesEtDangers', {
       zones: [{ x: 1, y: 2, r: 3, danger: 'danger1' }, { x: 4, y: 5, r: 6, danger: 'danger2' }],


### PR DESCRIPTION
Cela permet de recliquer sur une zone juste après l'avoir qualifié. Actuellement c'est impossible.