### PR TITLE
Inventaire: refactoring de la vue étagères et contenu

### DIFF
--- a/src/situations/inventaire/vues/contenu.js
+++ b/src/situations/inventaire/vues/contenu.js
@@ -15,13 +15,12 @@ export default class VueContenu {
       setTimeout(() => {
         this.calque.classList.add('invisible');
         this.element.classList.add('invisible');
+        this.element.remove();
+        this.calque.remove();
       }, delaiFermeture);
       event.stopPropagation();
     });
-    this.element = document.createElement('img');
-    this.element.classList.add('contenu', 'fermer', 'invisible');
-    pointInsertion.appendChild(this.element);
-    pointInsertion.appendChild(this.calque);
+    this.pointInsertion = pointInsertion;
   }
 
   position (position, dimensionFermee, dimensionOuvert) {
@@ -29,11 +28,16 @@ export default class VueContenu {
   }
 
   affiche (contenant) {
+    this.element = document.createElement('img');
     this.element.src = contenant.imageOuvert;
+    this.element.classList.add('contenu', 'fermer', 'invisible');
     this.element.style.top = this.position(contenant.posY - contenant.hauteur, contenant.hauteur, contenant.dimensionsOuvert.hauteur) + '%';
     this.element.style.left = this.position(contenant.posX, contenant.largeur, contenant.dimensionsOuvert.largeur) + '%';
     this.element.style.height = contenant.dimensionsOuvert.hauteur + '%';
     this.element.style.width = contenant.dimensionsOuvert.largeur + '%';
+
+    this.pointInsertion.appendChild(this.element);
+    this.pointInsertion.appendChild(this.calque);
 
     this.calque.classList.remove('invisible');
     this.element.classList.remove('invisible');

--- a/src/situations/inventaire/vues/etageres.js
+++ b/src/situations/inventaire/vues/etageres.js
@@ -3,16 +3,19 @@ import VueContenu from './contenu';
 import imageEtageres from 'inventaire/assets/etageres.png';
 
 export default class VueEtageres {
-  constructor (pointInsertion, journal) {
+  constructor (situation, journal) {
     this.journal = journal;
+    this.situation = situation;
+  }
+
+  affiche (pointInsertion) {
     this.element = document.createElement('div');
     this.element.id = 'etageres';
     this.element.classList.add('etageres');
+
     document.querySelector(pointInsertion).appendChild(this.element);
     document.querySelector(pointInsertion).classList.add('magasin');
-  }
 
-  affiche (contenants) {
     const etageres = document.createElement('img');
     etageres.id = 'imageEtageres';
     etageres.src = imageEtageres;
@@ -25,7 +28,7 @@ export default class VueEtageres {
 
     const vueContenants = new VueContenants(avantPlan, this.journal);
     const vueContenu = new VueContenu(avantPlan);
-    vueContenants.afficheLesContenants(contenants, vueContenu);
+    vueContenants.afficheLesContenants(this.situation.contenants, vueContenu);
 
     const redimensionne = () => {
       avantPlan.style.width = etageres.width + 'px';

--- a/src/situations/inventaire/vues/situation.js
+++ b/src/situations/inventaire/vues/situation.js
@@ -11,8 +11,8 @@ export default class VueSituation {
   }
 
   affiche (pointInsertion, $) {
-    new VueEtageres(pointInsertion, this.journal)
-      .affiche(this.situation.contenants);
+    new VueEtageres(this.situation, this.journal)
+      .affiche(pointInsertion);
 
     initialiseFormulaireSaisieInventaire(this.situation,
       pointInsertion,

--- a/tests/situations/inventaire/vues/contenu.js
+++ b/tests/situations/inventaire/vues/contenu.js
@@ -5,40 +5,38 @@ import VueContenu from 'inventaire/vues/contenu';
 
 describe('vue contenu', function () {
   let vue;
-  let calque;
-  let element;
   const DELAI_FERMETURE = 3;
 
   beforeEach(function () {
     document.body.innerHTML = '<div id="point-insertion"></div>';
     const pointInsertion = document.getElementById('point-insertion');
     vue = new VueContenu(pointInsertion, DELAI_FERMETURE);
-    calque = document.getElementById('calque');
-    element = vue.element;
   });
 
-  it("initialise un contenu invisible tant que le contenant n'est pas ouvert", function () {
-    expect(calque.classList).to.contain('invisible');
-    expect(element.classList).to.contain('invisible');
+  it('initialise un calque invisible', function () {
+    expect(vue.calque.classList).to.contain('invisible');
   });
 
   it("sait s'afficher puis se cacher", function (done) {
     const contenant = new Contenant({ idProduit: '0', quantite: 1, dimensionsOuvert: { largeur: 33, hauteur: 33 } });
     vue.affiche(contenant);
 
-    expect(calque.classList).to.not.contain('invisible');
+    expect(vue.calque.classList).to.not.contain('invisible');
     expect(vue.element.classList).to.not.contain('invisible');
 
-    calque.dispatchEvent(new Event('click'));
+    vue.calque.dispatchEvent(new Event('click'));
 
     setTimeout(() => {
-      expect(calque.classList).to.contain('invisible');
+      expect(vue.calque.classList).to.contain('invisible');
       expect(vue.element.classList).to.contain('invisible');
       done();
     }, DELAI_FERMETURE);
   });
 
   it("ajoute le calque après l'element pour qu'il soit devant", function () {
+    const contenant = new Contenant({ idProduit: '0', quantite: 1, dimensionsOuvert: { largeur: 33, hauteur: 33 } });
+    vue.affiche(contenant);
+
     expect(document.querySelector('.contenu + .calque')).to.not.be(null);
   });
 
@@ -53,7 +51,7 @@ describe('vue contenu', function () {
       const contenant = new Contenant({ imageOuvert: 'image_contenant', dimensionsOuvert: { largeur: 33, hauteur: 33 } }, { nom: 'Nova Sky' });
       vue.affiche(contenant);
 
-      expect(element.src).to.eql('http://localhost/image_contenant');
+      expect(vue.element.src).to.eql('http://localhost/image_contenant');
     });
 
     it('affiche le contenant ouvert aux dimensions données en paramètres', function () {

--- a/tests/situations/inventaire/vues/etageres.js
+++ b/tests/situations/inventaire/vues/etageres.js
@@ -1,21 +1,21 @@
 /* global Event */
 
-import Contenant from 'inventaire/modeles/contenant';
 import VueEtageres from 'inventaire/vues/etageres';
+import { unMagasin } from '../aides/magasin';
 
 describe('vue etagères', function () {
   let vue;
 
   beforeEach(function () {
     document.body.innerHTML = '<div id="magasin"></div>';
-    vue = new VueEtageres('#magasin');
+    vue = new VueEtageres(unMagasin().construit());
   });
 
   it("sait s'afficher dans une page web", function () {
+    vue.affiche('#magasin');
+
     const elementsTrouves = document.querySelectorAll('#magasin .etageres');
     expect(elementsTrouves.length).to.equal(1);
-
-    vue.affiche([]);
 
     const etageres = document.getElementById('imageEtageres');
     expect(etageres.tagName).to.equal('IMG');
@@ -23,17 +23,25 @@ describe('vue etagères', function () {
 
   it('ajoute plusieurs contenants sur les étagères', function () {
     const contenants = [
-      new Contenant({ idContenu: '0', quantite: 12 }),
-      new Contenant({ idContenu: '1', quantite: 7 })
+      { idContenu: '0', quantite: 12 },
+      { idContenu: '1', quantite: 7 }
     ];
-    vue.affiche(contenants);
+    const situation = unMagasin()
+      .avecCommeReferences(
+        { idProduit: '0', nom: 'Nova Sky', image: 'chemin image Nova Sky', forme: 'petiteBouteille', position: 2 },
+        { idProduit: '1', nom: 'Nova Sky', image: 'chemin image Nova Sky', forme: 'petiteBouteille', position: 2 }
+      )
+      .avecEnStock(...contenants)
+      .construit();
+    vue = new VueEtageres(situation);
+    vue.affiche('#magasin');
 
     const contenantsAjoutes = document.getElementsByClassName('contenant');
     expect(contenantsAjoutes.length).to.equal(2);
   });
 
   it("recalcule la taille de l'avant plan quand on redimensionne l'image", function () {
-    vue.affiche([]);
+    vue.affiche('#magasin');
     const imageEtageres = document.getElementById('imageEtageres');
     imageEtageres.width = 50;
     imageEtageres.height = 25;
@@ -42,11 +50,5 @@ describe('vue etagères', function () {
     const avantPlan = document.querySelector('.avant-plan');
     expect(avantPlan.style.width).to.equal('50px');
     expect(avantPlan.style.height).to.equal('25px');
-  });
-
-  it("ajoute la vue contenu à l'interieur de l'avant plan pour que ses dimensions soient bien calculées par rapport à la taille de l'image", function () {
-    vue.affiche([]);
-
-    expect(document.querySelector('.avant-plan .contenu')).to.not.equal(null);
   });
 });


### PR DESCRIPTION
J'ai normalisé a la façon pré-vue la vue étagères pour avoir un constructeur avec la situation et une méthode `affiche` avec le point d'insertion.

La vue contenu elle a été refactoré pour qu'elle recrée l'élément image a chaque affichage. Cela permet d'éviter un clignotement lors du changement sous Firefox et permet un changement du contenu avec l'activation de l'aide #544 