### PR TITLE
Refactore la récupération de l'évaluation

### DIFF
--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -46,19 +46,26 @@ export function creeStore (registreUtilisateur, fetch = window.fetch) {
           .deconnecte();
       },
       synchroniseSituations ({ commit }) {
-        return fetch(registreUtilisateur.urlEvaluation()).then((reponse) => {
-          return reponse.json();
-        }).then((json) => {
-          const situations = json.situations.map(function (situation, index) {
-            return {
-              nom: situation.libelle,
-              chemin: `${situation.nom_technique}.html`,
-              identifiant: situation.nom_technique,
-              niveauMinimum: index + 1
-            };
+        return fetch(registreUtilisateur.urlEvaluation())
+          .then((reponse) => {
+            if (reponse.status === 404) {
+              commit('deconnecte');
+              throw reponse;
+            }
+            return reponse;
+          })
+          .then(reponse => reponse.json())
+          .then((json) => {
+            const situations = json.situations.map(function (situation, index) {
+              return {
+                nom: situation.libelle,
+                chemin: `${situation.nom_technique}.html`,
+                identifiant: situation.nom_technique,
+                niveauMinimum: index + 1
+              };
+            });
+            commit('metsAJourSituations', situations);
           });
-          commit('metsAJourSituations', situations);
-        });
       },
 
       recupereCompetencesFortes ({ commit }) {

--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -45,7 +45,7 @@ export function creeStore (registreUtilisateur, fetch = window.fetch) {
         return registreUtilisateur
           .deconnecte();
       },
-      synchroniseSituations ({ commit }) {
+      synchroniseEvaluation ({ commit }) {
         return fetch(registreUtilisateur.urlEvaluation())
           .then((reponse) => {
             if (reponse.status === 404) {
@@ -65,15 +65,8 @@ export function creeStore (registreUtilisateur, fetch = window.fetch) {
               };
             });
             commit('metsAJourSituations', situations);
+            commit('metsAJourCompetencesFortes', json.competences_fortes);
           });
-      },
-
-      recupereCompetencesFortes ({ commit }) {
-        return fetch(registreUtilisateur.urlEvaluation()).then((reponse) => {
-          return reponse.json();
-        }).then((json) => {
-          commit('metsAJourCompetencesFortes', json.competences_fortes);
-        });
       }
     }
   });

