### PR TITLE
Bureau: Utilise l'événement change plutôt que input.

### DIFF
--- a/src/situations/questions/vues/qcm.js
+++ b/src/situations/questions/vues/qcm.js
@@ -14,7 +14,7 @@ export default class VueQCM extends VueQuestion {
       return `
         <div class="question-choix">
           <label>
-            <input name="numeratie" type="radio" value="${choix.id}" />
+            <input name="question" type="radio" value="${choix.id}" />
             ${choix.intitule}
           </label>
         </div>
@@ -35,12 +35,12 @@ export default class VueQCM extends VueQuestion {
     `);
     $(pointInsertion).append(this.$vue);
     const $envoiReponse = $('#envoi-reponse', this.$vue);
-    $('input[name="numeratie"]', this.$vue).on('input', () => {
+    $('input[name="question"]', this.$vue).on('change', () => {
       $envoiReponse.prop('disabled', false);
     });
     $envoiReponse.click(() => {
       $envoiReponse.prop('disabled', true);
-      const reponse = $('input[name="numeratie"]:checked', this.$vue).val();
+      const reponse = $('input[name="question"]:checked', this.$vue).val();
       this.emit(EVENEMENT_REPONSE, reponse);
     });
   }

--- a/tests/situations/questions/vues/qcm.js
+++ b/tests/situations/questions/vues/qcm.js
@@ -43,7 +43,7 @@ describe('La vue de la question QCM', function () {
     const $vue = new VueQCM(question);
     $vue.affiche('#point-insertion', $);
     expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(true);
-    $('#point-insertion input[type=radio][value=uid-32]').prop('checked', true).trigger('input');
+    $('#point-insertion input[type=radio][value=uid-32]').prop('checked', true).trigger('change');
     expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(false);
   });
 
@@ -66,7 +66,7 @@ describe('La vue de la question QCM', function () {
     const $vue = new VueQCM(question);
 
     $vue.affiche('#point-insertion', $);
-    $('#point-insertion input[type=radio][value=uid-32]').prop('checked', true).trigger('input');
+    $('#point-insertion input[type=radio][value=uid-32]').prop('checked', true).trigger('change');
     expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(false);
     $vue.on(EVENEMENT_REPONSE, (reponse) => {
       expect($('#point-insertion #envoi-reponse').prop('disabled')).to.be(true);


### PR DESCRIPTION
Fix #538 

> The DOM input event is fired synchronously when the value of an <input>, <select>, or <textarea> element is changed. For input elements with type=checkbox or type=radio, the input event should fire when a user toggles the control (via touch, mouse or keyboard) per the HTML5 specification, but historically, this has not been the case. Check compatibility, or attach to the change event instead for elements of these types.
