### PR TITLE
Configure eslint pour passer sur les fichiers vue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/config.sh
 node_modules/
 tests_build/
 .DS_Store
+.eslintcache

--- a/package-lock.json
+++ b/package-lock.json
@@ -3516,12 +3516,6 @@
         "ms": "^2.1.1"
       }
     },
-    "debug-log": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
-      "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-      "dev": true
-    },
     "decache": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
@@ -3643,28 +3637,6 @@
             "is-data-descriptor": "^1.0.0",
             "kind-of": "^6.0.2"
           }
-        }
-      }
-    },
-    "deglob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/deglob/-/deglob-4.0.1.tgz",
-      "integrity": "sha512-/g+RDZ7yf2HvoW+E5Cy+K94YhgcFgr6C8LuHZD1O5HoNPkf3KY6RfXJ0DBGlB/NkLi5gml+G9zqRzk9S0mHZCg==",
-      "dev": true,
-      "requires": {
-        "find-root": "^1.0.0",
-        "glob": "^7.0.5",
-        "ignore": "^5.0.0",
-        "pkg-config": "^1.1.0",
-        "run-parallel": "^1.1.2",
-        "uniq": "^1.0.1"
-      },
-      "dependencies": {
-        "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
-          "dev": true
         }
       }
     },
@@ -4089,9 +4061,9 @@
       }
     },
     "eslint": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.4.0.tgz",
-      "integrity": "sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.5.1.tgz",
+      "integrity": "sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -4184,12 +4156,6 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.0.tgz",
       "integrity": "sha512-EF6XkrrGVbvv8hL/kYa/m6vnvmUT+K82pJJc4JJVMM6+Qgqh0pnwprSxdduDLB9p/7bIxD+YV5O0wfb8lmcPbA==",
-      "dev": true
-    },
-    "eslint-config-standard-jsx": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-8.1.0.tgz",
-      "integrity": "sha512-ULVC8qH8qCqbU792ZOO6DaiaZyHNS/5CZt3hKqHkEhVlhPEPN3nfBqqxJCyp59XrjIBZPu1chMYe9T2DXZ7TMw==",
       "dev": true
     },
     "eslint-import-resolver-node": {
@@ -4407,39 +4373,20 @@
       "integrity": "sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==",
       "dev": true
     },
-    "eslint-plugin-react": {
-      "version": "7.14.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.14.3.tgz",
-      "integrity": "sha512-EzdyyBWC4Uz2hPYBiEJrKCUi2Fn+BJ9B/pJQcjw5X+x/H2Nm59S4MJIvL4O5NEE0+WbnQwEBxWY03oUk+Bc3FA==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.1.0",
-        "object.entries": "^1.1.0",
-        "object.fromentries": "^2.0.0",
-        "object.values": "^1.1.0",
-        "prop-types": "^15.7.2",
-        "resolve": "^1.10.1"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
-      }
-    },
     "eslint-plugin-standard": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz",
       "integrity": "sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==",
       "dev": true
+    },
+    "eslint-plugin-vue": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-5.2.3.tgz",
+      "integrity": "sha512-mGwMqbbJf0+VvpGR5Lllq0PMxvTdrZ/ZPjmhkacrCHbubJeJOt+T6E3HUzAifa2Mxi7RSdJfC9HFpOeSYVMMIw==",
+      "dev": true,
+      "requires": {
+        "vue-eslint-parser": "^5.0.0"
+      }
     },
     "eslint-scope": {
       "version": "5.0.0",
@@ -6700,16 +6647,6 @@
         "verror": "1.10.0"
       }
     },
-    "jsx-ast-utils": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.2.1.tgz",
-      "integrity": "sha512-v3FxCcAf20DayI+uxnCuw795+oOIkVu6EnJ1+kSzhqqTZHNkTZ7B66ZgLp4oLJ/gbA64cI0B7WRoHZMSRdyVRQ==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3",
-        "object.assign": "^4.1.0"
-      }
-    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -8076,30 +8013,6 @@
         "object-keys": "^1.0.11"
       }
     },
-    "object.entries": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.0.tgz",
-      "integrity": "sha512-l+H6EQ8qzGRxbkHOd5I/aHRhHDKoQXQ8g0BYt4uSweQU1/J6dZUOyWh9a2Vky35YCKjzmgxOzta2hH6kf9HuXA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3"
-      }
-    },
-    "object.fromentries": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1"
-      }
-    },
     "object.getownpropertydescriptors": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
