### PR TITLE
Tests : supprime l'initialisation global de Vue.prototype.$traduction

### DIFF
--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 import Accueil, { CLE_ETAT_ACCUEIL, LARGEUR_BATIMENT, ESPACEMENT_BATIMENT, DECALAGE_INITIAL } from 'accueil/vues/accueil';
 import AccesSituation from 'accueil/vues/acces_situation';
 import FormulaireIdentification from 'accueil/vues/formulaire_identification';
+import { traduction } from 'commun/infra/internationalisation';
 
 describe('La vue accueil', function () {
   let depotRessources;
@@ -42,6 +43,7 @@ describe('La vue accueil', function () {
     });
     localVue = createLocalVue();
     localVue.prototype.$depotRessources = depotRessources;
+    localVue.prototype.$traduction = traduction;
   });
 
   it('affiche les composants', function () {

--- a/tests/situations/accueil/vues/fin.js
+++ b/tests/situations/accueil/vues/fin.js
@@ -1,6 +1,7 @@
 import { mount, createLocalVue } from '@vue/test-utils';
 import Vuex from 'vuex';
 import Fin from 'accueil/vues/fin';
+import { traduction } from 'commun/infra/internationalisation';
 
 describe('La vue de fin', function () {
   let wrapper;
@@ -29,6 +30,7 @@ describe('La vue de fin', function () {
     });
     localVue = createLocalVue();
     localVue.prototype.$depotRessources = depotRessources;
+    localVue.prototype.$traduction = traduction;
   });
 
   it("sait s'afficher", function () {

--- a/tests/situations/accueil/vues/formulaire_identification.js
+++ b/tests/situations/accueil/vues/formulaire_identification.js
@@ -1,18 +1,17 @@
 import { mount, createLocalVue } from '@vue/test-utils';
-import Vue from 'vue';
 import Vuex from 'vuex';
 import FormulaireIdentificationVue from 'accueil/vues/formulaire_identification';
 import { traduction } from 'commun/infra/internationalisation';
-
-Vue.prototype.$traduction = traduction;
 
 describe("Le formulaire d'identification", function () {
   let wrapper;
   let promesse;
   let store;
+  let localVue;
 
   beforeEach(function () {
-    const localVue = createLocalVue();
+    localVue = createLocalVue();
+    localVue.prototype.$traduction = traduction;
     promesse = Promise.resolve();
     store = new Vuex.Store({
       state: { estConnecte: false }
@@ -128,7 +127,7 @@ describe("Le formulaire d'identification", function () {
 
   it('cache le champ campagne si il y a une propriété forceCampagne', function () {
     expect(wrapper.findAll('.input-accueil').length).to.equal(2);
-    wrapper = mount(FormulaireIdentificationVue, { store, propsData: { forceCampagne: 'ete-2019' } });
+    wrapper = mount(FormulaireIdentificationVue, { store, localVue, propsData: { forceCampagne: 'ete-2019' } });
     expect(wrapper.vm.campagne).to.eql('ete-2019');
     expect(wrapper.findAll('label').length).to.equal(2);
     expect(wrapper.findAll('.input-accueil').length).to.equal(1);

--- a/tests/situations/accueil/vues/index.js
+++ b/tests/situations/accueil/vues/index.js
@@ -4,6 +4,7 @@ import Index from 'accueil/vues/index';
 import OverlayChargement from 'commun/vues/overlay_chargement';
 import OverlayErreurChargement from 'commun/vues/overlay_erreur_chargement';
 import Accueil from 'accueil/vues/accueil';
+import { traduction } from 'commun/infra/internationalisation';
 
 describe('La vue index', function () {
   let depotRessources;
@@ -18,6 +19,7 @@ describe('La vue index', function () {
 
     localVue = createLocalVue();
     localVue.prototype.$depotRessources = depotRessources;
+    localVue.prototype.$traduction = traduction;
   });
 
   it('affiche les composants en chargement', function () {


### PR DESCRIPTION
J'ai rendu la variable local et donc il faut l'attacher à la vue locale à chaque fois qu'on en a besoins. 

Est-ce que c'est mieux ?

Ça me gênait que cette déclaration soit dans le fichier `tests/situations/accueil/vues/formulaire_identification.js`. Peut-être qu'on aurai pu la garder déclaré globalement mais alors à un endroit plus évident.