### PR TITLE
[Sécurité] Change le seuil d'affichage des zones hautes

### DIFF
--- a/src/situations/securite/vues/fenetre_zone.vue
+++ b/src/situations/securite/vues/fenetre_zone.vue
@@ -77,11 +77,11 @@ export default {
 
   computed: {
     bottom () {
-      if (this.zone.y < 45) return undefined;
+      if (this.zone.y < 50) return undefined;
       return this.formatePourcentage((100 - this.zone.y + Math.sin(Math.PI / 4) * this.zone.r).toFixed(1));
     },
     top () {
-      if (this.zone.y >= 45) return undefined;
+      if (this.zone.y >= 50) return undefined;
       return this.formatePourcentage((this.zone.y + Math.sin(Math.PI / 4) * this.zone.r).toFixed(1));
     },
     left () {


### PR DESCRIPTION
 pour éviter de masquer le bandeau des dangers

![Capture d’écran 2019-10-23 à 16 03 13](https://user-images.githubusercontent.com/298214/67400929-ab62bc00-f5ae-11e9-8305-de66b6e7471e.png)
![Capture d’écran 2019-10-23 à 16 03 26](https://user-images.githubusercontent.com/298214/67400946-aef64300-f5ae-11e9-9f8d-985e6f7048c4.png)