@@ -8596,113 +8509,6 @@
         "pngjs": "^3.0.0"
       }
     },
-    "pkg-conf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "graceful-fs": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-          "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-          "dev": true
-        },
-        "load-json-file": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-          "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.15",
-            "parse-json": "^4.0.0",
-            "pify": "^4.0.1",
-            "strip-bom": "^3.0.0",
-            "type-fest": "^0.3.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        }
-      }
-    },
-    "pkg-config": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pkg-config/-/pkg-config-1.1.1.tgz",
-      "integrity": "sha1-VX7yLXPaPIg3EHdmxS6tq94pj+Q=",
-      "dev": true,
-      "requires": {
-        "debug-log": "^1.0.0",
-        "find-root": "^1.0.0",
-        "xtend": "^4.0.1"
-      }
-    },
     "pkg-dir": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
@@ -9000,17 +8806,6 @@
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM=",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "proxy-addr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
@@ -9190,12 +8985,6 @@
           "dev": true
         }
       }
-    },
-    "react-is": {
-      "version": "16.9.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
-      "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==",
-      "dev": true
     },
     "read-chunk": {
       "version": "1.0.1",
@@ -9729,12 +9518,6 @@
         "is-promise": "^2.1.0"
       }
     },
-    "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-      "dev": true
-    },
     "run-queue": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -10041,24 +9824,6 @@
       "dev": true,
       "requires": {
         "node-forge": "0.8.2"
-      }
-    },
-    "semistandard": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/semistandard/-/semistandard-14.2.0.tgz",
-      "integrity": "sha512-mQ0heTpbW7WWBXKOIqitlfEcAZhgGTwaHr1zzv70PnZZc53J+4u31+vLUEsh2oKVWfVgcjrykT2hz02B1Cfaaw==",
-      "dev": true,
-      "requires": {
-        "eslint": "~6.4.0",
-        "eslint-config-semistandard": "15.0.0",
-        "eslint-config-standard": "14.1.0",
-        "eslint-config-standard-jsx": "8.1.0",
-        "eslint-plugin-import": "~2.18.0",
-        "eslint-plugin-node": "~10.0.0",
-        "eslint-plugin-promise": "~4.2.1",
-        "eslint-plugin-react": "~7.14.2",
-        "eslint-plugin-standard": "~4.0.0",
-        "standard-engine": "^12.0.0"
       }
     },
     "semver": {
@@ -10701,32 +10466,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
       "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ="
-    },
-    "standard-engine": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-12.0.0.tgz",
-      "integrity": "sha512-gJIIRb0LpL7AHyGbN9+hJ4UJns37lxmNTnMGRLC8CFrzQ+oB/K60IQjKNgPBCB2VP60Ypm6f8DFXvhVWdBOO+g==",
-      "dev": true,
-      "requires": {
-        "deglob": "^4.0.0",
-        "get-stdin": "^7.0.0",
-        "minimist": "^1.1.0",
-        "pkg-conf": "^3.1.0"
-      },
-      "dependencies": {
-        "get-stdin": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz",
-          "integrity": "sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -11560,12 +11299,6 @@
         "prelude-ls": "~1.1.2"
       }
     },
