### PR TITLE
Enregistre l'événement de prise de pièce dans le contrôle et le tri

### DIFF
--- a/src/situations/commun/modeles/evenement_piece_prise.js
+++ b/src/situations/commun/modeles/evenement_piece_prise.js
@@ -1,0 +1,7 @@
+import Evenement from 'commun/modeles/evenement';
+
+export default class EvenementPiecePrise extends Evenement {
+  constructor (donnees = {}) {
+    super('piecePrise', donnees);
+  }
+}

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,8 +1,9 @@
 import 'controle/styles/situation.scss';
 import { CHANGEMENT_ETAT, DEMARRE } from 'commun/modeles/situation';
-import { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE } from 'commun/modeles/piece';
+import { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE, CHANGEMENT_SELECTION } from 'commun/modeles/piece';
 import EvenementPieceBienPlacee from 'commun/modeles/evenement_piece_bien_placee';
 import EvenementPieceMalPlacee from 'commun/modeles/evenement_piece_mal_placee';
+import EvenementPiecePrise from 'commun/modeles/evenement_piece_prise';
 import EvenementPieceRatee from 'controle/modeles/evenement_piece_ratee';
 import { NOUVELLE_PIECE, PIECE_RATEE } from 'controle/modeles/situation';
 import VueBac from 'commun/vues/bac';
@@ -49,15 +50,20 @@ export default class VueSituation {
   }
 
   demarre (pointInsertion, $) {
-    this.situation.on(NOUVELLE_PIECE, (piece) => {
-      const vuePiece = this.creeVuePiece(piece);
-      vuePiece.affiche(pointInsertion, $);
-    });
     const envoiEvenementPiece = (Classe) => {
       return (piece) => {
         this.journal.enregistre(new Classe({ piece: { conforme: piece.categorie() } }));
       };
     };
+    this.situation.on(NOUVELLE_PIECE, (piece) => {
+      const vuePiece = this.creeVuePiece(piece);
+      vuePiece.affiche(pointInsertion, $);
+      piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
+        if (selectionnee) {
+          envoiEvenementPiece(EvenementPiecePrise)(piece);
+        }
+      });
+    });
     this.situation.on(PIECE_BIEN_PLACEE, envoiEvenementPiece(EvenementPieceBienPlacee));
     this.situation.on(PIECE_MAL_PLACEE, envoiEvenementPiece(EvenementPieceMalPlacee));
     this.situation.on(PIECE_RATEE, envoiEvenementPiece(EvenementPieceRatee));

--- a/src/situations/tri/vues/situation.js
+++ b/src/situations/tri/vues/situation.js
@@ -1,11 +1,12 @@
 import 'tri/styles/situation.scss';
-import { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE } from 'tri/modeles/piece';
+import { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE, CHANGEMENT_SELECTION } from 'tri/modeles/piece';
 import VueBac from 'commun/vues/bac.js';
 import VuePiece from 'tri/vues/piece.js';
 import VueChronometre from 'tri/vues/chronometre.js';
 import DeplaceurPieces from 'commun/composants/deplaceur_pieces';
 import EvenementPieceBienPlacee from 'commun/modeles/evenement_piece_bien_placee';
 import EvenementPieceMalPlacee from 'commun/modeles/evenement_piece_mal_placee';
+import EvenementPiecePrise from 'commun/modeles/evenement_piece_prise';
 
 export default class VueSituationTri {
   constructor (situation, journal, depotRessources) {
@@ -38,12 +39,19 @@ export default class VueSituationTri {
   envoiEvenementsAuJournal (journal) {
     const envoiEvenementPiece = (Classe) => {
       return (piece, bac) => {
-        const categorieBac = bac ? bac.categorie() : null;
-        journal.enregistre(new Classe({ piece: piece.categorie(), bac: categorieBac }));
+        const donneeBac = bac ? { bac: bac.categorie() } : {};
+        journal.enregistre(new Classe({ piece: piece.categorie(), ...donneeBac }));
       };
     };
     this.situation.on(PIECE_BIEN_PLACEE, envoiEvenementPiece(EvenementPieceBienPlacee));
     this.situation.on(PIECE_MAL_PLACEE, envoiEvenementPiece(EvenementPieceMalPlacee));
+    this.situation.piecesAffichees().forEach((piece) => {
+      piece.on(CHANGEMENT_SELECTION, (selectionnee) => {
+        if (selectionnee) {
+          envoiEvenementPiece(EvenementPiecePrise)(piece);
+        }
+      });
+    });
   }
 
   ajoutEcouteursPourLesSons () {

--- a/tests/situations/commun/modeles/evenement_piece_prise.js
+++ b/tests/situations/commun/modeles/evenement_piece_prise.js
@@ -1,0 +1,12 @@
+import EvenementPiecePrise from 'commun/modeles/evenement_piece_prise';
+
+describe("l'événement de pièce prise", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementPiecePrise().nom()).to.eql('piecePrise');
+  });
+
+  it('retourne ses donnees', function () {
+    const donnees = { piece: 'test' };
+    expect(new EvenementPiecePrise(donnees).donnees()).to.eql(donnees);
+  });
+});

