### PR TITLE
Ajustement d'éléments de design

### DIFF
--- a/src/situations/accueil/styles/formulaire_identification.scss
+++ b/src/situations/accueil/styles/formulaire_identification.scss
@@ -8,7 +8,6 @@
   width: 32%;
   height: 3rem;
   padding: 1rem;
-  color: $couleur-texte;
   transition: border .3s;
   outline: none;
 

--- a/src/situations/accueil/styles/formulaire_identification.scss
+++ b/src/situations/accueil/styles/formulaire_identification.scss
@@ -24,6 +24,7 @@
   display: flex;
   align-items: flex-start;
   max-width: 70%;
+  margin: 1.5rem 0;
 
   input[type="checkbox"] {
     flex-shrink: 0;

--- a/src/situations/commun/styles/action_overlay.scss
+++ b/src/situations/commun/styles/action_overlay.scss
@@ -14,7 +14,6 @@
     font-family: 'Quicksand', sans-serif;
     position:absolute;
     top: 7rem;
-    color: $couleur-texte;
     text-align: center;
     width: 100%;
     line-height: 6.5rem;

--- a/src/situations/commun/styles/boite_utilisateur.scss
+++ b/src/situations/commun/styles/boite_utilisateur.scss
@@ -3,7 +3,6 @@
 .boite-utilisateur {
   border: 1px solid $vert-clair;
   border-radius: 3rem;
-  color: $couleur-texte;
   font-size: 1.125rem;
   overflow: hidden;
   position: relative;

--- a/src/situations/commun/styles/boutons.scss
+++ b/src/situations/commun/styles/boutons.scss
@@ -9,7 +9,8 @@
   background-color: $couleur-fond-bouton-bleu;
   transition: border, background .3s;
   outline: none;
-  line-height: 1.3;
+  line-height: 1.8;
+  font-size: 1.1rem;
 
   &:active {
     border-color: $couleur-fond-bouton-bleu;
@@ -25,6 +26,7 @@
   }
 
   &.bouton-arrondi--petit {
-    font-size: 1rem;
+    line-height: 1.1;
+    font-size: 0.9rem;
   }
 }

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -12,6 +12,7 @@ body {
   font-size: 16px;
   display: flex;
   position: relative;
+  color: $couleur-texte;
   background-color: $couleur-fond;
 }
 
@@ -40,7 +41,6 @@ ul {
 
 h1,h2,h3,h4,h5,h6 {
   font-family: 'Quicksand', sans-serif;
-  color: $couleur-texte;
 }
 
 h1 {

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -95,7 +95,6 @@ h3 {
 }
 
 button {
-  font-size: 1.1rem;
   border: 0px;
 }
 

--- a/src/situations/commun/styles/commun.scss
+++ b/src/situations/commun/styles/commun.scss
@@ -51,7 +51,7 @@ h1 {
 h2 {
   font-size: 2rem;
   margin: 0;
-  padding-bottom: .5rem;
+  padding-bottom: 1rem;
 }
 
 h3 {

--- a/src/situations/questions/styles/situation.scss
+++ b/src/situations/questions/styles/situation.scss
@@ -39,7 +39,6 @@
   &-bouton {
     float: right;
     margin-top: 0.625rem;
-    font-size: 0.7rem;
   }
 }
 

--- a/src/situations/questions/vues/qcm.js
+++ b/src/situations/questions/vues/qcm.js
@@ -27,7 +27,7 @@ export default class VueQCM extends VueQuestion {
           <p class="sans-marge">${this.question.description}</p>
           <p class="intitule-question sans-marge">${this.question.intitule}</p>
           ${$valeursPossibles}
-          <button id="envoi-reponse" class="question-bouton bouton-arrondi" disabled>
+          <button id="envoi-reponse" class="question-bouton bouton-arrondi bouton-arrondi--petit" disabled>
             ${traduction('questions.qcm.valider')}
           </button>
         </div

--- a/src/situations/questions/vues/redaction_note.js
+++ b/src/situations/questions/vues/redaction_note.js
@@ -21,7 +21,7 @@ export default class VueRedactionNote extends VueQuestion {
           </p>
           <p class="messagerie-objet-reponse">${this.question.objet_reponse}</p>
           <textarea id="reponse-compte-rendu" placeholder="${this.question.entete_reponse}"></textarea>
-          <button id="envoi-reponse" class="question-bouton bouton-arrondi">
+          <button id="envoi-reponse" class="question-bouton bouton-arrondi bouton-arrondi--petit">
             ${traduction('questions.redaction_note.envoyer')}
           </button>
         </div>


### PR DESCRIPTION
Après une discussion avec Benjamin, j'ai ajusté quelques élements de design à sa demande.

- Couleur du texte en "bleu-sombre" par défaut
- Ajout d'espace sur le formulaire de connexion
- Normalisation de la taille des boutons. Il n'y a que deux tailles différentes dans l'application. Une 3eme est possible mais utilisé seulement sur le site vitrine.

Exemple de rendu sur le formulaire de connexion
<img width="1014" alt="Capture d’écran 2019-11-08 à 18 12 54" src="https://user-images.githubusercontent.com/298214/68496817-7b284800-0253-11ea-8b54-4c1ac87ec863.png">