-    "type-fest": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-      "dev": true
-    },
     "type-is": {
       "version": "1.6.18",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
@@ -11911,6 +11644,49 @@
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
       "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
+    },
+    "vue-eslint-parser": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-5.0.0.tgz",
+      "integrity": "sha512-JlHVZwBBTNVvzmifwjpZYn0oPWH2SgWv5dojlZBsrhablDu95VFD+hriB1rQGwbD+bms6g+rAFhQHk6+NyiS6g==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "eslint-scope": "^4.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^4.1.0",
+        "esquery": "^1.0.1",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
+          "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+          "dev": true
+        },
+        "eslint-scope": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+          "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "espree": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/espree/-/espree-4.1.0.tgz",
+          "integrity": "sha512-I5BycZW6FCVIub93TeVY1s7vjhP9CY6cXCznIRfiig7nRviKZYdRnj/sHEWC6A7WE9RDWOFq9+7OsWSYz8qv2w==",
+          "dev": true,
+          "requires": {
+            "acorn": "^6.0.2",
+            "acorn-jsx": "^5.0.0",
+            "eslint-visitor-keys": "^1.0.0"
+          }
+        }
+      }
     },
     "vue-hot-reload-api": {
       "version": "2.3.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "webpack --mode production",
     "dev": "env $(cat .env | xargs) webpack-dev-server --history-api-fallback --inline --progress --mode development",
     "test": "./bin/test.sh",
-    "lint": "semistandard"
+    "lint": "eslint --cache --ext .js,.vue src tests"
   },
   "engines": {
     "node": "10.11.x",
@@ -31,6 +31,14 @@
     "babel-loader": "^8.0.6",
     "clean-webpack-plugin": "^3.0.0",
     "css-loader": "^3.2.0",
+    "eslint": "^6.5.1",
+    "eslint-config-semistandard": "^15.0.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "eslint-plugin-vue": "^5.2.3",
     "expect.js": "^0.3.1",
     "favicons-webpack-plugin": "^1.0.2",
     "file-loader": "^4.2.0",
@@ -43,7 +51,6 @@
     "null-loader": "^3.0",
     "sass": "^1.22.12",
     "sass-loader": "^8.0.0",
-    "semistandard": "^14.2.0",
     "style-loader": "^1.0.0",
     "vue-loader": "^15.7.1",
     "vue-template-compiler": "^2.6.10",
@@ -61,23 +68,18 @@
     "vue": "^2.6.10",
     "vuex": "^3.1.1"
   },
-  "semistandard": {
-    "globals": [
-      "$",
-      "after",
-      "afterEach",
-      "before",
-      "beforeEach",
-      "describe",
-      "expect",
-      "it",
-      "jQuery",
-      "xit"
+  "eslintConfig": {
+    "plugins": ["vue"],
+    "extends": [
+      "semistandard",
+      "plugin:vue/essential"
     ],
-    "ignore": [
-      "public/",
-      "test_build/",
-      "dist/"
-    ]
+    "env": {
+      "browser": true,
+      "mocha": true
+    },
+    "globals": {
+      "expect": "readonly"
+    }
   }
 }

--- a/src/situations/accueil/vues/acces_situation.vue
+++ b/src/situations/accueil/vues/acces_situation.vue
@@ -31,10 +31,10 @@ export default {
     }
   },
 
-  data() {
+  data () {
     return {
       backgroundImage: `url('${this.depotRessources.batimentSituation(this.situation.identifiant).src}')`
     };
   }
-}
+};
 </script>

--- a/src/situations/accueil/vues/accueil.vue
+++ b/src/situations/accueil/vues/accueil.vue
@@ -107,7 +107,7 @@ export const CLE_ETAT_ACCUEIL = 'etatAccueil';
 export default {
   components: { FormulaireIdentification, AccesSituation, BoiteUtilisateur, OverlayIntro, Fin, TransitionFade },
 
-  data() {
+  data () {
     const parsedUrl = new URL(window.location.href);
     const { indexPrecedent } = this.recupereEtatDuPrecedentChargement();
     return {
@@ -160,7 +160,7 @@ export default {
           nom: traduction('accueil.conclure'),
           action: this.afficheEcranFin
         }
-      ]
+      ];
     },
 
     niveauMax () {
@@ -236,5 +236,5 @@ export default {
       this.ecranFinAfficher = true;
     }
   }
-}
+};
 </script>

--- a/src/situations/accueil/vues/fin.vue
+++ b/src/situations/accueil/vues/fin.vue
@@ -1,15 +1,26 @@
 <template>
-  <div class="overlay modale"
-       :class="{ attendre: ! competencesFortesRecus }">
-    <div v-if="competencesFortesRecus" class= "modale-interieur">
+  <div
+    :class="{ attendre: ! competencesFortesRecus }"
+    class="overlay modale"
+  >
+    <div
+      v-if="competencesFortesRecus"
+      class="modale-interieur"
+    >
       <h2>{{ traduction('accueil.fin.titre') }}</h2>
-      <p class="message-fin">{{ traduction('accueil.fin.message') }}
-        <span v-if="this.competencesFortes.length != 0" class="message-competences-fortes">{{ traduction('accueil.fin.competences') }}</span>
+      <p class="message-fin">
+        {{ traduction('accueil.fin.message') }}
+        <span
+          v-if="this.competencesFortes.length != 0"
+          class="message-competences-fortes"
+        >{{ traduction('accueil.fin.competences') }}</span>
       </p>
