### PR TITLE
Nouveaux style des boutons d'actions 

### DIFF
--- a/src/situations/accueil/styles/accueil.scss
+++ b/src/situations/accueil/styles/accueil.scss
@@ -44,7 +44,7 @@
   }
 
   .bouton-mission {
-    @include bouton($couleur-fond-bouton-violet, $couleur-fond-bouton-violet-focus);
+    @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
     border-radius: 3.125rem;
   }
 }

--- a/src/situations/commun/assets/play.svg
+++ b/src/situations/commun/assets/play.svg
@@ -1,11 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="20px" height="28px" viewBox="0 0 20 28" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
-    <title>Rectangle</title>
-    <desc>Created with Sketch.</desc>
-    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Button/Consigne/hover" transform="translate(-32.000000, -26.000000)" fill="#FFFFFF">
-            <path d="M35.2120864,26.4473039 L50.9119917,38.4091366 C51.7906014,39.0785534 51.9601856,40.3334768 51.2907687,41.2120864 C51.1820658,41.3547591 51.0546644,41.4821605 50.9119917,41.5908634 L35.2120864,53.5526961 C34.3334768,54.2221129 33.0785534,54.0525287 32.4091366,53.173919 C32.1437348,52.8255793 32,52.399758 32,51.9618326 L32,28.0381674 C32,26.9335979 32.8954305,26.0381674 34,26.0381674 C34.4379254,26.0381674 34.8637467,26.1819022 35.2120864,26.4473039 Z" id="Rectangle"></path>
-        </g>
-    </g>
+<svg width="12" height="13" viewBox="0 0 12 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M10.25 4.89295C11.5833 5.66275 11.5833 7.58725 10.25 8.35705L3.3125 12.3624C1.97917 13.1322 0.312501 12.17 0.312501 10.6304L0.312502 2.61963C0.312502 1.08003 1.97917 0.117781 3.3125 0.887582L10.25 4.89295Z" fill="#FBF9FA"/>
 </svg>

--- a/src/situations/commun/assets/stop.svg
+++ b/src/situations/commun/assets/stop.svg
@@ -1,3 +1,3 @@
-<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect x="0.5" y="0.5" width="15" height="15" fill="white"/>
+<svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="0.375" y="0.375" width="11.25" height="11.25" rx="2" fill="white"/>
 </svg>

--- a/src/situations/commun/styles/barre_dev.scss
+++ b/src/situations/commun/styles/barre_dev.scss
@@ -12,10 +12,10 @@
   padding: 5px;
 
   .bouton-go {
-    @include bouton($couleur-fond-bouton-violet, $couleur-fond-bouton-violet-focus);
+    @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
   }
 
   .bouton-fini {
-    @include bouton($couleur-fond-bouton-violet, $couleur-fond-bouton-violet-focus);
+    @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
   }
 }

--- a/src/situations/commun/styles/boite_utilisateur.scss
+++ b/src/situations/commun/styles/boite_utilisateur.scss
@@ -1,7 +1,7 @@
 @import 'commun/styles/couleurs.scss';
 
 .boite-utilisateur {
-  border: 1px solid $bleu-clair;
+  border: 1px solid $vert-clair;
   border-radius: 3rem;
   color: $couleur-texte;
   font-size: 1.125rem;
@@ -10,7 +10,7 @@
 
   .progression {
     position: absolute;
-    background-color: $bleu-clair;
+    background-color: $vert-clair;
     height: 100%;
     z-index: -1;
   }

--- a/src/situations/commun/styles/bouton.scss
+++ b/src/situations/commun/styles/bouton.scss
@@ -6,7 +6,7 @@
 }
 
 .bouton-lecture-en-cours {
-  @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, 3.5rem);
+  @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, 3rem);
   cursor: default;
 }
 
@@ -20,12 +20,10 @@
   }
 
   span {
-    text-transform: uppercase;
-    color: $couleur-etiquette-bouton;
-    font-weight: bold;
+    color: $couleur-texte;
+    font-size: 1.1rem;
     margin-left: 1rem;
     margin-right: 1rem;
-    width: 7rem;
   }
 
   &.desactivee span {

--- a/src/situations/commun/styles/bouton.scss
+++ b/src/situations/commun/styles/bouton.scss
@@ -2,11 +2,11 @@
 @import 'commun/styles/mixins/boutons.scss';
 
 .bouton-lire-consigne {
-  @include bouton($couleur-fond-bouton-violet, $couleur-fond-bouton-violet-focus);
+  @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu-focus);
 }
 
 .bouton-lecture-en-cours {
-  @include bouton($couleur-fond-bouton-violet, $couleur-fond-bouton-violet, $couleur-fond-bouton-violet, 3.5rem);
+  @include bouton($couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, $couleur-fond-bouton-bleu, 3.5rem);
   cursor: default;
 }
 

