### PR TITLE
Sécurité: Empêche l'ouverture de zone une fois l'une déjà ouverte.

### DIFF
--- a/src/situations/securite/vues/situation.vue
+++ b/src/situations/securite/vues/situation.vue
@@ -75,6 +75,7 @@ export default {
 
   methods: {
     selectionneZone (zone) {
+      if (this.zoneSelectionnee) { return; }
       this.zoneSelectionnee = zone;
     },
     deselectionneZone () {

--- a/src/situations/securite/vues/situation.vue
+++ b/src/situations/securite/vues/situation.vue
@@ -31,7 +31,6 @@
       :key="`${zoneSelectionnee.x}${zoneSelectionnee.y}`"
       :zone="zoneSelectionnee"
       @ferme="deselectionneZone"
-      @click.native.stop
      />
   </div>
 </template>
@@ -82,6 +81,7 @@ export default {
       this.zoneSelectionnee = null;
     },
     clickSituation (e) {
+      if (this.zoneSelectionnee) { return; }
       this.journal.enregistre(new EvenementClickHorsZone({ x: pourcentageX(e.layerX), y: pourcentageY(e.layerY) }));
     }
   }

--- a/tests/situations/securite/vues/situation.js
+++ b/tests/situations/securite/vues/situation.js
@@ -100,6 +100,22 @@ describe('La vue de la situation Sécurité', function () {
     });
   });
 
+  it("un click hors zone alors qu'une zone est sélectionné n'enregistre pas un événement click hors zone", function () {
+    store.commit('chargeZonesEtDangers', { zones: [{ x: 1, y: 2, r: 3 }], dangers: {} });
+    let enregistre = 0;
+    localVue.prototype.journal = {
+      enregistre (evenement) {
+        enregistre++;
+      }
+    };
+    wrapper.find('circle').trigger('click');
+    wrapper.trigger('click', {
+      layerX: 504,
+      layerY: 56.6
+    });
+    expect(enregistre).to.eql(0);
+  });
+
   it("un click sur une zone n'enregistre pas d'événement click hors zone", function () {
     store.commit('chargeZonesEtDangers', { zones: [{ x: 1, y: 2, r: 3 }], dangers: {} });
     let enregistre = 0;

--- a/tests/situations/securite/vues/situation.js
+++ b/tests/situations/securite/vues/situation.js
@@ -39,6 +39,14 @@ describe('La vue de la situation Sécurité', function () {
     expect(wrapper.findAll('.zone-selectionnee').length).to.eql(1);
   });
 
+  it("une fois une zone ouverte, ne permet pas d'en ouvrir une autre", function () {
+    store.commit('chargeZonesEtDangers', { zones: [{ x: 1, y: 2, r: 3 }, { x: 4, y: 5, r: 6 }], dangers: {} });
+    wrapper.find('.zone').trigger('click');
+    const zoneSelectionnee = wrapper.vm.zoneSelectionnee;
+    wrapper.findAll('.zone').at(1).trigger('click');
+    expect(zoneSelectionnee).to.eql(wrapper.vm.zoneSelectionnee);
+  });
+
   it('une fois le danger qualifié, rajoute une classe sur la zone', function () {
     store.commit('chargeZonesEtDangers', { zones: [{ x: 4, y: 5, r: 6, danger: 'test' }], dangers: { test: {} } });
     store.commit('ajouteDangerQualifie', { nom: 'test', choix: 'bon' });


### PR DESCRIPTION
Une fois une zone ouverte, on ne peut plus clique sur la situation pour en ouvrir une autre. On est obligé d'identifier/qualifier avant.