### PR TITLE
N'active pas Rollbar si la variable d'env JETON_CLIENT_ROLLBAR n'est pas présente

### DIFF
--- a/src/situations/commun/infra/report_erreurs.js
+++ b/src/situations/commun/infra/report_erreurs.js
@@ -1,6 +1,7 @@
 import Rollbar from 'rollbar';
 
 const rollbar = new Rollbar({
+  enabled: !!process.env.JETON_CLIENT_ROLLBAR,
   accessToken: process.env.JETON_CLIENT_ROLLBAR,
   captureUncaught: true,
   captureUnhandledRejections: true,


### PR DESCRIPTION
Cela permet d'éviter d'avoir plein Javascript dans la console indiquant que l'on a pas pu contacté le serveur de Rollbar

(et ainsi permettre de débugger plus facilement)