### PR TITLE
Des-enregistre les serviceWorkers qui sont sur les anciennes url sans /jeu

### DIFF
--- a/src/public/template_index.html
+++ b/src/public/template_index.html
@@ -35,6 +35,15 @@
     <script type="text/javascript">
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
+          ['https://app.eva.beta.gouv.fr', 'https://preprod.eva.beta.gouv.fr'].forEach((scope) => {
+            navigator.serviceWorker.getRegistration(scope)
+              .then((registration) => {
+                registration.unregister();
+              })
+              .catch((err) => {
+                // on ignore volontairement les erreurs
+              });
+          });
           navigator.serviceWorker.register('/jeu/service-worker.js').then(registration => {
             console.log('SW registered: ', registration);
           }).catch(registrationError => {


### PR DESCRIPTION
Au moment du changement d'url vers /jeu, nous avons basculer l'enregistrement du service worker sur ce nouveau "scope". Mais comme nous n'avons pas "unregister" l'ancient serviceworker, il continue de repondre présent sur l'ancienne url. Mais comme ce dernier n'est pas à jour, ça ne marche pas.

Avec cette correction, à condition que l'utilisateur arrive à charger le nouveau code (en faisant un rechargement sans le cache ça semble marcher), nous effectuons le des-enregistrement.

Ce code pourra être retiré au bout d'un certain temps