### PR TITLE
Ajout du type de pièce dans le controle.

### DIFF
--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -54,7 +54,7 @@ export default class VueSituation {
   demarre (pointInsertion, $) {
     const envoiEvenementPiece = (Classe) => {
       return (piece) => {
-        this.journal.enregistre(new Classe({ piece: { conforme: piece.categorie() } }));
+        this.journal.enregistre(new Classe({ piece: { type: piece.type, conforme: piece.categorie() } }));
       };
     };
     this.situation.on(NOUVELLE_PIECE, (piece) => {

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -55,7 +55,7 @@ describe('La vue de la situation « Contrôle »', function () {
 
     beforeEach(function () {
       journal = { enregistre () {} };
-      piece = new Piece({ categorie: true });
+      piece = new Piece({ categorie: true, type: 'def2' });
       vueSituation = vueSituationMinimaliste(journal);
 
       vueSituation.affiche('#point-insertion', $);
@@ -66,7 +66,7 @@ describe('La vue de la situation « Contrôle »', function () {
       vueSituation.situation.emit(NOUVELLE_PIECE, piece);
       journal.enregistre = function (e) {
         expect(e).to.be.a(EvenementPiecePrise);
-        expect(e.donnees()).to.eql({ piece: { conforme: true } });
+        expect(e.donnees()).to.eql({ piece: { conforme: true, type: 'def2' } });
         done();
       };
       piece.selectionne({ x: 0, y: 0 });
@@ -86,7 +86,7 @@ describe('La vue de la situation « Contrôle »', function () {
     it('écoute les événements PIECE_BIEN_PLACEE pour les enregistrer dans le journal', function (done) {
       journal.enregistre = function (e) {
         expect(e).to.be.a(EvenementPieceBienPlacee);
-        expect(e.donnees()).to.eql({ piece: { conforme: true } });
+        expect(e.donnees()).to.eql({ piece: { conforme: true, type: 'def2' } });
         done();
       };
       vueSituation.situation.emit(PIECE_BIEN_PLACEE, piece);
@@ -95,7 +95,7 @@ describe('La vue de la situation « Contrôle »', function () {
     it('écoute les événements PIECE_MAL_PLACEE pour les enregistrer dans le journal', function (done) {
       journal.enregistre = function (e) {
         expect(e).to.be.a(EvenementPieceMalPlacee);
-        expect(e.donnees()).to.eql({ piece: { conforme: true } });
+        expect(e.donnees()).to.eql({ piece: { conforme: true, type: 'def2' } });
         done();
       };
       vueSituation.situation.emit(PIECE_MAL_PLACEE, piece);
@@ -104,7 +104,7 @@ describe('La vue de la situation « Contrôle »', function () {
     it('écoute les événements PIECE_RATEE pour les enregistrer dans le journal', function (done) {
       journal.enregistre = function (e) {
         expect(e).to.be.a(EvenementPieceRatee);
-        expect(e.donnees()).to.eql({ piece: { conforme: true } });
+        expect(e.donnees()).to.eql({ piece: { conforme: true, type: 'def2' } });
         done();
       };
       vueSituation.situation.emit(PIECE_RATEE, piece);
@@ -113,7 +113,7 @@ describe('La vue de la situation « Contrôle »', function () {
     it('écoute les événements PIECE_DEPOSE_HORS_BACS pour les enregistrer dans le journal', function (done) {
       journal.enregistre = function (e) {
         expect(e).to.be.a(EvenementPieceDeposeHorsBacs);
-        expect(e.donnees()).to.eql({ piece: { conforme: true } });
+        expect(e.donnees()).to.eql({ piece: { conforme: true, type: 'def2' } });
         done();
       };
       vueSituation.situation.emit(PIECE_DEPOSE_HORS_BACS, piece);
@@ -122,7 +122,7 @@ describe('La vue de la situation « Contrôle »', function () {
     it('écoute les événements NOUVELLE_PIECE pour les enregistrer dans le journal', function (done) {
       journal.enregistre = function (e) {
         expect(e).to.be.a(EvenementPieceApparition);
-        expect(e.donnees()).to.eql({ piece: { conforme: true } });
+        expect(e.donnees()).to.eql({ piece: { conforme: true, type: 'def2' } });
         done();
       };
       vueSituation.situation.emit(NOUVELLE_PIECE, piece);


### PR DESCRIPTION
On ne peut pas différencier le type de biscuit coté serveur actuellement car on sait simplement si celui ci est conforme on non conforme. En rajoutant son type, nous saurons le faire.

Contribue à https://github.com/betagouv/competences-pro-serveur/issues/224