### PR TITLE
Sécurité: Change le style des zones de dangers qualifiés.

### DIFF
--- a/src/situations/securite/styles/acte.scss
+++ b/src/situations/securite/styles/acte.scss
@@ -7,8 +7,14 @@
 .zone {
   fill: transparent;
 
-  &-selectionnee, &-qualifiee {
+  &-selectionnee {
     stroke: $couleur-accent-et-erreur;
+    stroke-width: 6px;
+  }
+
+  &-qualifiee {
+    fill: transparentize($bleu-clair, .25);
+    stroke: $blanc;
     stroke-width: 6px;
   }
 


### PR DESCRIPTION
![Screenshot_2019-10-22 Sécurité(1)](https://user-images.githubusercontent.com/86659/67282806-cb24b200-f4d2-11e9-9a4d-bd60c01c491a.png)
