### PR TITLE
⚰️ Supprime enregistreDonneesComplementaires du store de l'accueil

### DIFF
--- a/src/situations/accueil/modeles/store.js
+++ b/src/situations/accueil/modeles/store.js
@@ -144,18 +144,6 @@ export function creeStore (registreUtilisateur, registreCampagne) {
         });
       },
 
-      enregistreDonneesComplementaires ({ commit }, donneesSociodemographiques) {
-        const idEvaluation = registreUtilisateur.idEvaluation();
-        if (!idEvaluation) {
-          commit('deconnecte');
-          return;
-        }
-        return registreUtilisateur.enregistreDonneesComplementaires(idEvaluation, donneesSociodemographiques)
-          .then(() => {
-            commit('demarre');
-          });
-      },
-
       deconnecte () {
         return registreUtilisateur.deconnecte();
       },


### PR DESCRIPTION
N'était plus utilisé depuis 2023 et appelait une methode registreUtilisateur.enregistreDonneesComplementaires qui n'existe plus