### PR TITLE
Securité: envoi l'événement qualification danger

### DIFF
--- a/src/situations/securite/modeles/evenement_qualification_danger.js
+++ b/src/situations/securite/modeles/evenement_qualification_danger.js
@@ -1,0 +1,7 @@
+import Evenement from 'commun/modeles/evenement';
+
+export default class EvenementQualificationDanger extends Evenement {
+  constructor (donnees = {}) {
+    super('qualificationDanger', donnees);
+  }
+}

--- a/src/situations/securite/modeles/rapporteur.js
+++ b/src/situations/securite/modeles/rapporteur.js
@@ -1,0 +1,14 @@
+import EvenementQualificationDanger from './evenement_qualification_danger';
+
+export default function rapporteAuJournal (store, journal) {
+  store.subscribe((mutation, state) => {
+    if (mutation.type === 'ajouteDangerQualifie') {
+      journal.enregistre(
+        new EvenementQualificationDanger({
+          danger: mutation.payload.nom,
+          reponse: mutation.payload.choix
+        })
+      );
+    }
+  });
+}

--- a/src/situations/securite/vues/situation.js
+++ b/src/situations/securite/vues/situation.js
@@ -3,12 +3,14 @@ import Vue from 'vue';
 import { traduction } from 'commun/infra/internationalisation';
 import { creeStore, synchroniseStoreEtModeleSituation } from '../store/store';
 import { zones, dangers } from '../data/zones';
+import rapporteAuJournal from '../modeles/rapporteur';
 import Situation from './situation.vue';
 
 export default class VueSituation {
   constructor (situation, journal, depotRessources, registreUtilisateur) {
     this.situation = situation;
     this.depotRessources = depotRessources;
+    this.journal = journal;
 
     Vue.prototype.depotRessources = depotRessources;
     Vue.prototype.traduction = traduction;
@@ -20,6 +22,7 @@ export default class VueSituation {
     const store = creeStore();
     store.commit('chargeZonesEtDangers', { zones, dangers });
     synchroniseStoreEtModeleSituation(this.situation, store);
+    rapporteAuJournal(store, this.journal);
     new Vue({
       store,
       render: createEle => createEle(Situation)

--- a/tests/situations/securite/modeles/evenement_qualification_danger.js
+++ b/tests/situations/securite/modeles/evenement_qualification_danger.js
@@ -1,0 +1,12 @@
+import EvenementQualificationDanger from 'securite/modeles/evenement_qualification_danger';
+
+describe("l'événement de la qualification de danger", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementQualificationDanger().nom()).to.eql('qualificationDanger');
+  });
+
+  it('retourne ses donnees', function () {
+    const donnees = { danger: 'nomDanger', reponse: 'bonne' };
+    expect(new EvenementQualificationDanger(donnees).donnees()).to.eql(donnees);
+  });
+});

--- a/tests/situations/securite/modeles/rapporteur.js
+++ b/tests/situations/securite/modeles/rapporteur.js
@@ -1,0 +1,29 @@
+import rapporteAuJournal from 'securite/modeles/rapporteur';
+import EvenementQualificationDanger from 'securite/modeles/evenement_qualification_danger';
+import { creeStore, FINI } from 'securite/store/store';
+
+describe('Le rapporteur', function () {
+  it('il rapporte les dangers qualifiés au journal', function (done) {
+    const store = creeStore();
+    const journal = {};
+    rapporteAuJournal(store, journal);
+    journal.enregistre = (evenement) => {
+      expect(evenement).to.be.a(EvenementQualificationDanger);
+      expect(evenement.donnees()).to.eql({ danger: 'danger1', reponse: 'bonne' });
+      done();
+    };
+    store.commit('ajouteDangerQualifie', { nom: 'danger1', choix: 'bonne' });
+  });
+
+  it('il ne rapporte que les dangers qualifiés au journal', function () {
+    let compteurAppelEnregistre = 0;
+    const store = creeStore();
+    const journal = {};
+    rapporteAuJournal(store, journal);
+    journal.enregistre = (evenement) => {
+      compteurAppelEnregistre++;
+    };
+    store.commit('modifieEtat', FINI);
+    expect(compteurAppelEnregistre).to.eql(0);
+  });
+});


### PR DESCRIPTION
A chaque fois qu'un danger est qualifié, on envoi l'événement `qualificationDanger` avec le nom du danger et la réponse choisi.