### PR TITLE
Empêche le conteneur d'être redimmensionné en fonction de l'espace disponible

### DIFF
--- a/src/situations/commun/styles/conteneur.scss
+++ b/src/situations/commun/styles/conteneur.scss
@@ -7,6 +7,7 @@
   @include conteneur;
   @include ombre;
   height: 41.875rem;
+  flex-shrink: 0;
 
   -moz-user-select: none;
   -webkit-user-select: none;


### PR DESCRIPTION
Fix #512 

Lorsque la fenetre n'est pas assez large, une barre de défilement verticale et horizontale est affiché. La barre verticale est présente car on mis un `min-height: 100vh` sur le body, et la scrollbar horizontal prend de la hauteur :/. C'est un moindre mal pour le moment.