--- a/src/situations/commun/styles/boutons.scss
+++ b/src/situations/commun/styles/boutons.scss
@@ -6,21 +6,21 @@
   border-radius: 2rem;
   cursor: pointer;
   color: $blanc;
-  background-color: $couleur-fond-bouton-violet;
+  background-color: $couleur-fond-bouton-bleu;
   transition: border, background .3s;
   outline: none;
   line-height: 1.3;
 
   &:active {
-    border-color: $couleur-fond-bouton-violet;
+    border-color: $couleur-fond-bouton-bleu;
   }
   &:hover,
   &:focus {
-    background-color: $couleur-fond-bouton-violet-focus;
+    background-color: $couleur-fond-bouton-bleu-focus;
   }
   &[disabled] {
-    background-color: grayscale($couleur-fond-bouton-violet);
-    border-color: grayscale($couleur-fond-bouton-violet-focus);
+    background-color: grayscale($couleur-fond-bouton-bleu);
+    border-color: grayscale($couleur-fond-bouton-bleu-focus);
     cursor: auto;
   }
 

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -71,7 +71,7 @@ h3 {
   width: 0;
   height: 5rem;
   padding: 0;
-  color: $couleur-bordure-bouton;
+  color: $couleur-fond-bouton-bleu;
   border-left: 1.5rem solid $blanc;
   border-right: 1.5rem solid $blanc;
   border-bottom: 1.5rem solid transparent;

--- a/src/situations/commun/styles/couleurs.scss
+++ b/src/situations/commun/styles/couleurs.scss
@@ -21,8 +21,6 @@ $couleur-texte: $couleur-sombre;
 
 // boutons
 $couleur-texte-bouton-retour: #414141;
-$couleur-bordure-bouton: #a6d4ff;
-$couleur-bordure-bouton-focus: #047be7;
 $couleur-fond-bouton-terminer: #008DDC;
 $couleur-fond-bouton-terminer-focus: #00659F;
 $couleur-fond-bouton-vert: $vert-clair;

--- a/src/situations/commun/styles/couleurs.scss
+++ b/src/situations/commun/styles/couleurs.scss
@@ -29,12 +29,12 @@ $couleur-fond-bouton-terminer-focus: #00659F;
 $couleur-fond-bouton-vert: #129F46;
 $couleur-fond-bouton-vert-focus: #0B8538;
 $couleur-fond-bouton-bleu: #12AFFF;
-$couleur-fond-bouton-bleu-focus: #0996DF;
+$couleur-fond-bouton-bleu-focus: darken($couleur-fond-bouton-bleu, 10%);
 $couleur-ombre: rgba(0,0,0,0.31);
 $couleur-fond-bouton-rouge: $rouge;
-$couleur-fond-bouton-rouge-focus: #C2001A;
+$couleur-fond-bouton-rouge-focus: darken($rouge, 10%);
 $couleur-fond-bouton-violet: $violet;
-$couleur-fond-bouton-violet-focus: #556ffe;
+$couleur-fond-bouton-violet-focus: darken($violet, 10%);
 // actions
 $couleur-fond-actions: $couleur-fond;
 

--- a/src/situations/commun/styles/couleurs.scss
+++ b/src/situations/commun/styles/couleurs.scss
@@ -21,7 +21,6 @@ $couleur-texte: $couleur-sombre;
 
 // boutons
 $couleur-texte-bouton-retour: #414141;
-$couleur-etiquette-bouton: #898989;
 $couleur-bordure-bouton: #a6d4ff;
 $couleur-bordure-bouton-focus: #047be7;
 $couleur-fond-bouton-terminer: #008DDC;

--- a/src/situations/commun/styles/couleurs.scss
+++ b/src/situations/commun/styles/couleurs.scss
@@ -3,14 +3,14 @@ $blanc: #ffffff;
 $noir: #000000;
 $gris: #969696;
 $bleu-fonce: #1E416A;
-$violet: #6E84FE;
+$bleu: #6E84FE;
 $rouge: #FD5C54;
 $vert-clair: #9ADBD0;
 $gris-clair: #DDDDDD;
 
 // branding & style-guide
 $couleur-sombre: $bleu-fonce;
-$couleur-principale-marque-et-interaction: $violet;
+$couleur-principale-marque-et-interaction: $bleu;
 $couleur-accent-et-erreur: $rouge;
 $couleur-legere-accent-et-validation: $vert-clair;
 $couleur-clair: $gris-clair;
@@ -26,15 +26,13 @@ $couleur-bordure-bouton: #a6d4ff;
 $couleur-bordure-bouton-focus: #047be7;
 $couleur-fond-bouton-terminer: #008DDC;
 $couleur-fond-bouton-terminer-focus: #00659F;
-$couleur-fond-bouton-vert: #129F46;
-$couleur-fond-bouton-vert-focus: #0B8538;
-$couleur-fond-bouton-bleu: #12AFFF;
-$couleur-fond-bouton-bleu-focus: darken($couleur-fond-bouton-bleu, 10%);
+$couleur-fond-bouton-vert: $vert-clair;
+$couleur-fond-bouton-vert-focus: darken($vert-clair, 10%);
+$couleur-fond-bouton-bleu: $bleu;
+$couleur-fond-bouton-bleu-focus: darken($bleu, 10%);
 $couleur-ombre: rgba(0,0,0,0.31);
 $couleur-fond-bouton-rouge: $rouge;
 $couleur-fond-bouton-rouge-focus: darken($rouge, 10%);
-$couleur-fond-bouton-violet: $violet;
-$couleur-fond-bouton-violet-focus: darken($violet, 10%);
 // actions
 $couleur-fond-actions: $couleur-fond;
 

--- a/src/situations/commun/styles/couleurs.scss
+++ b/src/situations/commun/styles/couleurs.scss
@@ -5,14 +5,14 @@ $gris: #969696;
 $bleu-fonce: #1E416A;
 $violet: #6E84FE;
 $rouge: #FD5C54;
-$bleu-clair: #9ADBD0;
+$vert-clair: #9ADBD0;
 $gris-clair: #DDDDDD;
 
 // branding & style-guide
 $couleur-sombre: $bleu-fonce;
 $couleur-principale-marque-et-interaction: $violet;
 $couleur-accent-et-erreur: $rouge;
-$couleur-legere-accent-et-validation: $bleu-clair;
+$couleur-legere-accent-et-validation: $vert-clair;
 $couleur-clair: $gris-clair;
 
 // général

--- a/src/situations/commun/styles/erreur_chargement.scss
+++ b/src/situations/commun/styles/erreur_chargement.scss
@@ -3,8 +3,4 @@
 
 .bouton-erreur-chargement {
   @include bouton($couleur-fond-bouton-rouge, $couleur-fond-bouton-rouge-focus);
-
-  img {
-    height: 2rem;
-  }
 }

--- a/src/situations/commun/styles/fin.scss
+++ b/src/situations/commun/styles/fin.scss
@@ -24,7 +24,7 @@
     }
 
     &-nom {
-      color: $violet;
+      color: $couleur-principale-marque-et-interaction;
     }
     &-description {
       font-size: 1rem;

--- a/src/situations/commun/styles/mixins/boutons.scss
+++ b/src/situations/commun/styles/mixins/boutons.scss
@@ -1,8 +1,8 @@
-@mixin bouton($couleur-fond, $couleur-fond-focus, $couleur-bordure: $blanc, $hauteur-image: 1.3rem) {
+@mixin bouton($couleur-fond, $couleur-fond-focus, $couleur-bordure: $blanc, $hauteur-image: 1rem) {
   border-radius: 3.125rem;
   cursor: pointer;
-  height: 4rem;
-  width: 4rem;
+  height: 3rem;
+  width: 3rem;
   background-color: $couleur-fond;
   display: flex;
   align-items: center;

--- a/src/situations/commun/vues/bouton.js
+++ b/src/situations/commun/vues/bouton.js
@@ -5,9 +5,8 @@ export default class VueBouton {
     this.click = click;
   }
 
-  ajouteUneEtiquette (etiquette, aGauche = false) {
+  ajouteUneEtiquette (etiquette) {
     this.etiquette = etiquette;
-    this.aGauche = aGauche;
   }
 
   affiche (pointInsertion, $) {
@@ -16,9 +15,6 @@ export default class VueBouton {
     this.$element = $bouton;
     if (this.etiquette) {
       const $boutonEtEtiquette = $('<div class="bouton-et-etiquette"></div>');
-      if (this.aGauche) {
-        $boutonEtEtiquette.addClass('gauche');
-      }
       $boutonEtEtiquette.append($bouton);
       $boutonEtEtiquette.append(`<span>${this.etiquette}</span>`);
       this.$element = $boutonEtEtiquette;

--- a/src/situations/commun/vues/stop.js
+++ b/src/situations/commun/vues/stop.js
@@ -18,7 +18,7 @@ export default class VueStop {
 
   affiche (pointInsertion, $) {
     const boutonStop = new VueBouton('bouton-stop', stop, () => { this.clickSurStop($(pointInsertion).parent(), $); });
-    boutonStop.ajouteUneEtiquette(traduction('situation.arreter_mission'), true);
+    boutonStop.ajouteUneEtiquette(traduction('situation.arreter_mission'));
     boutonStop.affiche(pointInsertion, $);
   }
 

--- a/src/situations/inventaire/styles/formulaire_saisie_inventaire.scss
+++ b/src/situations/inventaire/styles/formulaire_saisie_inventaire.scss
@@ -14,7 +14,7 @@
   padding: 0rem;
 
   &:hover {
-    border-color: $couleur-bordure-bouton-focus;
+    border-color: $couleur-fond-bouton-bleu-focus;
   }
 }
 
@@ -99,7 +99,7 @@
       font-size: 1.125rem;
       border-radius: .625rem .625rem 0 0;
 
-      &:hover { background: $couleur-bordure-bouton-focus }
+      &:hover { background: $couleur-fond-bouton-bleu-focus; }
     }
   }
 

--- a/src/situations/questions/styles/situation.scss
+++ b/src/situations/questions/styles/situation.scss
@@ -44,7 +44,7 @@
 }
 
 .intitule-question {
-  color: $couleur-fond-bouton-violet;
+  color: $couleur-fond-bouton-bleu;
 }
 
 .sans-marge {

--- a/src/situations/securite/styles/acte.scss
+++ b/src/situations/securite/styles/acte.scss
@@ -13,7 +13,7 @@
   }
 
   &-qualifiee {
-    fill: transparentize($bleu-clair, .25);
+    fill: transparentize($vert-clair, .25);
     stroke: $blanc;
     stroke-width: 6px;
   }
@@ -64,6 +64,6 @@
   animation: 1s agrandit-puis-retrecit;
 
   path {
-    fill: $bleu-clair;
+    fill: $vert-clair;
   }
 }

--- a/src/situations/securite/styles/fenetre_aide.scss
+++ b/src/situations/securite/styles/fenetre_aide.scss
@@ -11,7 +11,7 @@
 }
 
 .aide-activee {
-  background: $bleu-clair;
+  background: $vert-clair;
   color: $blanc;
   padding: .7rem 1.375rem;
   border-radius: 3.125rem;

--- a/tests/situations/commun/vues/bouton.js
+++ b/tests/situations/commun/vues/bouton.js
@@ -22,11 +22,4 @@ describe('vue Bouton', function () {
     expect($('.bouton-et-etiquette .bouton-lire-consigne').length).to.eql(1);
     expect($('.bouton-et-etiquette span').text()).to.equal('Un texte');
   });
-
-  it('sait afficher le libellé à gauche du bouton', function () {
-    vue.ajouteUneEtiquette('Un texte', true);
-    vue.affiche('#point-insertion', $);
-
-    expect($('.bouton-et-etiquette.gauche').length).to.eql(1);
-  });
 });

--- a/tests/situations/commun/vues/stop.js
+++ b/tests/situations/commun/vues/stop.js
@@ -25,7 +25,7 @@ describe('vue Stop', function () {
 
   it("sait s'insérer dans une page web", function () {
     vue.affiche('#point-insertion', $);
-    expect($('#point-insertion .bouton-stop').hasClass('invisible')).to.be(false);
+    expect($('#point-insertion .bouton-stop').length).to.eql(1);
   });
 
   it('ouvre une fenêtre de confirmation avant de stopper', function () {


### PR DESCRIPTION
Des variables ont été supprimés et renommés et le style des boutons d'actions ont changé.

Quelques exemples:

![Screenshot_2019-11-05 Sécurité(1)](https://user-images.githubusercontent.com/86659/68226866-1373c200-fff3-11e9-9d96-04f98d16fd9d.png)
![Screenshot_2019-11-05 Sécurité](https://user-images.githubusercontent.com/86659/68226867-1373c200-fff3-11e9-8170-cf21122420e0.png)
![Screenshot_2019-11-05 Compétences pro](https://user-images.githubusercontent.com/86659/68226869-1373c200-fff3-11e9-8d80-c4c82997494d.png)