--- a/src/situations/accueil/vues/accueil.vue
+++ b/src/situations/accueil/vues/accueil.vue
@@ -170,12 +170,12 @@ export default {
   },
 
   mounted () {
-    this.synchroniseSituations();
+    this.synchroniseEvaluation();
   },
 
   watch: {
     estConnecte () {
-      this.synchroniseSituations(false);
+      this.synchroniseEvaluation(false);
       if (!this.estConnecte) {
         this.reinitialiseDonnees();
       } else {
@@ -189,9 +189,9 @@ export default {
   },
 
   methods: {
-    synchroniseSituations (sync = true) {
+    synchroniseEvaluation (sync = true) {
       if (!this.estConnecte) return;
-      this.$store.dispatch('synchroniseSituations')
+      this.$store.dispatch('synchroniseEvaluation')
         .then(() => {
           if (sync) {
             this.indexBatiment = this.niveauMax;

--- a/src/situations/accueil/vues/fin.vue
+++ b/src/situations/accueil/vues/fin.vue
@@ -1,12 +1,6 @@
 <template>
-  <div
-    :class="{ attendre: ! competencesFortesRecus }"
-    class="overlay modale"
-  >
-    <div
-      v-if="competencesFortesRecus"
-      class="modale-interieur"
-    >
+  <div class="overlay modale">
+    <div class="modale-interieur">
       <h2>{{ $traduction('accueil.fin.titre') }}</h2>
       <div class="contenu">
         <p class="message-fin">
@@ -42,17 +36,7 @@ import { mapActions, mapState } from 'vuex';
 import 'commun/styles/fin.scss';
 
 export default {
-  data () {
-    return {
-      competencesFortesRecus: false
-    };
-  },
-
   computed: mapState(['competencesFortes']),
-
-  mounted () {
-    this.recupereCompetencesFortes();
-  },
 
   methods: {
     ...mapActions(['deconnecte']),
@@ -63,12 +47,6 @@ export default {
 
     lienSiteVitrine (competence) {
       return `https://eva.beta.gouv.fr/competences/${competence}`;
-    },
-
-    recupereCompetencesFortes (sync = true) {
-      this.$store.dispatch('recupereCompetencesFortes').then(() => {
-        this.competencesFortesRecus = true;
-      });
     }
   }
 };

--- a/tests/situations/accueil/modeles/store.js
+++ b/tests/situations/accueil/modeles/store.js
@@ -90,6 +90,18 @@ describe("Le store de l'accueil", function () {
     });
   });
 
+  it('se déconnecte en cas de 404 du serveur', function () {
+    registreUtilisateur.urlEvaluation = () => '/evaluation';
+    const fetch = (url) => Promise.resolve({
+      status: 404
+    });
+    const store = creeStore(registreUtilisateur, fetch);
+    store.commit('connecte', 'test');
+    return store.dispatch('synchroniseSituations').catch(() => {
+      expect(store.state.estConnecte).to.eql(false);
+    });
+  });
+
   it('sait récupérer les deux compétences fortes depuis le serveur', function () {
     registreUtilisateur.urlEvaluation = () => '/evaluation/1';
     const fetch = (url) => Promise.resolve({

--- a/tests/situations/accueil/modeles/store.js
+++ b/tests/situations/accueil/modeles/store.js
@@ -75,11 +75,11 @@ describe("Le store de l'accueil", function () {
     const fetch = (url) => Promise.resolve({
       json: () => {
         const situation = { nom_technique: 'nom_technique', libelle: 'libelle' };
-        return { situations: [situation] };
+        return { situations: [situation], competences_fortes: [] };
       }
     });
     const store = creeStore(registreUtilisateur, fetch);
-    return store.dispatch('synchroniseSituations').then(() => {
+    return store.dispatch('synchroniseEvaluation').then(() => {
       const situationAttendue = {
         identifiant: 'nom_technique',
         nom: 'libelle',
@@ -97,7 +97,7 @@ describe("Le store de l'accueil", function () {
     });
     const store = creeStore(registreUtilisateur, fetch);
     store.commit('connecte', 'test');
-    return store.dispatch('synchroniseSituations').catch(() => {
+    return store.dispatch('synchroniseEvaluation').catch(() => {
       expect(store.state.estConnecte).to.eql(false);
     });
   });
@@ -106,11 +106,11 @@ describe("Le store de l'accueil", function () {
     registreUtilisateur.urlEvaluation = () => '/evaluation/1';
     const fetch = (url) => Promise.resolve({
       json: () => {
-        return { competences_fortes: ['comprehension_consigne', 'rapidite', 'tri'] };
+        return { situations: [], competences_fortes: ['comprehension_consigne', 'rapidite', 'tri'] };
       }
     });
     const store = creeStore(registreUtilisateur, fetch);
-    return store.dispatch('recupereCompetencesFortes').then(() => {
+    return store.dispatch('synchroniseEvaluation').then(() => {
       const competencesFortesAttendues = ['comprehension_consigne', 'rapidite'];
       expect(store.state.competencesFortes).to.eql(competencesFortesAttendues);
     });

--- a/tests/situations/accueil/vues/accueil.js
+++ b/tests/situations/accueil/vues/accueil.js
@@ -131,9 +131,9 @@ describe('La vue accueil', function () {
     expect(wrapper.vm.decalageGaucheVue(2)).to.equal((LARGEUR_BATIMENT + ESPACEMENT_BATIMENT) * 2);
   });
 
-  it("synchronise les situations quand un utilisateur affiche l'accueil en étant connecté", function (done) {
+  it("synchronise l'évaluation quand un utilisateur affiche l'accueil en étant connecté", function (done) {
     store.dispatch = (evenement) => {
-      expect(evenement).to.eql('synchroniseSituations');
+      expect(evenement).to.eql('synchroniseEvaluation');
       done();
       return Promise.resolve();
     };
@@ -144,10 +144,10 @@ describe('La vue accueil', function () {
     });
   });
 
-  it('synchronise les situations à la connexion', function () {
+  it("synchronise l'évaluation à la connexion", function () {
     let nombreDispatch = 0;
     store.dispatch = (evenement) => {
-      expect(evenement).to.eql('synchroniseSituations');
+      expect(evenement).to.eql('synchroniseEvaluation');
       nombreDispatch++;
       return Promise.resolve();
     };

--- a/tests/situations/accueil/vues/fin.js
+++ b/tests/situations/accueil/vues/fin.js
@@ -24,8 +24,7 @@ describe('La vue de fin', function () {
         competencesFortes: []
       },
       actions: {
-        deconnecte () {},
-        recupereCompetencesFortes () {}
+        deconnecte () {}
       }
     });
     localVue = createLocalVue();
@@ -36,7 +35,6 @@ describe('La vue de fin', function () {
   it("sait s'afficher", function () {
     store.state.competencesFortes = ['rapidite', 'comprehension_consigne'];
     wrapper = mount(Fin, { store, localVue });
-    wrapper.vm.competencesFortesRecus = true;
 
     expect(wrapper.find('h2').text()).to.eql('accueil.fin.titre');
     expect(wrapper.find('button').text()).to.eql('accueil.fin.bouton');
@@ -44,7 +42,6 @@ describe('La vue de fin', function () {
 
   it("se déconnecte a l'appui sur le bouton", function () {
     wrapper = mount(Fin, { store, localVue });
-    wrapper.vm.competencesFortesRecus = true;
 
     let deconnecte = 0;
     store.dispatch = (nom) => {
@@ -58,7 +55,6 @@ describe('La vue de fin', function () {
   it('récupère les compétences fortes', function () {
     store.state.competencesFortes = ['rapidite', 'comprehension_consigne'];
     wrapper = mount(Fin, { store, localVue });
-    wrapper.vm.competencesFortesRecus = true;
 
     expect(wrapper.findAll('.message-competences-fortes').length).to.equal(1);
     expect(wrapper.find('.message-competences-fortes').text()).to.eql('accueil.fin.competences');
@@ -68,7 +64,6 @@ describe('La vue de fin', function () {
   it("n'afiche pas de message de détection de compétences fortes si l'évalué n'en a pas", function () {
     store.state.competences = [];
     wrapper = mount(Fin, { store, localVue });
-    wrapper.vm.competencesFortesRecus = true;
 
     expect(wrapper.findAll('.competences-fortes-conteneur').length).to.equal(0);
   });


### PR DESCRIPTION
Les deux actions `synchroniseSituations` et `recupereCompetencesFortes` ont été fusionnées car elles récupéraient la même URL, mais pas les mêmes infos dedans.

Et si le serveur nous renvoie une 404, on se déconnecte (cela permet de gérer la suppression d'évaluation coté serveur, alors que le client ne s'est pas déconnecté).