### PR TITLE
🔧 Ne perd pas les paramètres lors de la redirection de /jeu

### DIFF
--- a/server.js
+++ b/server.js
@@ -6,9 +6,19 @@ var app = express();
 var directory = path.join('/', (process.env.STATIC_DIR || 'public'));
 var router = express.Router();
 
-router.get('/jeu', function (req, res, next) {
-  res.redirect(process.env.URL_JEUX);
-});
+function gereRedirectionJeu(req, res) {
+  var cheminRedirection = req.path.replace('/jeu', '');
+  var urlRedirection = process.env.URL_JEUX + cheminRedirection;
+  if (req.query && Object.keys(req.query).length > 0) {
+    var params = new URLSearchParams(req.query).toString();
+    urlRedirection += '?' + params;
+  }
+  res.redirect(urlRedirection);
+}
+
+router.get('/jeu', gereRedirectionJeu);
+router.get('/jeu/*', gereRedirectionJeu);
+
 app.use('/', router);
 app.use(express.static(path.join(__dirname, directory)));
 


### PR DESCRIPTION
On redirige avec les parametres : 
`/jeu?code=EVACOB` -> `/?code=EVACOB` 
`/jeu/?code=EVACOB` -> `/?code=EVACOB` 
`/jeu/?code=EVACOB&horsligne=false` -> `/?code=EVACOB&horsligne=false` 