--- a/tests/situations/controle/aides/mock_depot_ressources_controle.js
+++ b/tests/situations/controle/aides/mock_depot_ressources_controle.js
@@ -12,4 +12,6 @@ export default class MockDepotRessources {
   tapis () {
     return { src: '' };
   }
+
+  piece () {}
 }

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -3,9 +3,10 @@ import $ from 'jquery';
 import MockDepotRessourcesControle from '../aides/mock_depot_ressources_controle';
 import EvenementPieceBienPlacee from 'commun/modeles/evenement_piece_bien_placee';
 import EvenementPieceMalPlacee from 'commun/modeles/evenement_piece_mal_placee';
+import EvenementPiecePrise from 'commun/modeles/evenement_piece_prise';
 import EvenementPieceRatee from 'controle/modeles/evenement_piece_ratee';
 import Piece, { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE } from 'commun/modeles/piece';
-import Situation, { PIECE_RATEE } from 'controle/modeles/situation';
+import Situation, { PIECE_RATEE, NOUVELLE_PIECE } from 'controle/modeles/situation';
 import VueSituation from 'controle/vues/situation';
 
 function vueSituationMinimaliste (journal) {
@@ -57,6 +58,27 @@ describe('La vue de la situation « Contrôle »', function () {
 
       vueSituation.affiche('#point-insertion', $);
       vueSituation.demarre('#point-insertion', $);
+    });
+
+    it('écoute les événements de sélection de pièces', function (done) {
+      journal.enregistre = function (e) {
+        expect(e).to.be.a(EvenementPiecePrise);
+        expect(e.donnees()).to.eql({ piece: { conforme: true } });
+        done();
+      };
+      vueSituation.situation.emit(NOUVELLE_PIECE, piece);
+      piece.selectionne({ x: 0, y: 0 });
+    });
+
+    it('écoute seulement les événements de sélection de pièces', function () {
+      let nombreAppelsEnregistre = 0;
+      journal.enregistre = function (e) {
+        nombreAppelsEnregistre++;
+      };
+      vueSituation.situation.emit(NOUVELLE_PIECE, piece);
+      piece.selectionne({ x: 0, y: 0 });
+      piece.deselectionne();
+      expect(nombreAppelsEnregistre).to.eql(1);
     });
 
     it('écoute les événements PIECE_BIEN_PLACEE pour les enregistrer dans le journal', function (done) {

--- a/tests/situations/tri/vues/situation.js
+++ b/tests/situations/tri/vues/situation.js
@@ -6,6 +6,7 @@ import Situation from 'tri/modeles/situation';
 import Piece, { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE } from 'commun/modeles/piece';
 import EvenementPieceBienPlacee from 'commun/modeles/evenement_piece_bien_placee';
 import EvenementPieceMalPlacee from 'commun/modeles/evenement_piece_mal_placee';
+import EvenementPiecePrise from 'commun/modeles/evenement_piece_prise';
 
 import MockDepotRessourcesTri from '../aides/mock_depot_ressources_tri';
 
@@ -64,6 +65,29 @@ describe('La situation « Tri »', function () {
       vueSituation.affiche('#point-insertion', $);
     });
 
+    it('écouter la sélection de pièce pour les enregistrer dans le journal', function (done) {
+      situation.piecesAffichees = () => [piece];
+      vueSituation = new VueSituation(situation, journal, mockDepotRessources);
+      journal.enregistre = function (e) {
+        expect(e).to.be.a(EvenementPiecePrise);
+        expect(e.donnees()).to.eql({ piece: 'bonbon1' });
+        done();
+      };
+      vueSituation.situation.piecesAffichees()[0].selectionne({ x: 0, y: 0 });
+    });
+
+    it('écouter seulement la sélection de pièce pour les enregistrer dans le journal', function () {
+      situation.piecesAffichees = () => [piece];
+      vueSituation = new VueSituation(situation, journal, mockDepotRessources);
+      let nombreAppelsEnregistre = 0;
+      journal.enregistre = function (e) {
+        nombreAppelsEnregistre++;
+      };
+      vueSituation.situation.piecesAffichees()[0].selectionne({ x: 0, y: 0 });
+      vueSituation.situation.piecesAffichees()[0].deselectionne();
+      expect(nombreAppelsEnregistre).to.eql(1);
+    });
+
     it('écoute les événements PIECE_BIEN_PLACEE pour les enregistrer dans le journal', function (done) {
       journal.enregistre = function (e) {
         expect(e).to.be.a(EvenementPieceBienPlacee);
@@ -81,16 +105,6 @@ describe('La situation « Tri »', function () {
         done();
       };
       vueSituation.situation.emit(PIECE_MAL_PLACEE, piece, bac);
-    });
-
-    it('écoute les événements PIECE_MAL_PLACEE pour les enregistrer dans le journal sans bac', function (done) {
-      bac.categorie = () => 'bonbon2';
-      journal.enregistre = function (e) {
-        expect(e).to.be.a(EvenementPieceMalPlacee);
-        expect(e.donnees()).to.eql({ piece: 'bonbon1', bac: null });
-        done();
-      };
-      vueSituation.situation.emit(PIECE_MAL_PLACEE, piece, null);
     });
 
     it("joue le son sonBonBac lorsque'une pièce est bien placéee", function (done) {


### PR DESCRIPTION
Lorsqu'une pièce (bonbon ou biscuit) est prise par un·e évalué·e, alors on enregistre un événement `piecePrise`.

Contribue à https://github.com/betagouv/competences-pro-serveur/issues/224 et https://github.com/betagouv/competences-pro-serveur/issues/225 