### PR TITLE
Ignore le fichier .env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin/config.sh
 node_modules/
 .DS_Store
 .eslintcache
+.env


### PR DESCRIPTION
Co-authored-by: Marie Leuliette <marie.leuliette@gmail.com>

Objectif : ne plus expliciter la variable URL_API à chaque fois dans le terminal