### PR TITLE
Ajout d'un mode entrainement dans le cadre

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -114,6 +114,7 @@
   },
   "situation": {
     "ecouter-consigne": "Commencez par écouter la consigne",
+    "entrainement_go": "Vous pouvez commencer l'entrainement",
     "erreur_chargement": "Erreur de chargement. Veuillez rééssayer.",
     "chargement": "Chargement en cours",
     "go": "Vous pouvez commencer",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -118,6 +118,7 @@
     "erreur_chargement": "Erreur de chargement. Veuillez rééssayer.",
     "chargement": "Chargement en cours",
     "go": "Vous pouvez commencer",
+    "entrainement_fini": "Bravo vous avez terminé l'entrainement",
     "modale": {
       "annuler": "Non",
       "ok": "Oui"

--- a/src/situations/commun/modeles/situation.js
+++ b/src/situations/commun/modeles/situation.js
@@ -5,6 +5,8 @@ export const ERREUR_CHARGEMENT = 'erreurDeChargement';
 export const ATTENTE_DEMARRAGE = 'attenteDemarrage';
 export const LECTURE_CONSIGNE = 'lectureConsigne';
 export const CONSIGNE_ECOUTEE = 'consigneEcoutée';
+export const ENTRAINEMENT_DEMARRE = 'entrainementDemarré';
+export const ENTRAINEMENT_FINI = 'entrainementFini';
 export const DEMARRE = 'démarré';
 export const FINI = 'fini';
 export const STOPPEE = 'stoppée';
@@ -12,9 +14,10 @@ export const STOPPEE = 'stoppée';
 export const CHANGEMENT_ETAT = 'changementEtat';
 
 export default class Situation extends EventEmitter {
-  constructor () {
+  constructor (modeEntrainement = false) {
     super();
     this._etat = CHARGEMENT;
+    this._entrainementDisponible = modeEntrainement;
   }
 
   etat () {
@@ -26,5 +29,9 @@ export default class Situation extends EventEmitter {
 
     this._etat = etat;
     this.emit(CHANGEMENT_ETAT, etat);
+  }
+
+  entrainementDisponible () {
+    return this._entrainementDisponible;
   }
 }

--- a/src/situations/commun/vues/actions.js
+++ b/src/situations/commun/vues/actions.js
@@ -1,6 +1,6 @@
 import 'commun/styles/actions.scss';
 import 'commun/styles/bouton.scss';
-import { CHANGEMENT_ETAT, CONSIGNE_ECOUTEE, DEMARRE } from 'commun/modeles/situation';
+import { CHANGEMENT_ETAT, CONSIGNE_ECOUTEE, DEMARRE, ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI } from 'commun/modeles/situation';
 
 import VueStop from 'commun/vues/stop';
 import VueRejoueConsigne from 'commun/vues/rejoue_consigne';
@@ -27,9 +27,17 @@ export default class VueActions {
     actionsEtat.set(CONSIGNE_ECOUTEE, () => {
       this.rejoueConsigne.affiche(this.$actions, $, this.situation);
     });
-    actionsEtat.set(DEMARRE, () => {
+    actionsEtat.set(ENTRAINEMENT_DEMARRE, () => {
       this.stop.affiche(this.$actions, $);
-      this.rejoueConsigne.affiche(this.$actions, $, this.situation);
+    });
+    actionsEtat.set(ENTRAINEMENT_FINI, () => {
+      this.rejoueConsigne.cache();
+    });
+    actionsEtat.set(DEMARRE, () => {
+      if (!this.situation.entrainementDisponible()) {
+        this.stop.affiche(this.$actions, $);
+        this.rejoueConsigne.affiche(this.$actions, $, this.situation);
+      }
     });
     const changements = actionsEtat.get(etat);
     if (changements) {

--- a/src/situations/commun/vues/bouton.js
+++ b/src/situations/commun/vues/bouton.js
@@ -27,6 +27,8 @@ export default class VueBouton {
   }
 
   cache () {
-    this.$element.remove();
+    if (this.$element) {
+      this.$element.remove();
+    }
   }
 }

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -1,5 +1,16 @@
 import 'commun/styles/cadre.scss';
-import { CHARGEMENT, ERREUR_CHARGEMENT, ATTENTE_DEMARRAGE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI, STOPPEE, CHANGEMENT_ETAT } from 'commun/modeles/situation';
+import {
+  CHARGEMENT,
+  ERREUR_CHARGEMENT,
+  ATTENTE_DEMARRAGE,
+  LECTURE_CONSIGNE,
+  CONSIGNE_ECOUTEE,
+  ENTRAINEMENT_FINI,
+  DEMARRE,
+  FINI,
+  STOPPEE,
+  CHANGEMENT_ETAT
+} from 'commun/modeles/situation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 import VueActions from 'commun/vues/actions';
 import VueChargement from 'commun/vues/chargement';
@@ -24,6 +35,7 @@ export default class VueCadre {
     this.vuesEtats.set(ATTENTE_DEMARRAGE, VueJoue);
     this.vuesEtats.set(LECTURE_CONSIGNE, VueConsigne);
     this.vuesEtats.set(CONSIGNE_ECOUTEE, VueGo);
+    this.vuesEtats.set(ENTRAINEMENT_FINI, VueGo);
     this.vuesEtats.set(FINI, VueTerminer);
     this.envoiEvenementDemarrageUneFoisDemarre();
   }

--- a/src/situations/commun/vues/cadre.js
+++ b/src/situations/commun/vues/cadre.js
@@ -5,10 +5,10 @@ import {
   ATTENTE_DEMARRAGE,
   LECTURE_CONSIGNE,
   CONSIGNE_ECOUTEE,
+  ENTRAINEMENT_DEMARRE,
   ENTRAINEMENT_FINI,
   DEMARRE,
   FINI,
-  STOPPEE,
   CHANGEMENT_ETAT
 } from 'commun/modeles/situation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
@@ -81,7 +81,7 @@ export default class VueCadre {
 
   previensLaFermetureDeLaSituation ($) {
     $(window).on('beforeunload', (e) => {
-      if (![CHARGEMENT, ERREUR_CHARGEMENT, ATTENTE_DEMARRAGE, FINI, STOPPEE].includes(this.situation.etat())) {
+      if ([ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE].includes(this.situation.etat())) {
         e.preventDefault();
         return '';
       }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -1,19 +1,33 @@
-import { ENTRAINEMENT_DEMARRE, DEMARRE } from 'commun/modeles/situation';
+import { ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE } from 'commun/modeles/situation';
 import VueActionOverlay from 'commun/vues/action_overlay';
 
 import go from 'commun/assets/go.svg';
 import { traduction } from 'commun/infra/internationalisation';
 
+function messageVueGo (situation) {
+  if (situation.etat() === ENTRAINEMENT_FINI) {
+    return 'situation.entrainement_fini';
+  }
+  return situation.entrainementDisponible() ? 'situation.entrainement_go' : 'situation.go';
+}
+
 export default class VueGo extends VueActionOverlay {
   constructor (situation) {
-    const message = situation.entrainementDisponible() ? 'situation.entrainement_go' : 'situation.go';
+    const message = messageVueGo(situation);
     super(go, traduction(message), 'bouton-go', 'bouton-centre-visible', 'hors-actions');
 
     this.situation = situation;
   }
 
   click () {
-    const prochainEtat = this.situation.entrainementDisponible() ? ENTRAINEMENT_DEMARRE : DEMARRE;
-    this.situation.modifieEtat(prochainEtat);
+    this.situation.modifieEtat(this.prochainEtat());
+  }
+
+  prochainEtat () {
+    if (this.situation.etat() === ENTRAINEMENT_FINI ||
+        !this.situation.entrainementDisponible()) {
+      return DEMARRE;
+    }
+    return ENTRAINEMENT_DEMARRE;
   }
 }

--- a/src/situations/commun/vues/go.js
+++ b/src/situations/commun/vues/go.js
@@ -1,4 +1,4 @@
-import { DEMARRE } from 'commun/modeles/situation';
+import { ENTRAINEMENT_DEMARRE, DEMARRE } from 'commun/modeles/situation';
 import VueActionOverlay from 'commun/vues/action_overlay';
 
 import go from 'commun/assets/go.svg';
@@ -6,11 +6,14 @@ import { traduction } from 'commun/infra/internationalisation';
 
 export default class VueGo extends VueActionOverlay {
   constructor (situation) {
-    super(go, traduction('situation.go'), 'bouton-go', 'bouton-centre-visible', 'hors-actions');
+    const message = situation.entrainementDisponible() ? 'situation.entrainement_go' : 'situation.go';
+    super(go, traduction(message), 'bouton-go', 'bouton-centre-visible', 'hors-actions');
+
     this.situation = situation;
   }
 
   click () {
-    this.situation.modifieEtat(DEMARRE);
+    const prochainEtat = this.situation.entrainementDisponible() ? ENTRAINEMENT_DEMARRE : DEMARRE;
+    this.situation.modifieEtat(prochainEtat);
   }
 }

--- a/src/situations/commun/vues/rejoue_consigne.js
+++ b/src/situations/commun/vues/rejoue_consigne.js
@@ -28,6 +28,11 @@ export default class VueRejoueConsigne {
     this.vueBoutonLire.affiche(this.$boutonRejoueConsigne, $);
   }
 
+  cache () {
+    this.vueBoutonLire.cache();
+    this.vueBoutonLectureEnCours.cache();
+  }
+
   litConsigne ($) {
     this.journal.enregistre(new EvenementRejoueConsigne());
     this.vueBoutonLire.cache();

--- a/tests/situations/commun/modeles/situation.js
+++ b/tests/situations/commun/modeles/situation.js
@@ -31,4 +31,14 @@ describe('une situation', function () {
     uneSituation.modifieEtat(CHARGEMENT);
     expect(compteurChangementEtat).to.eql(0);
   });
+
+  it("retourne l'information si le mode entrainement est disponible", function () {
+    const uneSituation = new Situation();
+    expect(uneSituation.entrainementDisponible()).to.be(false);
+  });
+
+  it("permet d'être initialisé avec le mode entrainement disponible", function () {
+    const uneSituation = new Situation(true);
+    expect(uneSituation.entrainementDisponible()).to.be(true);
+  });
 });

--- a/tests/situations/commun/vues/actions.js
+++ b/tests/situations/commun/vues/actions.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 import VueActions from 'commun/vues/actions';
-import SituationCommune, { CONSIGNE_ECOUTEE, DEMARRE } from 'commun/modeles/situation';
+import SituationCommune, { CONSIGNE_ECOUTEE, DEMARRE, ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI } from 'commun/modeles/situation';
 
 describe('Affiche les éléments communs aux situations', function () {
   let vueActions;
@@ -19,7 +19,7 @@ describe('Affiche les éléments communs aux situations', function () {
     expect($('.actions').length).to.equal(1);
   });
 
-  it("N'affiche pas les éléments communs au situation par défaut (bouton stop, bouton rejoue consigne)", function () {
+  it("N'affiche pas les éléments communs aux situations par défaut (bouton stop, bouton rejoue consigne)", function () {
     vueActions.affiche('#magasin', $);
     expect($('.bouton-stop').length).to.equal(0);
     expect($('.bouton-lire-consigne', '.actions').length).to.equal(0);
@@ -37,6 +37,29 @@ describe('Affiche les éléments communs aux situations', function () {
     situation.modifieEtat(DEMARRE);
     expect($('.bouton-stop').length).to.equal(1);
     expect($('.bouton-lire-consigne', '.actions').length).to.equal(0);
+  });
+
+  it("n'affiche pas le bouton rejoue consigne une fois l'entrainement terminé", function () {
+    vueActions.affiche('#magasin', $);
+    situation.modifieEtat(CONSIGNE_ECOUTEE);
+    situation.modifieEtat(ENTRAINEMENT_DEMARRE);
+    expect($('.bouton-lire-consigne', '.actions').length).to.equal(1);
+    situation.modifieEtat(ENTRAINEMENT_FINI);
+    expect($('.bouton-lire-consigne', '.actions').length).to.equal(0);
+    situation.modifieEtat(DEMARRE);
+    expect($('.bouton-lire-consigne', '.actions').length).to.equal(0);
+  });
+
+  it("affiche le bouton stop une fois l'entrainement démarré", function () {
+    situation.entrainementDisponible = () => true;
+    vueActions.affiche('#magasin', $);
+    situation.modifieEtat(CONSIGNE_ECOUTEE);
+    situation.modifieEtat(ENTRAINEMENT_DEMARRE);
+    expect($('.bouton-stop').length).to.equal(1);
+    situation.modifieEtat(ENTRAINEMENT_FINI);
+    expect($('.bouton-stop').length).to.equal(1);
+    situation.modifieEtat(DEMARRE);
+    expect($('.bouton-stop').length).to.equal(1);
   });
 
   it('cache le conteneur', function () {

--- a/tests/situations/commun/vues/cadre.js
+++ b/tests/situations/commun/vues/cadre.js
@@ -1,6 +1,11 @@
 import $ from 'jquery';
 
-import SituationCommune, { CHANGEMENT_ETAT, CHARGEMENT, ERREUR_CHARGEMENT, ATTENTE_DEMARRAGE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE, FINI, STOPPEE } from 'commun/modeles/situation';
+import SituationCommune, {
+  CHANGEMENT_ETAT, CHARGEMENT, ERREUR_CHARGEMENT,
+  ATTENTE_DEMARRAGE, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE,
+  ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI,
+  DEMARRE, FINI, STOPPEE
+} from 'commun/modeles/situation';
 import EvenementDemarrage from 'commun/modeles/evenement_demarrage';
 import VueCadre from 'commun/vues/cadre';
 import DepotRessourcesCommune from 'commun/infra/depot_ressources_communes';
@@ -109,7 +114,7 @@ describe('Une vue du cadre', function () {
   it('demande une confirmation pour quitter la page lorsque la situation est démarré', function () {
     const vueCadre = uneVueCadre();
     return vueCadre.affiche('#point-insertion', $).then(() => {
-      [LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, DEMARRE].forEach((etat) => {
+      [ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE].forEach((etat) => {
         situation.modifieEtat(etat);
         const event = $.Event('beforeunload');
         $(window).trigger(event);
@@ -121,7 +126,7 @@ describe('Une vue du cadre', function () {
   it("ne demande pas une confirmation pour quitter la page lorsque la situation n'a pas démarré", function () {
     const vueCadre = uneVueCadre();
     return vueCadre.affiche('#point-insertion', $).then(() => {
-      [CHARGEMENT, ERREUR_CHARGEMENT, FINI, ATTENTE_DEMARRAGE, STOPPEE].forEach((etat) => {
+      [CHARGEMENT, ERREUR_CHARGEMENT, LECTURE_CONSIGNE, CONSIGNE_ECOUTEE, FINI, ATTENTE_DEMARRAGE, STOPPEE].forEach((etat) => {
         situation.modifieEtat(etat);
         const event = $.Event('beforeunload');
         $(window).trigger(event);

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 import VueGo from 'commun/vues/go';
-import Situation, { DEMARRE } from 'commun/modeles/situation';
+import Situation, { ENTRAINEMENT_DEMARRE, DEMARRE } from 'commun/modeles/situation';
 import { traduction } from 'commun/infra/internationalisation';
 
 describe('vue Go', function () {
@@ -12,17 +12,34 @@ describe('vue Go', function () {
     $('body').append('<div id="pointInsertion"></div>');
     situation = new Situation();
     vue = new VueGo(situation);
-    vue.affiche('#pointInsertion', $);
   });
 
   it('affiche les informations', () => {
+    vue.affiche('#pointInsertion', $);
     expect($('#pointInsertion .overlay').length).to.eql(1);
     expect($('#pointInsertion .bouton-go').length).to.eql(1);
     expect($('#pointInsertion .message').text()).to.eql(traduction('situation.go'));
   });
 
+  it('affiche des informations différentes lorsque le mode entrainement est disponible', () => {
+    situation = new Situation(true);
+    vue = new VueGo(situation);
+    vue.affiche('#pointInsertion', $);
+    expect($('#pointInsertion .bouton-go').length).to.eql(1);
+    expect($('#pointInsertion .message').text()).to.eql(traduction('situation.entrainement_go'));
+  });
+
   it("au click, change l'état à DEMARRE", () => {
+    vue.affiche('#pointInsertion', $);
     vue.click();
     expect(situation.etat()).to.eql(DEMARRE);
+  });
+
+  it("au click, change l'état à ENTRAINEMENT_DEMARRE lorsque le mode entrainement est disponible", () => {
+    situation = new Situation(true);
+    vue = new VueGo(situation);
+    vue.affiche('#pointInsertion', $);
+    vue.click();
+    expect(situation.etat()).to.eql(ENTRAINEMENT_DEMARRE);
   });
 });

--- a/tests/situations/commun/vues/go.js
+++ b/tests/situations/commun/vues/go.js
@@ -1,7 +1,7 @@
 import $ from 'jquery';
 
 import VueGo from 'commun/vues/go';
-import Situation, { ENTRAINEMENT_DEMARRE, DEMARRE } from 'commun/modeles/situation';
+import Situation, { ENTRAINEMENT_DEMARRE, ENTRAINEMENT_FINI, DEMARRE } from 'commun/modeles/situation';
 import { traduction } from 'commun/infra/internationalisation';
 
 describe('vue Go', function () {
@@ -29,6 +29,15 @@ describe('vue Go', function () {
     expect($('#pointInsertion .message').text()).to.eql(traduction('situation.entrainement_go'));
   });
 
+  it('affiche des informations différentes lorsque le mode entrainement est disponible mais que celui ci est terminé', () => {
+    situation = new Situation(true);
+    situation.modifieEtat(ENTRAINEMENT_FINI);
+    vue = new VueGo(situation);
+    vue.affiche('#pointInsertion', $);
+    expect($('#pointInsertion .bouton-go').length).to.eql(1);
+    expect($('#pointInsertion .message').text()).to.eql(traduction('situation.entrainement_fini'));
+  });
+
   it("au click, change l'état à DEMARRE", () => {
     vue.affiche('#pointInsertion', $);
     vue.click();
@@ -41,5 +50,14 @@ describe('vue Go', function () {
     vue.affiche('#pointInsertion', $);
     vue.click();
     expect(situation.etat()).to.eql(ENTRAINEMENT_DEMARRE);
+  });
+
+  it("au click, change l'état à DEMARRE lorsque le mode entrainement est fini", () => {
+    situation = new Situation(true);
+    situation.modifieEtat(ENTRAINEMENT_FINI);
+    vue = new VueGo(situation);
+    vue.affiche('#pointInsertion', $);
+    vue.click();
+    expect(situation.etat()).to.eql(DEMARRE);
   });
 });

--- a/tests/situations/commun/vues/rejoue_consigne.js
+++ b/tests/situations/commun/vues/rejoue_consigne.js
@@ -31,6 +31,13 @@ describe('vue Rejoue Consigne', function () {
     expect($('#pointInsertion .bouton-lire-consigne').length).to.eql(1);
   });
 
+  it('sait se cacher', function () {
+    vue.affiche('#pointInsertion', $, situation);
+    vue.cache();
+    expect($('#pointInsertion .bouton-lire-consigne').length).to.eql(0);
+    expect($('#pointInsertion .bouton-lecture-en-cours').length).to.eql(0);
+  });
+
   it('passe en état lecture en cours', function () {
     vue.affiche('#pointInsertion', $, situation);
     vue.litConsigne($);


### PR DESCRIPTION
Lorsqu'une situation a un mode entraînement disponible:

- la vue go affiche un message: "Vous pouvez commencer l’entraînement"
- le bouton stop et rejoue consigne sont actif pendant entraînement
- une fois entraînement terminé, la vue go affiche un message: "Bravo vous avez terminé l'entraînement"
- pendant la situation, le bouton rejoue consigne est caché

A part cela, les autres situations devraient continué a fonctionner comme auparavant

Quelques screens dans une situation avec entrainement pour tester

![Screenshot_2019-10-16 Sécurité(1)](https://user-images.githubusercontent.com/86659/66901005-23087800-effe-11e9-9de2-170ee780225a.png)

![Screenshot_2019-10-16 Sécurité(2)](https://user-images.githubusercontent.com/86659/66901028-2ef43a00-effe-11e9-86df-4c04a24136b5.png)

