### PR TITLE
Design: allonge la boite de progression de l'utilisateur

### DIFF
--- a/src/situations/commun/styles/boite_utilisateur.scss
+++ b/src/situations/commun/styles/boite_utilisateur.scss
@@ -16,8 +16,14 @@
   }
 
   .contenu {
-    padding: 1rem;
+    padding: 0.8rem 2rem;
     display: flex;
+    justify-content: space-between;
+    min-width: 20rem;
+
+    .progression-actions {
+      display: flex;
+    }
   }
 
   .progression-utilisateur {

--- a/src/situations/commun/vues/boite_utilisateur.vue
+++ b/src/situations/commun/vues/boite_utilisateur.vue
@@ -9,10 +9,12 @@
     />
     <div class="contenu">
       <div>{{ nom }}</div>
-      <div class="progression-utilisateur">{{ situationsFaites.length }}/{{ situations.length }}</div>
-      <a class="deconnexion" href="#" @click.prevent="deconnecte">
-        <i class="fas fa-sign-out-alt"></i>
-      </a>
+      <div class="progression-actions">
+        <div class="progression-utilisateur">{{ situationsFaites.length }}/{{ situations.length }}</div>
+        <a class="deconnexion" href="#" @click.prevent="deconnecte">
+          <i class="fas fa-sign-out-alt"></i>
+        </a>
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
<img width="1029" alt="Capture d’écran 2019-11-12 à 18 45 11" src="https://user-images.githubusercontent.com/298214/68696085-9c9f7180-057c-11ea-8053-9b19d34074d7.png">
