### PR TITLE
Contrôle: enregistre un événement de dépose de pièces

### DIFF
--- a/src/situations/commun/modeles/piece.js
+++ b/src/situations/commun/modeles/piece.js
@@ -9,6 +9,7 @@ export const PIECE_BIEN_PLACEE = 'pieceBienPlacée';
 export const PIECE_MAL_PLACEE = 'pieceMalPlacée';
 export const PIECE_DEPOSE_HORS_BACS = 'pieceDeposeHorsBacs';
 export const PIECE_PRISE = 'piecePrise';
+export const PIECE_DEPOSE_DANS_BAC = 'pieceDeposeDansBac';
 
 export default class Piece extends EventEmitter {
   constructor ({ x, y, type, largeur, hauteur, categorie }) {

--- a/src/situations/controle/modeles/evenement_piece_depose_dans_bac.js
+++ b/src/situations/controle/modeles/evenement_piece_depose_dans_bac.js
@@ -1,0 +1,7 @@
+import Evenement from 'commun/modeles/evenement';
+
+export default class EvenementPieceDeposeDansBac extends Evenement {
+  constructor (donnees = {}) {
+    super('pieceDeposeDansBac', donnees);
+  }
+}

--- a/src/situations/controle/modeles/situation.js
+++ b/src/situations/controle/modeles/situation.js
@@ -5,6 +5,7 @@ import Piece, {
   PIECE_BIEN_PLACEE,
   PIECE_MAL_PLACEE,
   PIECE_DEPOSE_HORS_BACS,
+  PIECE_DEPOSE_DANS_BAC,
   PIECE_PRISE
 } from 'commun/modeles/piece';
 import Bac from 'commun/modeles/bac';
@@ -140,7 +141,9 @@ export default class Situation extends SituationCommune {
 
   reinitialiseBacs (piece) {
     const bac = this.bacs().find((bac) => bac.contient(piece));
-    if (!bac) {
+    if (bac) {
+      this.emit(PIECE_DEPOSE_DANS_BAC, piece);
+    } else {
       this.emit(PIECE_DEPOSE_HORS_BACS, piece);
     }
     this.bacs().forEach(bac => bac.reinitialiseEtatSurvole());

--- a/src/situations/controle/vues/situation.js
+++ b/src/situations/controle/vues/situation.js
@@ -1,12 +1,19 @@
 import 'controle/styles/situation.scss';
 import { CHANGEMENT_ETAT, DEMARRE } from 'commun/modeles/situation';
-import { PIECE_BIEN_PLACEE, PIECE_MAL_PLACEE, PIECE_DEPOSE_HORS_BACS, PIECE_PRISE } from 'commun/modeles/piece';
+import {
+  PIECE_BIEN_PLACEE,
+  PIECE_MAL_PLACEE,
+  PIECE_DEPOSE_HORS_BACS,
+  PIECE_DEPOSE_DANS_BAC,
+  PIECE_PRISE
+} from 'commun/modeles/piece';
 import EvenementPieceBienPlacee from 'commun/modeles/evenement_piece_bien_placee';
 import EvenementPieceMalPlacee from 'commun/modeles/evenement_piece_mal_placee';
 import EvenementPiecePrise from 'commun/modeles/evenement_piece_prise';
 import EvenementPieceDeposeHorsBacs from 'commun/modeles/evenement_piece_depose_hors_bacs';
 import EvenementPieceRatee from 'controle/modeles/evenement_piece_ratee';
 import EvenementPieceApparition from 'controle/modeles/evenement_piece_apparition';
+import EvenementPieceDeposeDansBac from 'controle/modeles/evenement_piece_depose_dans_bac';
 import { NOUVELLE_PIECE, PIECE_RATEE } from 'controle/modeles/situation';
 import VueBac from 'commun/vues/bac';
 import VuePiece from 'controle/vues/piece';
@@ -67,6 +74,7 @@ export default class VueSituation {
     this.situation.on(PIECE_MAL_PLACEE, envoiEvenementPiece(EvenementPieceMalPlacee));
     this.situation.on(PIECE_RATEE, envoiEvenementPiece(EvenementPieceRatee));
     this.situation.on(PIECE_DEPOSE_HORS_BACS, envoiEvenementPiece(EvenementPieceDeposeHorsBacs));
+    this.situation.on(PIECE_DEPOSE_DANS_BAC, envoiEvenementPiece(EvenementPieceDeposeDansBac));
     this.situation.demarre();
   }
 }

--- a/tests/situations/controle/modeles/evenement_piece_depose_dans_bac.js
+++ b/tests/situations/controle/modeles/evenement_piece_depose_dans_bac.js
@@ -1,0 +1,12 @@
+import EvenementPieceDeposeDansBac from 'controle/modeles/evenement_piece_depose_dans_bac';
+
+describe("l'événement de dépose de pièce dans un bac", function () {
+  it('retourne son nom', function () {
+    expect(new EvenementPieceDeposeDansBac().nom()).to.eql('pieceDeposeDansBac');
+  });
+
+  it('retourne ses donnees', function () {
+    const donnees = { piece: { conforme: true } };
+    expect(new EvenementPieceDeposeDansBac(donnees).donnees()).to.eql(donnees);
+  });
+});

--- a/tests/situations/controle/modeles/situation.js
+++ b/tests/situations/controle/modeles/situation.js
@@ -5,6 +5,7 @@ import Piece, {
   PIECE_BIEN_PLACEE,
   PIECE_MAL_PLACEE,
   PIECE_DEPOSE_HORS_BACS,
+  PIECE_DEPOSE_DANS_BAC,
   PIECE_PRISE
 } from 'commun/modeles/piece';
 
@@ -227,6 +228,15 @@ describe('La situation « Contrôle »', function () {
       });
       piece.deselectionne();
       expect(nombreAppelsDeposeHorsBacs).to.eql(0);
+    });
+
+    it("l'événement PIECE_DANS_BAC a la dépose d'un biscuit dans un bac", function (done) {
+      bac.contient = () => true;
+      situation.on(PIECE_DEPOSE_DANS_BAC, (piece2) => {
+        expect(piece2).to.eql(piece);
+        done();
+      });
+      piece.deselectionne();
     });
   });
 });

