### PR TITLE
ajoute des retours à la ligne pour le message d'abandon

### DIFF
--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -131,7 +131,7 @@
       "ok": "Oui"
     },
     "reussite": "C'est terminé, bravo !",
-    "stop": "Attention, vous n'avez pas terminé. Votre résultat sera impacté. Voulez vous vraiment abandonner ?",
+    "stop": "Attention, vous n'avez pas terminé.<br>Votre résultat sera impacté.<br>Voulez-vous vraiment abandonner ?",
     "retour_accueil": "Retour au parc",
     "repeter_consigne": "Répéter la consigne",
     "abandonner_situation": "Arrêter la situation"


### PR DESCRIPTION
<img width="776" alt="Capture d’écran 2019-12-11 à 11 55 40" src="https://user-images.githubusercontent.com/28393/70615741-453d0180-1c0d-11ea-8188-8f5a9ea708c4.png">

fix #646 