-      <p class="competences" v-for="(competence, index) in competencesFortes">
-        <img
-          :src="affichePicto(competence)"
-        />
+      <p
+        v-for="competence in competencesFortes"
+        :key="competence"
+        class="competences"
+      >
+        <img :src="affichePicto(competence)" />
         {{ traduction(`accueil.fin.${competence}`) }}
       </p>
       <button
@@ -22,7 +33,7 @@
 
 <script>
 import { mapActions, mapState } from 'vuex';
-import "commun/styles/fin.scss";
+import 'commun/styles/fin.scss';
 
 export default {
   data () {
@@ -31,9 +42,7 @@ export default {
     };
   },
 
-  computed: {
-    ...mapState(['competencesFortes']),
-  },
+  computed: mapState(['competencesFortes']),
 
   mounted () {
     this.recupereCompetencesFortes();

--- a/src/situations/accueil/vues/formulaire_identification.vue
+++ b/src/situations/accueil/vues/formulaire_identification.vue
@@ -106,5 +106,5 @@ export default {
         });
     }
   }
-}
+};
 </script>

--- a/src/situations/accueil/vues/overlay_intro.vue
+++ b/src/situations/accueil/vues/overlay_intro.vue
@@ -33,7 +33,6 @@
 </template>
 
 <script>
-import { mapActions } from 'vuex';
 import 'commun/styles/modale.scss';
 
 export default {

--- a/src/situations/commun/vues/boite_utilisateur.vue
+++ b/src/situations/commun/vues/boite_utilisateur.vue
@@ -30,8 +30,7 @@ export default {
       return `${this.situationsFaites.length * 100 / this.situations.length}%`;
     }
   },
-  methods: {
-    ...mapActions(['deconnecte']),
-  }
-}
+
+  methods: mapActions(['deconnecte'])
+};
 </script>

--- a/src/situations/securite/vues/fenetre_zone.vue
+++ b/src/situations/securite/vues/fenetre_zone.vue
@@ -34,14 +34,14 @@ export default {
       identificationDanger: {
         titre: traduction('securite.danger.identification.titre'),
         options: [
-          { libelle: traduction('securite.danger.identification.oui'), valeur: "oui"},
-          { libelle: traduction('securite.danger.identification.non'), valeur: "non"}
+          { libelle: traduction('securite.danger.identification.oui'), valeur: 'oui' },
+          { libelle: traduction('securite.danger.identification.non'), valeur: 'non' }
         ],
         bouton: traduction('securite.danger.identification.bouton'),
         choix: '',
         submit: this.identifie
       }
-    }
+    };
   },
 
   computed: {
@@ -67,7 +67,7 @@ export default {
         titre: traduction('securite.danger.qualification.titre'),
         options: this.$store.state.dangers[this.zone.danger].qualifications,
         bouton: traduction('securite.danger.qualification.bouton'),
-        choix: qualification ? qualification : '',
+        choix: qualification || '',
         submit: this.qualifie
       };
     },
@@ -96,5 +96,5 @@ export default {
       this.$emit('ferme');
     }
   }
-}
+};
 </script>

--- a/src/situations/securite/vues/formulaire_radio.vue
+++ b/src/situations/securite/vues/formulaire_radio.vue
@@ -3,6 +3,7 @@
     <h3>{{ question.titre }}</h3>
     <div
       v-for="option in question.options"
+      :key="option.valeur"
       class="identification-danger-input">
       <label>
         <input v-model="choix" type="radio" name="option" :value="option.valeur" />
@@ -34,14 +35,14 @@ export default {
 
   computed: {
     desactivee () {
-      return this.choix === "";
+      return this.choix === '';
     }
   },
 
   methods: {
-    submit() {
+    submit () {
       this.question.submit(this.choix);
     }
   }
-}
+};
 </script>

--- a/src/situations/securite/vues/situation.vue
+++ b/src/situations/securite/vues/situation.vue
@@ -7,6 +7,7 @@
     <svg height="100%" width="100%">
       <circle
         v-for="zone in zones"
+        :key="`${zone.x}-${zone.y}`"
         :cx="`${zone.x}%`"
         :cy="`${zone.y}%`"
         :r="`${zone.r}%`"
@@ -65,5 +66,5 @@ export default {
       this.zoneSelectionnee = null;
     }
   }
-}
+};
 </script>


### PR DESCRIPTION
Pour rajouter le support des fichiers vue, on ne peut pas passer par `semistandard` directement, il faut passer la config réutilisable eslint.