--- a/tests/situations/controle/vues/situation.js
+++ b/tests/situations/controle/vues/situation.js
@@ -7,11 +7,13 @@ import EvenementPiecePrise from 'commun/modeles/evenement_piece_prise';
 import EvenementPieceDeposeHorsBacs from 'commun/modeles/evenement_piece_depose_hors_bacs';
 import EvenementPieceRatee from 'controle/modeles/evenement_piece_ratee';
 import EvenementPieceApparition from 'controle/modeles/evenement_piece_apparition';
+import EvenementPieceDeposeDansBac from 'controle/modeles/evenement_piece_depose_dans_bac';
 import Situation, { PIECE_RATEE, NOUVELLE_PIECE } from 'controle/modeles/situation';
 import Piece, {
   PIECE_BIEN_PLACEE,
   PIECE_MAL_PLACEE,
   PIECE_DEPOSE_HORS_BACS,
+  PIECE_DEPOSE_DANS_BAC,
   PIECE_PRISE
 } from 'commun/modeles/piece';
 import VueSituation from 'controle/vues/situation';
@@ -110,6 +112,15 @@ describe('La vue de la situation « Contrôle »', function () {
         done();
       };
       vueSituation.situation.emit(PIECE_DEPOSE_HORS_BACS, piece);
+    });
+
+    it('écoute les événements PIECE_DEPOSE_DANS_BAC pour les enregistrer dans le journal', function (done) {
+      journal.enregistre = function (e) {
+        expect(e).to.be.a(EvenementPieceDeposeDansBac);
+        expect(e.donnees()).to.eql({ piece: { conforme: true, type: 'def2' } });
+        done();
+      };
+      vueSituation.situation.emit(PIECE_DEPOSE_DANS_BAC, piece);
     });
 
     it('écoute les événements NOUVELLE_PIECE pour les enregistrer dans le journal', function (done) {


### PR DESCRIPTION
Contribue à #631

Lorsqu'un biscuit est déposé dans un bac, on enregistre désormais un événement `pieceDeposeDansBac` qui permettra de calculer le temps entre la prise de biscuit et la dépose.